### PR TITLE
[Actions] Build any branch, cache Gradle packages and save artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,10 @@
 
 name: Java CI with Gradle
 
-on:
-  push:
-    branches: [ trunk ]
-  pull_request:
-    branches: [ trunk ]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -24,3 +19,8 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build --stacktrace
+    - name: Upload artifacts to Github Actions  
+      uses: actions/upload-artifact@v2
+      with:
+        name: Compiled artifacts for ${{ github.sha }}
+        path: build/libs


### PR DESCRIPTION
This PR adds the features in the title to the current Github Action.

It builds on every branch because there is no reason not to. It can also help checking if a PR builds correctly when targetting a different branch than `trunk`.

It uses the Actions `cache`, caching files produced by Gradle (dependencies, etc), so builds are faster.

And it saves artifacts in the action run, making them available to be downloaded from Github to check what could have gone wrong (if the user has a Github account). Those are not releases, and are only stored for 30 days IIRC.