### PR TITLE
Add Fabric API dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	modImplementation(fabricApi.module('fabric-resource-loader-v0', project.fabric_version))
 	modImplementation(fabricApi.module('fabric-key-binding-api-v1', project.fabric_version))


### PR DESCRIPTION
Adding Fabric API dependency in build.gradle instead of crashing when missing