### PR TITLE
Split UniformHolder interface

### DIFF
--- a/src/main/java/net/coderbot/iris/gl/program/ProgramUniforms.java
+++ b/src/main/java/net/coderbot/iris/gl/program/ProgramUniforms.java
@@ -5,13 +5,14 @@ import java.util.*;
 
 import com.google.common.collect.ImmutableList;
 import net.coderbot.iris.Iris;
+import net.coderbot.iris.gl.uniform.LocationalUniformHolder;
 import net.coderbot.iris.gl.uniform.Uniform;
-import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL20C;
 
 import net.minecraft.client.MinecraftClient;
+
 
 public class ProgramUniforms {
 	private final ImmutableList<Uniform> perTick;
@@ -62,7 +63,7 @@ public class ProgramUniforms {
 		return new Builder(name, program);
 	}
 
-	public static class Builder implements UniformHolder {
+	public static class Builder implements LocationalUniformHolder {
 		private final String name;
 		private final int program;
 
@@ -82,7 +83,7 @@ public class ProgramUniforms {
 		}
 
 		@Override
-		public UniformHolder addUniform(UniformUpdateFrequency updateFrequency, Uniform uniform) {
+		public Builder addUniform(UniformUpdateFrequency updateFrequency, Uniform uniform) {
 			switch (updateFrequency) {
 				case ONCE:
 					once.add(uniform);

--- a/src/main/java/net/coderbot/iris/gl/uniform/LocationalUniformHolder.java
+++ b/src/main/java/net/coderbot/iris/gl/uniform/LocationalUniformHolder.java
@@ -1,0 +1,110 @@
+package net.coderbot.iris.gl.uniform;
+
+import java.util.OptionalInt;
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.client.util.math.Vector4f;
+import net.minecraft.util.math.Matrix4f;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+
+public interface LocationalUniformHolder extends UniformHolder {
+	LocationalUniformHolder addUniform(UniformUpdateFrequency updateFrequency, Uniform uniform);
+
+	OptionalInt location(String name);
+
+	@Override
+	default LocationalUniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, FloatSupplier value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new FloatUniform(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, IntSupplier value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new FloatUniform(id, () -> (float) value.getAsInt())));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, DoubleSupplier value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new FloatUniform(id, () -> (float) value.getAsDouble())));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform1i(UniformUpdateFrequency updateFrequency, String name, IntSupplier value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new IntUniform(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform1b(UniformUpdateFrequency updateFrequency, String name, BooleanSupplier value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new BooleanUniform(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform2f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec2f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector2Uniform(id, value, true)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform2i(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec2f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector2Uniform(id, value, false)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform3f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector3f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector3Uniform(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniformTruncated3f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector4f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, Vector3Uniform.truncated(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform3d(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec3d> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, Vector3Uniform.converted(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniform4f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector4f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector4Uniform(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniformMatrix(UniformUpdateFrequency updateFrequency, String name, Supplier<Matrix4f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new MatrixUniform(id, value)));
+
+		return this;
+	}
+
+	@Override
+	default LocationalUniformHolder uniformJomlMatrix(UniformUpdateFrequency updateFrequency, String name, Supplier<net.coderbot.iris.vendored.joml.Matrix4f> value) {
+		location(name).ifPresent(id -> addUniform(updateFrequency, new JomlMatrixUniform(id, value)));
+
+		return this;
+	}
+}

--- a/src/main/java/net/coderbot/iris/gl/uniform/Uniform.java
+++ b/src/main/java/net/coderbot/iris/gl/uniform/Uniform.java
@@ -3,7 +3,7 @@ package net.coderbot.iris.gl.uniform;
 public abstract class Uniform {
 	protected final int location;
 
-	public Uniform(int location) {
+	Uniform(int location) {
 		this.location = location;
 	}
 

--- a/src/main/java/net/coderbot/iris/gl/uniform/Uniform.java
+++ b/src/main/java/net/coderbot/iris/gl/uniform/Uniform.java
@@ -3,7 +3,7 @@ package net.coderbot.iris.gl.uniform;
 public abstract class Uniform {
 	protected final int location;
 
-	Uniform(int location) {
+	public Uniform(int location) {
 		this.location = location;
 	}
 

--- a/src/main/java/net/coderbot/iris/gl/uniform/UniformHolder.java
+++ b/src/main/java/net/coderbot/iris/gl/uniform/UniformHolder.java
@@ -1,6 +1,5 @@
 package net.coderbot.iris.gl.uniform;
 
-import java.util.OptionalInt;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 import java.util.function.IntSupplier;
@@ -13,85 +12,29 @@ import net.minecraft.util.math.Vec2f;
 import net.minecraft.util.math.Vec3d;
 
 public interface UniformHolder {
-	UniformHolder addUniform(UniformUpdateFrequency updateFrequency, Uniform uniform);
+	UniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, FloatSupplier value);
 
-	OptionalInt location(String name);
+	UniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, IntSupplier value);
 
-	default UniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, FloatSupplier value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new FloatUniform(id, value)));
+	UniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, DoubleSupplier value);
 
-		return this;
-	}
+	UniformHolder uniform1i(UniformUpdateFrequency updateFrequency, String name, IntSupplier value);
 
-	default UniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, IntSupplier value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new FloatUniform(id, () -> (float) value.getAsInt())));
+	UniformHolder uniform1b(UniformUpdateFrequency updateFrequency, String name, BooleanSupplier value);
 
-		return this;
-	}
+	UniformHolder uniform2f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec2f> value);
 
-	default UniformHolder uniform1f(UniformUpdateFrequency updateFrequency, String name, DoubleSupplier value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new FloatUniform(id, () -> (float) value.getAsDouble())));
+	UniformHolder uniform2i(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec2f> value);
 
-		return this;
-	}
+	UniformHolder uniform3f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector3f> value);
 
-	default UniformHolder uniform1i(UniformUpdateFrequency updateFrequency, String name, IntSupplier value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new IntUniform(id, value)));
+	UniformHolder uniformTruncated3f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector4f> value);
 
-		return this;
-	}
+	UniformHolder uniform3d(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec3d> value);
 
-	default UniformHolder uniform1b(UniformUpdateFrequency updateFrequency, String name, BooleanSupplier value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new BooleanUniform(id, value)));
+	UniformHolder uniform4f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector4f> value);
 
-		return this;
-	}
+	UniformHolder uniformMatrix(UniformUpdateFrequency updateFrequency, String name, Supplier<Matrix4f> value);
 
-	default UniformHolder uniform2f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec2f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector2Uniform(id, value, true)));
-
-		return this;
-	}
-
-	default UniformHolder uniform2i(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec2f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector2Uniform(id, value, false)));
-
-		return this;
-	}
-
-	default UniformHolder uniform3f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector3f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector3Uniform(id, value)));
-
-		return this;
-	}
-
-	default UniformHolder uniformTruncated3f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector4f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, Vector3Uniform.truncated(id, value)));
-
-		return this;
-	}
-
-	default UniformHolder uniform3d(UniformUpdateFrequency updateFrequency, String name, Supplier<Vec3d> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, Vector3Uniform.converted(id, value)));
-
-		return this;
-	}
-
-	default UniformHolder uniform4f(UniformUpdateFrequency updateFrequency, String name, Supplier<Vector4f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new Vector4Uniform(id, value)));
-
-		return this;
-	}
-
-	default UniformHolder uniformMatrix(UniformUpdateFrequency updateFrequency, String name, Supplier<Matrix4f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new MatrixUniform(id, value)));
-
-		return this;
-	}
-
-	default UniformHolder uniformJomlMatrix(UniformUpdateFrequency updateFrequency, String name, Supplier<net.coderbot.iris.vendored.joml.Matrix4f> value) {
-		location(name).ifPresent(id -> addUniform(updateFrequency, new JomlMatrixUniform(id, value)));
-
-		return this;
-	}
+	UniformHolder uniformJomlMatrix(UniformUpdateFrequency updateFrequency, String name, Supplier<net.coderbot.iris.vendored.joml.Matrix4f> value);
 }

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -1,20 +1,15 @@
 package net.coderbot.iris.uniforms;
 
-import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.ONCE;
-import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_FRAME;
-import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_TICK;
-
 import java.util.Objects;
 import java.util.function.IntSupplier;
 
+import net.coderbot.iris.gl.uniform.LocationalUniformHolder;
 import net.coderbot.iris.gl.uniform.UniformHolder;
-import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.shaderpack.IdMap;
 import net.coderbot.iris.shaderpack.PackDirectives;
-import net.coderbot.iris.texunits.TextureUnit;
-
 import net.coderbot.iris.uniforms.transforms.SmoothedFloat;
 import net.coderbot.iris.uniforms.transforms.SmoothedVec2f;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.GameRenderer;
@@ -32,6 +27,9 @@ import net.minecraft.util.math.Vec2f;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.LightType;
 
+import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_FRAME;
+import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_TICK;
+
 public final class CommonUniforms {
 	private static final MinecraftClient client = MinecraftClient.getInstance();
 
@@ -39,7 +37,7 @@ public final class CommonUniforms {
 		// no construction allowed
 	}
 
-	public static void addCommonUniforms(UniformHolder uniforms, IdMap idMap, PackDirectives directives) {
+	public static void addCommonUniforms(LocationalUniformHolder uniforms, IdMap idMap, PackDirectives directives) {
 		CameraUniforms.addCameraUniforms(uniforms);
 		ViewportUniforms.addViewportUniforms(uniforms);
 		WorldTimeUniforms.addWorldTimeUniforms(uniforms);
@@ -49,6 +47,10 @@ public final class CommonUniforms {
 		MatrixUniforms.addMatrixUniforms(uniforms);
 		SamplerUniforms.addCommonSamplerUniforms(uniforms);
 
+		CommonUniforms.generalCommonUniforms(uniforms);
+	}
+
+	public static void generalCommonUniforms(UniformHolder uniforms){
 		uniforms
 			.uniform1b(PER_FRAME, "hideGUI", () -> client.options.hudHidden)
 			.uniform1f(PER_FRAME, "eyeAltitude", () -> Objects.requireNonNull(client.getCameraEntity()).getEyeY())

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -37,6 +37,7 @@ public final class CommonUniforms {
 		// no construction allowed
 	}
 
+	// Needs to use a LocationalUniformHolder as we need it for the common uniforms
 	public static void addCommonUniforms(LocationalUniformHolder uniforms, IdMap idMap, PackDirectives directives) {
 		CameraUniforms.addCameraUniforms(uniforms);
 		ViewportUniforms.addViewportUniforms(uniforms);

--- a/src/main/java/net/coderbot/iris/uniforms/SamplerUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/SamplerUniforms.java
@@ -33,6 +33,7 @@ public class SamplerUniforms {
 		// no construction allowed
 	}
 
+	// Needs to use a LocationalUniformHolder as we need a way to figure out if `watershadow` is used or not.
 	public static void addCommonSamplerUniforms(LocationalUniformHolder uniforms) {
 		// Generic always-accessible samplers
 		addSampler(uniforms, COLOR_TEX_4, "gaux1", "colortex4");

--- a/src/main/java/net/coderbot/iris/uniforms/SamplerUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/SamplerUniforms.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.uniforms;
 
+import net.coderbot.iris.gl.uniform.LocationalUniformHolder;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.texunits.TextureUnit;
@@ -32,7 +33,7 @@ public class SamplerUniforms {
 		// no construction allowed
 	}
 
-	public static void addCommonSamplerUniforms(UniformHolder uniforms) {
+	public static void addCommonSamplerUniforms(LocationalUniformHolder uniforms) {
 		// Generic always-accessible samplers
 		addSampler(uniforms, COLOR_TEX_4, "gaux1", "colortex4");
 		addSampler(uniforms, COLOR_TEX_5, "gaux2", "colortex5");


### PR DESCRIPTION
(Needed for Custom Uniforms)

This pr moves part of the code of `UniformHolder` into `LocationalUniformHolder` as the Custom Uniform input manager can't return any useful `location` nor can it accept arbitrary uniforms.