### PR TITLE
Add basic build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ That being said... **If you want to test out compiled alpha builds of the mod, p
 
 **No support will be provided for users who cannot figure out how to properly compile the mod themselves.**
 
+Build:
+
+- `gradlew build`
 
 ## What is Iris, anyways?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ That being said... **If you want to test out compiled alpha builds of the mod, p
 
 Build:
 
-- `gradlew build`
+- `chmod +x ./gradlew`
+- `./gradlew build`
 
 ## What is Iris, anyways?
 


### PR DESCRIPTION
I suppose that the idea is that you won't be pestered by people expecting support for compiling the mod without being paid for it, but I feel like it would be helpful for people who respect that concept but have no prior experience compiling java mods if there was a basic build instruction?