### PR TITLE
Remove MixinWorldRenderer from mixins block

### DIFF
--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -15,12 +15,10 @@
 	"texunits.MixinGlStateManager",
 	"texunits.MixinLightmapTextureManager",
 	"texunits.MixinOverlayTexture",
-	"texunits.MixinVertexFormats"
+	"texunits.MixinVertexFormats",
+	"gbuffer.MixinWorldRenderer"
   ],
   "injectors": {
 	"defaultRequire": 1
-  },
-  "mixins": [
-	"gbuffer.MixinWorldRenderer"
-  ]
+  }
 }


### PR DESCRIPTION
the mixin `gbuffer.MixinWorldRenderer` was in the mixins block instead of client