### PR TITLE
Make camera in fluid check use actual camera position

### DIFF
--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.tag.FluidTags;
 
 public final class CommonUniforms {
 	private static final MinecraftClient client = MinecraftClient.getInstance();
@@ -61,7 +62,7 @@ public final class CommonUniforms {
 
 		if (cameraEntity.isSubmergedInWater()) {
 			return 1;
-		} else if (cameraEntity.isInLava()) {
+		} else if (cameraEntity.isSubmergedIn(FluidTags.LAVA)) {
 			return 2;
 		} else {
 			return 0;

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.fluid.FluidState;
 import net.minecraft.tag.FluidTags;
 
 public final class CommonUniforms {
@@ -58,11 +59,11 @@ public final class CommonUniforms {
 	}
 
 	private static int isEyeInWater() {
-		Entity cameraEntity = Objects.requireNonNull(client.getCameraEntity());
+		FluidState submergedFluid = client.gameRenderer.getCamera().getSubmergedFluidState();
 
-		if (cameraEntity.isSubmergedInWater()) {
+		if (submergedFluid.isIn(FluidTags.WATER)) {
 			return 1;
-		} else if (cameraEntity.isSubmergedIn(FluidTags.LAVA)) {
+		} else if (submergedFluid.isIn(FluidTags.LAVA)) {
 			return 2;
 		} else {
 			return 0;


### PR DESCRIPTION
This started being a fix for camera having the lava effect when the player was just barely touching lava (first commit), but ended up changing the way the effect is decided.

This is needed because in third person, where the entity _eyes_ are submerged may not be where the _camera_ is submerded.

This is actually the way the game does it (in `net.minecraft.client.render.BackgroundRenderer#applyFog`), though I haven't checked if OF does the same (I'd suppose it does).

BTW, talking about fluids, Iris internal currently removes the vanilla effect of being submerged in fluids, not sure if that's known (although according to the debugger, that `applyFog` function is still called).