### PR TITLE
Allow for completely turning off shaders and using vanilla rendering

### DIFF
--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -72,7 +72,6 @@ public class Iris implements ClientModInitializer {
 
 		ClientTickEvents.END_CLIENT_TICK.register(minecraftClient -> {
 			if (reloadKeybind.wasPressed()){
-
 				try {
 					reload();
 					// TODO: Is this needed?
@@ -95,12 +94,14 @@ public class Iris implements ClientModInitializer {
 
 	public static void loadShaderpack() {
 		// Attempt to load an external shaderpack if it is available
-		if (!irisConfig.isInternal()) {
+		if (!irisConfig.isInternal() && !irisConfig.isNoOp()) {
 			if (!loadExternalShaderpack(irisConfig.getShaderPackName())) {
 				loadInternalShaderpack();
 			}
-		} else {
+		} else if(irisConfig.isInternal()) {
 			loadInternalShaderpack();
+		} else {
+			loadNoOpShaderPack();
 		}
 	}
 
@@ -172,6 +173,12 @@ public class Iris implements ClientModInitializer {
 		}
 
 		logger.info("Using internal shaders");
+	}
+
+	private static void loadNoOpShaderPack() {
+		currentPack = ShaderPack.NO_OP;
+
+		logger.info("Using no shaders");
 	}
 
 	public static void reload() throws IOException {

--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -38,22 +38,31 @@ public class IrisConfig {
 	}
 
 	/**
+	 * returns whether or not the current shaderpack is no-op
+	 *
+	 * @return if shaders should be off (using no-op shaders)
+	 */
+	public boolean isNoOp() {
+		return shaderPackName == null || shaderPackName.equals("(off)");
+	}
+
+	/**
 	 * returns whether or not the current shaderpack is internal
 	 *
 	 * @return if the shaderpack is internal
 	 */
 	public boolean isInternal() {
-		return shaderPackName == null;
+		return shaderPackName != null && shaderPackName.equals("(internal)");
 	}
 
 	/**
 	 * Returns the name of the current shaderpack
 	 *
-	 * @return shaderpack name. If internal it returns "(internal)"
+	 * @return shaderpack name. If internal it returns "(internal)", and if shaders are off it returns "(off)".
 	 */
 	public String getShaderPackName() {
 		if (shaderPackName == null) {
-			return "(internal)";
+			return "(off)";
 		}
 
 		return shaderPackName;
@@ -74,7 +83,7 @@ public class IrisConfig {
 		properties.load(Files.newInputStream(propertiesPath));
 		shaderPackName = properties.getProperty("shaderPack");
 
-		if (shaderPackName != null && shaderPackName.equals("(internal)")) {
+		if (shaderPackName != null && shaderPackName.equals("(off)")) {
 			shaderPackName = null;
 		}
 	}

--- a/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
@@ -62,6 +62,8 @@ public class IdMap {
 	private static Optional<Properties> loadProperties(Path shaderPath, String name) {
 		Properties properties = new Properties();
 
+		if(shaderPath == null) return Optional.empty();
+
 		try {
 			properties.load(Files.newInputStream(shaderPath.resolve(name)));
 		} catch (IOException e) {

--- a/src/main/java/net/coderbot/iris/shaderpack/ShaderPack.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/ShaderPack.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.texture.InternalTextureFormat;
 import org.apache.logging.log4j.Level;
+import org.jetbrains.annotations.Nullable;
 
 public class ShaderPack {
 	private final PackDirectives packDirectives;
@@ -32,7 +33,9 @@ public class ShaderPack {
 	private final IdMap idMap;
 	private final Map<String, Map<String, String>> langMap;
 
-	public ShaderPack(Path root) throws IOException {
+	public static final ShaderPack NO_OP;
+
+	public ShaderPack(@Nullable Path root) throws IOException {
 		this.packDirectives = new PackDirectives();
 
 		this.gbuffersBasic = readProgramSource(root, "gbuffers_basic", this);
@@ -124,6 +127,10 @@ public class ShaderPack {
 		String vertexSource = null;
 		String fragmentSource = null;
 
+		if(root == null) {
+			return new ProgramSource(program, null, null, pack);
+		}
+
 		try {
 			Path vertexPath = root.resolve(program + ".vsh");
 			vertexSource = readFile(vertexPath);
@@ -160,6 +167,8 @@ public class ShaderPack {
 	}
 
 	private Map<String, Map<String, String>> parseLangEntries(Path root) throws IOException {
+		if(root == null) return new HashMap<>();
+
 		Path langFolderPath = root.resolve("lang");
 		Map<String, Map<String, String>> allLanguagesMap = new HashMap<>();
 
@@ -240,5 +249,16 @@ public class ShaderPack {
 				return Optional.empty();
 			}
 		}
+	}
+
+	static {
+		ShaderPack s;
+		try {
+			s = new ShaderPack(null);
+		} catch (IOException e) {
+			e.printStackTrace();
+			s = null;
+		}
+		NO_OP = s;
 	}
 }


### PR DESCRIPTION
The PR adds a builtin no-op shaderpack which is loaded when the shaderpack name is set to `(off)`.
The default shaderpack has also been changed to `(off)` rather than `(internal)`.