### PR TITLE
Make FrameUpdateNotifier an instance variable of DeferredWorldRenderingPipeline (fixes DOF reload crash)

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinWorldRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinWorldRenderer.java
@@ -50,7 +50,7 @@ public class MixinWorldRenderer {
 	private void iris$beginWorldRender(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo callback) {
 		CapturedRenderingState.INSTANCE.setGbufferModelView(matrices.peek().getModel());
 		CapturedRenderingState.INSTANCE.setTickDelta(tickDelta);
-		pipeline = Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
+		pipeline = Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension(), true);
 		if (pipeline instanceof DeferredWorldRenderingPipeline) {
 			((DeferredWorldRenderingPipeline) pipeline).getUpdateNotifier().onNewFrame();
 		}

--- a/src/main/java/net/coderbot/iris/mixin/MixinWorldRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinWorldRenderer.java
@@ -4,6 +4,7 @@ import net.coderbot.iris.HorizonRenderer;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.fantastic.FlushableVertexConsumerProvider;
 import net.coderbot.iris.layer.GbufferProgram;
+import net.coderbot.iris.pipeline.DeferredWorldRenderingPipeline;
 import net.coderbot.iris.pipeline.WorldRenderingPipeline;
 import net.coderbot.iris.uniforms.CapturedRenderingState;
 import net.coderbot.iris.uniforms.FrameUpdateNotifier;
@@ -41,7 +42,7 @@ public class MixinWorldRenderer {
 
 	@Unique
 	private boolean skyTextureEnabled;
-	
+
 	@Unique
 	private WorldRenderingPipeline pipeline;
 
@@ -50,8 +51,10 @@ public class MixinWorldRenderer {
 		CapturedRenderingState.INSTANCE.setGbufferModelView(matrices.peek().getModel());
 		CapturedRenderingState.INSTANCE.setTickDelta(tickDelta);
 		pipeline = Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
-		FrameUpdateNotifier.INSTANCE.onNewFrame();
-		
+		if (pipeline instanceof DeferredWorldRenderingPipeline) {
+			((DeferredWorldRenderingPipeline) pipeline).getUpdateNotifier().onNewFrame();
+		}
+
 		pipeline.beginWorldRendering();
 	}
 

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -88,6 +88,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 	private final NativeImageBackedSingleColorTexture normals;
 	private final NativeImageBackedSingleColorTexture specular;
 	private final AbstractTexture noise;
+	private final FrameUpdateNotifier updateNotifier;
 
 	private final int waterId;
 	private final float sunPathRotation;
@@ -101,6 +102,8 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 
 	public DeferredWorldRenderingPipeline(ProgramSet programs) {
 		Objects.requireNonNull(programs);
+
+		this.updateNotifier = new FrameUpdateNotifier();
 
 		this.renderTargets = new RenderTargets(MinecraftClient.getInstance().getFramebuffer(), programs.getPackDirectives().getRenderTargetDirectives());
 		this.waterId = programs.getPack().getIdMap().getBlockProperties().getOrDefault(Registry.BLOCK.get(WATER_IDENTIFIER).getDefaultState(), -1);
@@ -153,7 +156,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 
 		GlStateManager.activeTexture(GL20C.GL_TEXTURE0);
 
-		this.compositeRenderer = new CompositeRenderer(programs, renderTargets, noise);
+		this.compositeRenderer = new CompositeRenderer(programs, renderTargets, noise, updateNotifier);
 
 		this.usesShadows |= compositeRenderer.usesShadows();
 
@@ -368,7 +371,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 			usesShadows = true;
 		}
 
-		CommonUniforms.addCommonUniforms(builder, source.getParent().getPack().getIdMap(), source.getParent().getPackDirectives(), FrameUpdateNotifier.INSTANCE);
+		CommonUniforms.addCommonUniforms(builder, source.getParent().getPack().getIdMap(), source.getParent().getPackDirectives(), updateNotifier);
 		SamplerUniforms.addWorldSamplerUniforms(builder);
 		SamplerUniforms.addDepthSamplerUniforms(builder);
 		GlFramebuffer framebuffer = renderTargets.createFramebufferWritingToMain(source.getDirectives().getDrawBuffers());
@@ -658,5 +661,9 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 
 	public void endShadowRender() {
 		isRenderingShadow = false;
+	}
+
+	public FrameUpdateNotifier getUpdateNotifier() {
+		return updateNotifier;
 	}
 }

--- a/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -25,7 +25,7 @@ public class PipelineManager {
 		this.wasDisablingDirectionalShading = DirectionalShadingHelper.shouldDisableDirectionalShading;
 	}
 
-	public WorldRenderingPipeline preparePipeline(DimensionId currentDimension) {
+	public WorldRenderingPipeline preparePipeline(DimensionId currentDimension, boolean reloadRenderer) {
 		if (currentDimension != lastDimension) {
 			Iris.logger.info("Reloading shaderpack on dimension change (" + lastDimension + " -> " + currentDimension + ")");
 
@@ -51,7 +51,9 @@ public class PipelineManager {
 			// TODO: Do not always reload on shaderpack changes, and only reload if the block ID mapping changes
 			//
 			// If the block ID mapping changes and the world render is not reloaded, then things won't work correctly.
-			MinecraftClient.getInstance().worldRenderer.reload();
+			if (reloadRenderer) {
+				MinecraftClient.getInstance().worldRenderer.reload();
+			}
 
 			// If Sodium is loaded, we need to reload the world renderer to properly recreate the ChunkRenderBackend
 			// Otherwise, the terrain shaders won't be changed properly.

--- a/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
@@ -162,7 +162,7 @@ public class ShadowRenderer implements ShadowMapRenderer {
 			throw new RuntimeException("Shader compilation failed!", e);
 		}
 
-		CommonUniforms.addCommonUniforms(builder, source.getParent().getPack().getIdMap(), directives, FrameUpdateNotifier.INSTANCE);
+		CommonUniforms.addCommonUniforms(builder, source.getParent().getPack().getIdMap(), directives, ((DeferredWorldRenderingPipeline) pipeline).getUpdateNotifier());
 		SamplerUniforms.addWorldSamplerUniforms(builder);
 
 		return new Pair<>(builder.build(), source.getDirectives());

--- a/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
@@ -133,7 +133,7 @@ public class SodiumTerrainPipeline {
 	}
 
 	public static Optional<SodiumTerrainPipeline> create() {
-		Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
+		Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension(), false);
 
 		return Iris.getCurrentPack().map(
 			pack -> new SodiumTerrainPipeline(Objects.requireNonNull(pack.getProgramSet(Iris.getCurrentDimension())))

--- a/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
@@ -121,6 +121,8 @@ public class SodiumTerrainPipeline {
 	}
 
 	public static Optional<SodiumTerrainPipeline> create() {
+		Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
+
 		return Iris.getCurrentPack().map(
 			pack -> new SodiumTerrainPipeline(Objects.requireNonNull(pack.getProgramSet(Iris.getCurrentDimension())))
 		);
@@ -153,7 +155,8 @@ public class SodiumTerrainPipeline {
 	public ProgramUniforms initUniforms(int programId) {
 		ProgramUniforms.Builder uniforms = ProgramUniforms.builder("<sodium shaders>", programId);
 
-		CommonUniforms.addCommonUniforms(uniforms, programSet.getPack().getIdMap(), programSet.getPackDirectives(), FrameUpdateNotifier.INSTANCE);
+		WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipeline();
+		CommonUniforms.addCommonUniforms(uniforms, programSet.getPack().getIdMap(), programSet.getPackDirectives(), ((DeferredWorldRenderingPipeline) pipeline).getUpdateNotifier());
 		SamplerUniforms.addWorldSamplerUniforms(uniforms);
 		SamplerUniforms.addDepthSamplerUniforms(uniforms);
 		BuiltinReplacementUniforms.addBuiltinReplacementUniforms(uniforms);

--- a/src/main/java/net/coderbot/iris/postprocess/CompositeRenderer.java
+++ b/src/main/java/net/coderbot/iris/postprocess/CompositeRenderer.java
@@ -39,12 +39,15 @@ public class CompositeRenderer {
 	private final ImmutableList<SwapPass> swapPasses;
 	private final GlFramebuffer baseline;
 	private final AbstractTexture noiseTexture;
+	private final FrameUpdateNotifier updateNotifier;
 
 	final CenterDepthSampler centerDepthSampler;
 	private boolean usesShadows = false;
 
-	public CompositeRenderer(ProgramSet pack, RenderTargets renderTargets, AbstractTexture noiseTexture) {
-		centerDepthSampler = new CenterDepthSampler(renderTargets, FrameUpdateNotifier.INSTANCE);
+	public CompositeRenderer(ProgramSet pack, RenderTargets renderTargets, AbstractTexture noiseTexture, FrameUpdateNotifier updateNotifier) {
+		this.updateNotifier = updateNotifier;
+
+		centerDepthSampler = new CenterDepthSampler(renderTargets, updateNotifier);
 
 		final PackRenderTargetDirectives renderTargetDirectives = pack.getPackDirectives().getRenderTargetDirectives();
 		final Map<Integer, PackRenderTargetDirectives.RenderTargetSettings> renderTargetSettings =
@@ -331,7 +334,7 @@ public class CompositeRenderer {
 			usesShadows = true;
 		}
 
-		CommonUniforms.addCommonUniforms(builder, source.getParent().getPack().getIdMap(), source.getParent().getPackDirectives(), FrameUpdateNotifier.INSTANCE);
+		CommonUniforms.addCommonUniforms(builder, source.getParent().getPack().getIdMap(), source.getParent().getPackDirectives(), updateNotifier);
 		SamplerUniforms.addCompositeSamplerUniforms(builder);
 		SamplerUniforms.addDepthSamplerUniforms(builder);
 

--- a/src/main/java/net/coderbot/iris/uniforms/FrameUpdateNotifier.java
+++ b/src/main/java/net/coderbot/iris/uniforms/FrameUpdateNotifier.java
@@ -4,12 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class FrameUpdateNotifier {
-	// TODO: Make this specific to the current Pipeline object.
-	public static final FrameUpdateNotifier INSTANCE = new FrameUpdateNotifier();
-
 	private final List<Runnable> listeners;
 
-	private FrameUpdateNotifier() {
+	public FrameUpdateNotifier() {
 		listeners = new ArrayList<>();
 	}
 


### PR DESCRIPTION
This is cherry-picked from starline and has been tested to work properly with sodium.
This fixes #283.