### PR TITLE
Add blockstate parsing

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/vertices/MixinChunkRebuildTask.java
+++ b/src/main/java/net/coderbot/iris/mixin/vertices/MixinChunkRebuildTask.java
@@ -62,8 +62,7 @@ public class MixinChunkRebuildTask {
 			return -1;
 		}
 
-		Identifier id = Registry.BLOCK.getId(state.getBlock());
-		return (short) (int) idMap.getBlockProperties().getOrDefault(id, -1);
+		return (short) (int) idMap.getBlockProperties().getOrDefault(state, -1);
 	}
 
 	@Inject(method = RENDER, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockRenderManager;renderFluid(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/client/render/VertexConsumer;Lnet/minecraft/fluid/FluidState;)Z"), locals = LocalCapture.CAPTURE_FAILHARD)

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -31,6 +31,7 @@ import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.gl.GlProgramManager;
 import net.minecraft.client.particle.ParticleTextureSheet;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 /**
  * Encapsulates the compiled shader program objects for the currently loaded shaderpack.
@@ -84,11 +85,13 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 	private static final List<GbufferProgram> programStack = new ArrayList<>();
 	private static final List<String> programStackLog = new ArrayList<>();
 
+	private static final Identifier WATER_IDENTIFIER = new Identifier("minecraft", "water");
+
 	public DeferredWorldRenderingPipeline(ProgramSet programs) {
 		Objects.requireNonNull(programs);
 
 		this.renderTargets = new RenderTargets(MinecraftClient.getInstance().getFramebuffer(), programs.getPackDirectives());
-		this.waterId = programs.getPack().getIdMap().getBlockProperties().getOrDefault(new Identifier("minecraft", "water"), -1);
+		this.waterId = programs.getPack().getIdMap().getBlockProperties().getOrDefault(Registry.BLOCK.get(WATER_IDENTIFIER).getDefaultState(), -1);
 
 		this.basic = programs.getGbuffersBasic().map(this::createPass).orElse(null);
 		this.textured = programs.getGbuffersTextured().map(this::createPass).orElse(basic);

--- a/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
@@ -188,7 +188,11 @@ public class IdMap {
 			for (String part : value.split(" ")) {
 
 				// adds block state entries if present
-				addBlockStates(part, idMap, intId);
+				boolean bl = addBlockStates(part, idMap, intId);
+				if (bl) {
+					// if the blockstate was sucessfully parsed, continue parsing ids
+					continue;
+				}
 
 				try {
 					Identifier identifier = new Identifier(part);
@@ -204,7 +208,7 @@ public class IdMap {
 		return Object2IntMaps.unmodifiable(idMap);
 	}
 
-	private static void addBlockStates(String entry, Object2IntMap<BlockState> idMap, int intId) {
+	private static boolean addBlockStates(String entry, Object2IntMap<BlockState> idMap, int intId) {
 		String[] splitStates = entry.split(":");
 
 		// make sure we only get the part of the string that is part of the block id, not the state
@@ -224,7 +228,7 @@ public class IdMap {
 		// so we just continue the iteration
 		if (idParts.size() > 2) {
 			Iris.logger.warn("block property \"" + entry + "\" could not be parsed!");
-			return;
+			return false;
 		}
 
 
@@ -266,6 +270,9 @@ public class IdMap {
 			}
 
 			idMap.put(state, intId);
+			return true;
+		} else {
+			return false;
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
@@ -6,7 +6,15 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
@@ -14,9 +22,12 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.coderbot.iris.Iris;
 import org.apache.logging.log4j.Level;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.state.property.Property;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
+import net.minecraft.util.registry.Registry;
 
 /**
  * A utility class for parsing entries in item.properties, block.properties, and entities.properties files in shaderpacks
@@ -35,7 +46,7 @@ public class IdMap {
 	/**
 	 * A map that contains the identifier of an item to the integer value parsed in block.properties
 	 */
-	private Map<Identifier, Integer> blockPropertiesMap = new HashMap<>();
+	private Object2IntMap<BlockState> blockPropertiesMap;
 
 	/**
 	 * A map that contains render layers for blocks in block.properties
@@ -51,7 +62,7 @@ public class IdMap {
 
 		loadProperties(shaderPath, "block.properties").ifPresent(blockProperties -> {
 			// TODO: This won't parse block states in block.properties properly
-			blockPropertiesMap = parseIdMap(blockProperties, "block.", "block.properties");
+			blockPropertiesMap = parseBlockMap(blockProperties, "block.", "block.properties");
 			blockRenderLayerMap = parseRenderLayerMap(blockProperties, "layer.", "block.properties");
 		});
 
@@ -152,6 +163,118 @@ public class IdMap {
 		return Object2IntMaps.unmodifiable(idMap);
 	}
 
+	private static Object2IntMap<BlockState> parseBlockMap(Properties properties, String keyPrefix, String fileName) {
+		Object2IntMap<BlockState> idMap = new Object2IntOpenHashMap<>();
+
+		properties.forEach((keyObject, valueObject) -> {
+			String key = (String) keyObject;
+			String value = (String) valueObject;
+
+			if (!key.startsWith(keyPrefix)) {
+				// Not a valid line, ignore it
+				return;
+			}
+
+			int intId;
+
+			try {
+				intId = Integer.parseInt(key.substring(keyPrefix.length()));
+			} catch (NumberFormatException e) {
+				// Not a valid property line
+				Iris.logger.warn("Failed to parse line in " + fileName + ": invalid key " + key);
+				return;
+			}
+
+			for (String part : value.split(" ")) {
+
+				// adds block state entries if present
+				addBlockStates(part, idMap, intId);
+
+				try {
+					Identifier identifier = new Identifier(part);
+
+					idMap.put(Registry.BLOCK.get(identifier).getDefaultState(), intId);
+				} catch (InvalidIdentifierException e) {
+					Iris.logger.warn("Failed to parse an identifier in " + fileName + " for the key " + key + ":");
+					Iris.logger.catching(Level.WARN, e);
+				}
+			}
+		});
+
+		return Object2IntMaps.unmodifiable(idMap);
+	}
+
+	private static void addBlockStates(String entry, Object2IntMap<BlockState> idMap, int intId) {
+		String[] splitStates = entry.split(":");
+
+		// make sure we only get the part of the string that is part of the block id, not the state
+		//
+		// for example, if we have "minecraft:tall_grass:half=upper"
+		// this list makes sure we only have "minecraft:tall_grass" or just "tall_grass" if "minecraft" is omitted
+		List<String> idParts = Arrays.stream(splitStates)
+			.filter(s -> !s.contains("="))
+			.collect(Collectors.toList());
+
+		List<String> stateParts = Arrays.stream(splitStates)
+			.filter(s -> s.contains("="))
+			.collect(Collectors.toList());
+
+
+		// if the list has more than 2 fields, then the pack author accidently put something like minecraft:tall_grass:random, which cannot be parsed
+		// so we just continue the iteration
+		if (idParts.size() > 2) {
+			Iris.logger.warn("block property \"" + entry + "\" could not be parsed!");
+			return;
+		}
+
+
+		// join the elements of the list with ":"
+		String idString = String.join(":", idParts);
+
+		// if the part does not end with the id string, then the entry is using states and we should parse that
+		if (!entry.endsWith(idString)) {
+
+			// if the number of states is greater than one, that means we have found an entry which uses block states
+			Identifier id = new Identifier(idString);
+
+			BlockState state = Registry.BLOCK.get(id).getDefaultState();
+
+			for (String stateProperty : stateParts) {
+				// split the total property into name/value
+				String[] keyValue = stateProperty.split("=");
+
+				if (keyValue.length < 2) {
+					Iris.logger.warn("Could not parse state entry \"" + stateProperty + "\" for id \"" + idString + "\"");
+					continue;
+				}
+
+				// name of property
+				String name = keyValue[0];
+
+				//desired value property should have
+				String propertyValue = keyValue[1];
+
+				//get the property via name
+				Property<?> property = state.getBlock().getStateManager().getProperty(name);
+
+				if (property != null) {
+					//set the state to be the previous state with the new state that we just parsed
+					state = parsePropertyValue(property, propertyValue, state);
+				} else {
+					Iris.logger.warn("Could not parse state entry \"" + stateProperty + "\" for id \"" + idString + "\"");
+				}
+			}
+
+			idMap.put(state, intId);
+		}
+	}
+
+	private static <T extends Comparable<T>> BlockState parsePropertyValue(Property<T> property, String string, BlockState state) {
+		Optional<T> optional = property.parse(string);
+		return optional.map(t -> state.with(property, t)).orElse(null);
+
+	}
+
 	/**
 	 * Parses a render layer map
 	 */
@@ -204,7 +327,7 @@ public class IdMap {
 		return layerMap;
 	}
 
-	public Map<Identifier, Integer> getBlockProperties() {
+	public Map<BlockState, Integer> getBlockProperties() {
 		return blockPropertiesMap;
 	}
 

--- a/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.coderbot.iris.Iris;
 import org.apache.logging.log4j.Level;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.state.property.Property;
@@ -197,7 +198,11 @@ public class IdMap {
 				try {
 					Identifier identifier = new Identifier(part);
 
-					idMap.put(Registry.BLOCK.get(identifier).getDefaultState(), intId);
+					Block block = Registry.BLOCK.get(identifier);
+
+					block.getStateManager().getStates().forEach(state -> {
+						idMap.put(state, intId);
+					});
 				} catch (InvalidIdentifierException e) {
 					Iris.logger.warn("Failed to parse an identifier in " + fileName + " for the key " + key + ":");
 					Iris.logger.catching(Level.WARN, e);

--- a/src/main/java/net/coderbot/iris/uniforms/IdMapUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IdMapUniforms.java
@@ -9,6 +9,7 @@ import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.shaderpack.IdMap;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
@@ -24,7 +25,7 @@ public final class IdMapUniforms {
 	}
 
 	public static void addIdMapUniforms(UniformHolder uniforms, IdMap idMap) {
-		Map<Identifier, Integer> blockIdMap = idMap.getBlockProperties();
+		Map<BlockState, Integer> blockIdMap = idMap.getBlockProperties();
 		Map<Identifier, Integer> entityIdMap = idMap.getEntityIdMap();
 
 		uniforms
@@ -70,7 +71,7 @@ public final class IdMapUniforms {
 	 *
 	 * @return the blockentity id
 	 */
-	private static int getBlockEntityId(Map<Identifier, Integer> blockIdMap) {
+	private static int getBlockEntityId(Map<BlockState, Integer> blockIdMap) {
 		BlockEntity entity = CapturedRenderingState.INSTANCE.getCurrentRenderedBlockEntity();
 
 		if (entity == null || !entity.hasWorld()) {
@@ -79,15 +80,15 @@ public final class IdMapUniforms {
 
 		ClientWorld world = Objects.requireNonNull(MinecraftClient.getInstance().world);
 
-		Block blockAt = world.getBlockState(entity.getPos()).getBlock();
+		BlockState blockAt = world.getBlockState(entity.getPos());
 
-		if (!entity.getType().supports(blockAt)) {
+		if (!entity.getType().supports(blockAt.getBlock())) {
 			// Somehow the block here isn't compatible with the block entity at this location.
 			// I'm not sure how this could ever reasonably happen.
 			return -1;
 		}
 
-		return blockIdMap.getOrDefault(Registry.BLOCK.getId(blockAt), -1);
+		return blockIdMap.getOrDefault(blockAt, -1);
 	}
 
 	/**


### PR DESCRIPTION
Adds blockstate parsing for `IdMap` , should avoid those errors in the log.

Closes #32 