### PR TITLE
Removed unused local variable.

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/renderlayer/MixinRenderLayer.java
+++ b/src/main/java/net/coderbot/iris/mixin/renderlayer/MixinRenderLayer.java
@@ -112,8 +112,6 @@ public class MixinRenderLayer {
 	}
 
 	private static RenderLayer wrapGlint(String glintType, RenderLayer wrapped) {
-		String name = ((RenderPhaseAccessor) wrapped).getName();
-
 		String wrappedName = "iris:" + glintType + "_glint";
 
 		if (glintType == null) {


### PR DESCRIPTION
Removed declaration of unused String variable `name` from function `private static RenderLayer wrapGlint(String, RenderLayer)`. This variable was most likely a stray artifact from a copy-paste operation.