### PR TITLE
Add a Shader Pack Selection UI

### DIFF
--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -229,6 +229,20 @@ public class Iris implements ClientModInitializer {
 		internal = true;
 	}
 
+	public static boolean isValidShaderpack(Path pack) {
+		if (Files.isDirectory(pack)) {
+			return Files.exists(pack.resolve("shaders"));
+		}
+		if (pack.toString().endsWith(".zip")) {
+			try {
+				FileSystem zipSystem = FileSystems.newFileSystem(pack, Iris.class.getClassLoader());
+				return Files.exists(zipSystem.getPath("shaders"));
+			} catch (IOException ignored) {
+			}
+		}
+		return false;
+	}
+
 	public static void reload() throws IOException {
 		// allows shaderpacks to be changed at runtime
 		irisConfig.initialize();

--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -38,7 +38,7 @@ public class Iris implements ClientModInitializer {
 	public static final String MODID = "iris";
 	public static final Logger logger = LogManager.getLogger(MODID);
 
-	private static final Path shaderpacksDirectory = FabricLoader.getInstance().getGameDir().resolve("shaderpacks");
+	public static final Path shaderpacksDirectory = FabricLoader.getInstance().getGameDir().resolve("shaderpacks");
 
 	private static ShaderPack currentPack;
 	private static String currentPackName;

--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import net.coderbot.iris.Iris;
 import net.fabricmc.loader.api.FabricLoader;
 
 /**
@@ -64,6 +65,25 @@ public class IrisConfig {
 		}
 
 		return shaderPackName;
+	}
+
+	/**
+	 * Sets the name of the current shaderpack
+	 */
+	public void setShaderPackName(String name) {
+		if (name.equals("(internal)")) {
+			this.shaderPackName = null;
+		}
+		else {
+			this.shaderPackName = name;
+		}
+		try {
+			save();
+		}
+		catch (IOException e) {
+			Iris.logger.error("Error saving configuration file, unable to set shader pack name");
+			e.printStackTrace();
+		}
 	}
 
 	/**

--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -73,14 +73,12 @@ public class IrisConfig {
 	public void setShaderPackName(String name) {
 		if (name.equals("(internal)")) {
 			this.shaderPackName = null;
-		}
-		else {
+		} else {
 			this.shaderPackName = name;
 		}
 		try {
 			save();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			Iris.logger.error("Error saving configuration file, unable to set shader pack name");
 			e.printStackTrace();
 		}

--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -80,7 +80,7 @@ public class IrisConfig {
 			save();
 		} catch (IOException e) {
 			Iris.logger.error("Error saving configuration file, unable to set shader pack name");
-			e.printStackTrace();
+			Iris.logger.catching(e);
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/gui/element/IrisScreenEntryListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/IrisScreenEntryListWidget.java
@@ -1,0 +1,23 @@
+package net.coderbot.iris.gui.element;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.TickableElement;
+import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class IrisScreenEntryListWidget<E extends AlwaysSelectedEntryListWidget.Entry<E>> extends AlwaysSelectedEntryListWidget<E> {
+	public IrisScreenEntryListWidget(MinecraftClient client, int width, int height, int top, int bottom, int left, int right, int itemHeight) {
+		super(client, width, height, top, bottom, itemHeight);
+		this.left = left;
+		this.right = right;
+	}
+
+	@Override
+	protected int getScrollbarPositionX() {
+		return width - 6;
+	}
+
+	public void select(int entry) {
+		setSelected(this.getEntry(entry));
+	}
+}

--- a/src/main/java/net/coderbot/iris/gui/element/IrisScreenEntryListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/IrisScreenEntryListWidget.java
@@ -1,9 +1,7 @@
 package net.coderbot.iris.gui.element;
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.TickableElement;
 import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
-import net.minecraft.client.util.math.MatrixStack;
 
 public class IrisScreenEntryListWidget<E extends AlwaysSelectedEntryListWidget.Entry<E>> extends AlwaysSelectedEntryListWidget<E> {
 	public IrisScreenEntryListWidget(MinecraftClient client, int width, int height, int top, int bottom, int left, int right, int itemHeight) {

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -57,8 +57,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 					try {
 						FileSystem zipSystem = FileSystems.newFileSystem(p, Iris.class.getClassLoader());
 						return Files.exists(zipSystem.getPath("shaders"));
-					}
-					catch (IOException ignored) {
+					} catch (IOException ignored) {
 					}
 				}
 				return false;

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -72,6 +72,16 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 		this.addEntry(entry);
 	}
 
+	public void select(String name) {
+		for (int i = 0; i < getEntryCount(); i++) {
+			BaseEntry entry = getEntry(i);
+			if (entry instanceof ShaderPackEntry && ((ShaderPackEntry)entry).packName.equals(name)) {
+				setSelected(entry);
+				return;
+			}
+		}
+	}
+
 	public static abstract class BaseEntry extends AlwaysSelectedEntryListWidget.Entry<BaseEntry> {
 		protected BaseEntry() {}
 	}

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -1,0 +1,133 @@
+package net.coderbot.iris.gui.element;
+
+import com.google.common.collect.ImmutableList;
+import net.coderbot.iris.Iris;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.util.Formatting;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackListWidget.ShaderPackEntry> {
+	public static final List<String> BUILTIN_PACKS = ImmutableList.of("(internal)");
+
+	public ShaderPackListWidget(MinecraftClient client, int width, int height, int top, int bottom, int left, int right) {
+		super(client, width, height, top, bottom, left, right, 20);
+		refresh();
+	}
+
+	@Override
+	public int getRowWidth() {
+		return width - 50;
+	}
+
+	@Override
+	protected int getRowTop(int index) {
+		return super.getRowTop(index) + 2;
+	}
+
+	public void refresh() {
+		this.clearEntries();
+		try {
+			Path path = Iris.shaderpacksDirectory;
+			int index = -1;
+
+			for (String pack : BUILTIN_PACKS) {
+				index++;
+				addEntry(index, pack);
+			}
+
+			Collection<Path> folders = Files.walk(path, 1).filter(p -> {
+				if (Files.isDirectory(p)) {
+					return Files.exists(p.resolve("shaders"));
+				}
+				if (p.toString().endsWith(".zip")) {
+					try {
+						FileSystem zipSystem = FileSystems.newFileSystem(p, Iris.class.getClassLoader());
+						return Files.exists(zipSystem.getPath("shaders"));
+					}
+					catch (IOException ignored) {
+					}
+				}
+				return false;
+			}).collect(Collectors.toList());
+
+			for (Path folder : folders) {
+				String name = folder.getFileName().toString();
+				if (!BUILTIN_PACKS.contains(name)) {
+					index++;
+					addEntry(index, name);
+				}
+			}
+		} catch (Throwable e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void addEntry(int index, String name) {
+		ShaderPackEntry entry = new ShaderPackEntry(index, this, name);
+		if (Iris.getIrisConfig().getShaderPackName().equals(name)) {
+			this.setSelected(entry);
+		}
+		this.addEntry(entry);
+	}
+
+	public static class ShaderPackEntry extends AlwaysSelectedEntryListWidget.Entry<ShaderPackEntry> {
+		private final String packName;
+		private final ShaderPackListWidget list;
+		private final int index;
+
+		public ShaderPackEntry(int index, ShaderPackListWidget list, String packName) {
+			this.packName = packName;
+			this.list = list;
+			this.index = index;
+		}
+
+		public boolean isSelected() {
+			return list.getSelected() == this;
+		}
+
+		public String getPackName() {
+			return packName;
+		}
+
+		@Override
+		public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+			TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+			int color = 0xFFFFFF;
+			String name = packName;
+			if (textRenderer.getWidth(new LiteralText(name).formatted(Formatting.BOLD)) > this.list.getRowWidth() - 3) {
+				name = textRenderer.trimToWidth(name, this.list.getRowWidth() - 8) + "...";
+			}
+			MutableText text = new LiteralText(name);
+			if (this.isMouseOver(mouseX, mouseY)) {
+				text = text.formatted(Formatting.BOLD);
+			}
+			if (this.isSelected()) {
+				color = 0xFFF263;
+			}
+			drawCenteredText(matrices, textRenderer, text, (x + entryWidth / 2) - 2, y + (entryHeight - 11) / 2, color);
+		}
+
+		@Override
+		public boolean mouseClicked(double mouseX, double mouseY, int button) {
+			if (!this.isSelected() && button == 0) {
+				this.list.select(this.index);
+				return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -40,7 +40,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 	public void refresh() {
 		this.clearEntries();
 		try {
-			Path path = Iris.shaderpacksDirectory;
+			Path path = Iris.SHADERPACKS_DIRECTORY;
 			int index = -1;
 
 			for (String pack : BUILTIN_PACKS) {

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -60,7 +60,8 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 
 			this.addEntry(new LabelEntry(PACK_LIST_LABEL));
 		} catch (Throwable e) {
-			e.printStackTrace();
+			Iris.logger.error("Error reading files while constructing selection UI");
+			Iris.logger.catching(e);
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/gui/option/ShaderPackSelectionButtonOption.java
+++ b/src/main/java/net/coderbot/iris/gui/option/ShaderPackSelectionButtonOption.java
@@ -1,0 +1,31 @@
+package net.coderbot.iris.gui.option;
+
+import net.coderbot.iris.gui.screen.ShaderPackScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.AbstractButtonWidget;
+import net.minecraft.client.gui.widget.OptionButtonWidget;
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.Option;
+import net.minecraft.text.TranslatableText;
+
+public class ShaderPackSelectionButtonOption extends Option {
+	private final Screen parent;
+	private final MinecraftClient client;
+
+	public ShaderPackSelectionButtonOption(Screen parent, MinecraftClient client) {
+		super("options.iris.shaderPackSelection");
+		this.parent = parent;
+		this.client = client;
+	}
+
+	@Override
+	public AbstractButtonWidget createButton(GameOptions options, int x, int y, int width) {
+		return new OptionButtonWidget(
+				x, y, width, 20,
+				this,
+				new TranslatableText("options.iris.shaderPackSelection"),
+				button -> client.openScreen(new ShaderPackScreen(parent))
+		);
+	}
+}

--- a/src/main/java/net/coderbot/iris/gui/screen/HudHideable.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/HudHideable.java
@@ -1,0 +1,9 @@
+package net.coderbot.iris.gui.screen;
+
+/**
+ * Screens implementing this will hide the player hand and HUD
+ *
+ * Only used for instanceof checks
+ */
+public interface HudHideable {
+}

--- a/src/main/java/net/coderbot/iris/gui/screen/HudHideable.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/HudHideable.java
@@ -1,7 +1,0 @@
-package net.coderbot.iris.gui.screen;
-
-/**
- * Used only for instanceof checks
- */
-public interface HudHideable {
-}

--- a/src/main/java/net/coderbot/iris/gui/screen/HudHideable.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/HudHideable.java
@@ -1,0 +1,7 @@
+package net.coderbot.iris.gui.screen;
+
+/**
+ * Used only for instanceof checks
+ */
+public interface HudHideable {
+}

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -92,7 +92,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 			try {
 				Files.copy(pack, Iris.SHADERPACKS_DIRECTORY.resolve(fileName));
 			} catch (IOException e) {
-				e.printStackTrace();
+				Iris.logger.warn("Error copying dragged shader pack", e);
 				this.addedPackDialog = new TranslatableText(
 						"options.iris.shaderPackSelection.copyError",
 						fileName
@@ -142,7 +142,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 			Iris.reload();
 		} catch (IOException e) {
 			Iris.logger.error("Error reloading shader pack while applying changes!");
-			e.printStackTrace();
+			Iris.logger.catching(e);
 		}
 	}
 }

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -102,12 +102,15 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 				return;
 			}
 		}
+		this.shaderPacks.refresh();
 		if (packs.size() > 0) {
 			if (packs.size() == 1) {
+				String packName = packs.get(0).getFileName().toString();
 				this.addedPackDialog = new TranslatableText(
 						"options.iris.shaderPackSelection.addedPack",
-						packs.get(0).getFileName().toString()
+						packName
 				).formatted(Formatting.ITALIC, Formatting.YELLOW);
+				this.shaderPacks.select(packName);
 			} else {
 				this.addedPackDialog = new TranslatableText(
 						"options.iris.shaderPackSelection.addedPacks",
@@ -120,7 +123,6 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 			).formatted(Formatting.ITALIC, Formatting.RED);
 		}
 		this.addedPackDialogTimer = 100;
-		this.shaderPacks.refresh();
 	}
 
 	@Override

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -1,0 +1,84 @@
+package net.coderbot.iris.gui.screen;
+
+import net.coderbot.iris.Iris;
+import net.coderbot.iris.gui.element.ShaderPackListWidget;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Util;
+
+import java.io.IOException;
+
+public class ShaderPackScreen extends Screen implements HudHideable {
+	private final Screen parent;
+
+	private ShaderPackListWidget shaderPacks;
+
+	public ShaderPackScreen(Screen parent) {
+		super(new TranslatableText("options.iris.shaderPackSelection.title"));
+		this.parent = parent;
+	}
+
+	@Override
+	public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+		if (this.client.world == null) {
+			this.renderBackground(matrices);
+		}
+		else {
+			this.fillGradient(matrices, 0, 0, width, height, 0x4F232323, 0x4F232323);
+		}
+
+		this.shaderPacks.render(matrices, mouseX, mouseY, delta);
+		
+		drawCenteredText(matrices, this.textRenderer, this.title, (int)(this.width * 0.5), 8, 16777215);
+		drawCenteredText(matrices, this.textRenderer, new TranslatableText("pack.iris.select.title").formatted(Formatting.GRAY, Formatting.ITALIC), (int)(this.width * 0.5), 21, 16777215);
+		super.render(matrices, mouseX, mouseY, delta);
+	}
+
+	@Override
+	protected void init() {
+		super.init();
+		int bottomCenter = this.width / 2 - 50;
+		int topCenter = this.width / 2 - 76;
+		boolean inWorld = this.client.world != null;
+
+		this.shaderPacks = new ShaderPackListWidget(this.client, this.width, this.height, 32, this.height - 58, 0, this.width);
+		if (inWorld) {
+			this.shaderPacks.method_31322(false);
+		}
+		this.children.add(shaderPacks);
+
+		this.addButton(new ButtonWidget(bottomCenter + 104, this.height - 27, 100, 20, ScreenTexts.DONE, button -> {
+			applyChanges();
+			onClose();
+		}));
+		this.addButton(new ButtonWidget(bottomCenter, this.height - 27, 100, 20, new TranslatableText("options.iris.apply"), button -> this.applyChanges()));
+		this.addButton(new ButtonWidget(bottomCenter - 104, this.height - 27, 100, 20, ScreenTexts.CANCEL, button -> this.onClose()));
+		this.addButton(new ButtonWidget(topCenter - 78, this.height - 51, 152, 20, new TranslatableText("options.iris.openShaderPackFolder"), button -> Util.getOperatingSystem().open(Iris.shaderpacksDirectory.toFile())));
+		this.addButton(new ButtonWidget(topCenter + 78, this.height - 51, 152, 20, new TranslatableText("options.iris.refreshShaderPacks"), button -> this.shaderPacks.refresh()));
+	}
+
+	@Override
+	public void onClose() {
+		this.client.openScreen(parent);
+	}
+
+	private void applyChanges() {
+		ShaderPackListWidget.ShaderPackEntry entry = this.shaderPacks.getSelected();
+		String name = "(internal)";
+		if (entry != null) {
+			name = entry.getPackName();
+		}
+		Iris.getIrisConfig().setShaderPackName(name);
+		try {
+			Iris.reload();
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -13,7 +13,7 @@ import net.minecraft.util.Util;
 
 import java.io.IOException;
 
-public class ShaderPackScreen extends Screen implements HudHideable {
+public class ShaderPackScreen extends Screen {
 	private final Screen parent;
 
 	private ShaderPackListWidget shaderPacks;
@@ -27,13 +27,12 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 	public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
 		if (this.client.world == null) {
 			this.renderBackground(matrices);
-		}
-		else {
+		} else {
 			this.fillGradient(matrices, 0, 0, width, height, 0x4F232323, 0x4F232323);
 		}
 
 		this.shaderPacks.render(matrices, mouseX, mouseY, delta);
-		
+
 		drawCenteredText(matrices, this.textRenderer, this.title, (int)(this.width * 0.5), 8, 16777215);
 		drawCenteredText(matrices, this.textRenderer, new TranslatableText("pack.iris.select.title").formatted(Formatting.GRAY, Formatting.ITALIC), (int)(this.width * 0.5), 21, 16777215);
 		super.render(matrices, mouseX, mouseY, delta);
@@ -76,8 +75,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 		Iris.getIrisConfig().setShaderPackName(name);
 		try {
 			Iris.reload();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -72,7 +72,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 		}));
 		this.addButton(new ButtonWidget(bottomCenter, this.height - 27, 100, 20, new TranslatableText("options.iris.apply"), button -> this.applyChanges()));
 		this.addButton(new ButtonWidget(bottomCenter - 104, this.height - 27, 100, 20, ScreenTexts.CANCEL, button -> this.onClose()));
-		this.addButton(new ButtonWidget(topCenter - 78, this.height - 51, 152, 20, new TranslatableText("options.iris.openShaderPackFolder"), button -> Util.getOperatingSystem().open(Iris.shaderpacksDirectory.toFile())));
+		this.addButton(new ButtonWidget(topCenter - 78, this.height - 51, 152, 20, new TranslatableText("options.iris.openShaderPackFolder"), button -> Util.getOperatingSystem().open(Iris.SHADERPACKS_DIRECTORY.toFile())));
 		this.addButton(new ButtonWidget(topCenter + 78, this.height - 51, 152, 20, new TranslatableText("options.iris.refreshShaderPacks"), button -> this.shaderPacks.refresh()));
 	}
 
@@ -88,20 +88,18 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 	public void filesDragged(List<Path> paths) {
 		List<Path> packs = paths.stream().filter(Iris::isValidShaderpack).collect(Collectors.toList());
 		for (Path pack : packs) {
-			if (Iris.isValidShaderpack(pack)) {
-				String fileName = pack.getFileName().toString();
-				try {
-					Files.copy(pack, Iris.shaderpacksDirectory.resolve(fileName));
-				} catch (IOException e) {
-					e.printStackTrace();
-					this.addedPackDialog = new TranslatableText(
-							"options.iris.shaderPackSelection.copyError",
-							fileName
-					).formatted(Formatting.ITALIC, Formatting.RED);
-					this.addedPackDialogTimer = 100;
-					this.shaderPacks.refresh();
-					return;
-				}
+			String fileName = pack.getFileName().toString();
+			try {
+				Files.copy(pack, Iris.SHADERPACKS_DIRECTORY.resolve(fileName));
+			} catch (IOException e) {
+				e.printStackTrace();
+				this.addedPackDialog = new TranslatableText(
+						"options.iris.shaderPackSelection.copyError",
+						fileName
+				).formatted(Formatting.ITALIC, Formatting.RED);
+				this.addedPackDialogTimer = 100;
+				this.shaderPacks.refresh();
+				return;
 			}
 		}
 		if (packs.size() > 0) {
@@ -141,6 +139,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 		try {
 			Iris.reload();
 		} catch (IOException e) {
+			Iris.logger.error("Error reloading shader pack while applying changes!");
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/net/coderbot/iris/mixin/MixinInGameHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinInGameHud.java
@@ -17,7 +17,7 @@ public class MixinInGameHud {
 	@Shadow @Final private MinecraftClient client;
 
 	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
-	public void handleTransparentScreens(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
+	public void iris$handleHudHidingScreens(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
 		Screen screen = this.client.currentScreen;
 		if(screen instanceof HudHideable) {
 			ci.cancel();

--- a/src/main/java/net/coderbot/iris/mixin/MixinInGameHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinInGameHud.java
@@ -1,0 +1,26 @@
+package net.coderbot.iris.mixin;
+
+import net.coderbot.iris.gui.screen.HudHideable;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.math.MatrixStack;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InGameHud.class)
+public class MixinInGameHud {
+	@Shadow @Final private MinecraftClient client;
+
+	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
+	public void handleTransparentScreens(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
+		Screen screen = this.client.currentScreen;
+		if(screen instanceof HudHideable) {
+			ci.cancel();
+		}
+	}
+}

--- a/src/main/java/net/coderbot/iris/mixin/MixinInGameHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinInGameHud.java
@@ -19,7 +19,7 @@ public class MixinInGameHud {
 	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
 	public void iris$handleHudHidingScreens(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
 		Screen screen = this.client.currentScreen;
-		if(screen instanceof HudHideable) {
+		if (screen instanceof HudHideable) {
 			ci.cancel();
 		}
 	}

--- a/src/main/java/net/coderbot/iris/mixin/gui/MixinVideoOptionsScreen.java
+++ b/src/main/java/net/coderbot/iris/mixin/gui/MixinVideoOptionsScreen.java
@@ -1,0 +1,32 @@
+package net.coderbot.iris.mixin.gui;
+
+import net.coderbot.iris.gui.option.ShaderPackSelectionButtonOption;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.VideoOptionsScreen;
+import net.minecraft.client.options.Option;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(VideoOptionsScreen.class)
+public abstract class MixinVideoOptionsScreen extends Screen {
+	protected MixinVideoOptionsScreen(Text title) {
+		super(title);
+	}
+
+	@ModifyArg(
+			method = "init",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"
+			),
+			index = 0
+	)
+	private Option[] iris$addShaderPackScreenButton(Option[] old) {
+		Option[] options = new Option[old.length + 1];
+		System.arraycopy(old, 0, options, 0, old.length);
+		options[options.length - 1] = new ShaderPackSelectionButtonOption((VideoOptionsScreen)(Object)this, this.client);
+		return options;
+	}
+}

--- a/src/main/resources/assets/iris/lang/en_us.json
+++ b/src/main/resources/assets/iris/lang/en_us.json
@@ -10,6 +10,11 @@
   "options.iris.refreshShaderPacks": "Refresh Shader Packs",
   "options.iris.shaderPackSelection": "Shader Packs...",
   "options.iris.shaderPackSelection.title": "Shader Packs",
+  "options.iris.shaderPackSelection.addedPack": "Added Shader Pack \"%s\"",
+  "options.iris.shaderPackSelection.addedPacks": "Added %s Shader Packs",
+  "options.iris.shaderPackSelection.failedAdd": "Files were not valid Shader Packs",
+  "options.iris.shaderPackSelection.copyError": "Could not add Shader Pack \"%s\"",
 
-  "pack.iris.select.title": "Select"
+  "pack.iris.select.title": "Select",
+  "pack.iris.list.label": "+ Drag and Drop Shader Packs to add"
 }

--- a/src/main/resources/assets/iris/lang/en_us.json
+++ b/src/main/resources/assets/iris/lang/en_us.json
@@ -2,5 +2,14 @@
   "iris.shaders.reloaded": "Shaders Reloaded!",
   "iris.keybind.reload": "Reload Shaders",
   "iris.keybinds": "Iris",
-  "iris.shaders.reloaded.failure": "Failed to Reload Shaders! Reason: %s"
+  "iris.shaders.reloaded.failure": "Failed to Reload Shaders! Reason: %s",
+
+  "options.iris.apply": "Apply",
+  "options.iris.refresh": "Refresh",
+  "options.iris.openShaderPackFolder": "Open Shader Pack Folder...",
+  "options.iris.refreshShaderPacks": "Refresh Shader Packs",
+  "options.iris.shaderPackSelection": "Shader Packs...",
+  "options.iris.shaderPackSelection.title": "Shader Packs",
+
+  "pack.iris.select.title": "Select"
 }

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -10,11 +10,14 @@
     "MixinGameRenderer",
     "MixinGlStateManager",
     "MixinImmediateVertexConsumerProvider",
+    "MixinModelViewBobbing",
     "MixinParticleManager",
     "MixinTranslationStorage",
+    "MixinTweakFarPlane",
     "MixinWorldRenderer",
     "fabulous.MixinDisableFabulousGraphics",
     "fabulous.MixinOption",
+    "gui.MixinVideoOptionsScreen",
     "renderlayer.MixinFixEyesTranslucency",
     "renderlayer.MixinRenderLayer",
     "renderlayer.RenderLayerAccessor",
@@ -23,9 +26,7 @@
     "texunits.MixinGlStateManager",
     "texunits.MixinLightmapTextureManager",
     "texunits.MixinOverlayTexture",
-    "texunits.MixinVertexFormats",
-    "MixinModelViewBobbing",
-    "MixinTweakFarPlane"
+    "texunits.MixinVertexFormats"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -10,6 +10,7 @@
     "MixinGameRenderer",
     "MixinGlStateManager",
     "MixinImmediateVertexConsumerProvider",
+    "MixinInGameHud",
     "MixinModelViewBobbing",
     "MixinParticleManager",
     "MixinTranslationStorage",


### PR DESCRIPTION
This PR adds a shader pack selection GUI.
The GUI allows for viewing available shader packs and selecting one, as well as applying the shader pack or cancelling the selection.
It also allows for previewing the shader pack's appearance with a transparent background.

![shader_screen](https://user-images.githubusercontent.com/43485105/116357684-9b362900-a7b1-11eb-8ef2-0aa56247a7a3.png)

As of opening, this PR is a draft.