### PR TITLE
Prevent enabling shaders in the GUI when no packs are present

### DIFF
--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -1,7 +1,6 @@
 package net.coderbot.iris.gui.element;
 
 import com.google.common.collect.ImmutableList;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gui.GuiUtil;
 import net.minecraft.client.MinecraftClient;
@@ -140,7 +139,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 			int color = 0xFFFFFF;
 			String name = packName;
 
-			boolean shadersEnabled = list.getEnableShadersButton().enabled;
+			boolean shadersEnabled = list.getEnableShadersButton().shadersEnabled;
 
 			if (textRenderer.getWidth(new LiteralText(name).formatted(Formatting.BOLD)) > this.list.getRowWidth() - 3) {
 				name = textRenderer.trimToWidth(name, this.list.getRowWidth() - 8) + "...";
@@ -165,7 +164,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 
 		@Override
 		public boolean mouseClicked(double mouseX, double mouseY, int button) {
-			if (list.getEnableShadersButton().enabled && !this.isSelected() && button == 0) {
+			if (list.getEnableShadersButton().shadersEnabled && !this.isSelected() && button == 0) {
 				this.list.select(this.index);
 
 				return true;
@@ -189,32 +188,35 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 	}
 
 	public static class EnableShadersButtonEntry extends BaseEntry {
-		public boolean enabled;
-		private boolean canChange;
+		public boolean shadersEnabled;
+		private boolean buttonEnabled;
 
-		public EnableShadersButtonEntry(boolean enabled) {
-			this.enabled = enabled;
+		public EnableShadersButtonEntry(boolean shadersEnabled) {
+			this.shadersEnabled = shadersEnabled;
 		}
 
-		public void refresh(ShaderPackListWidget packs) {
-			this.canChange = packs.packCount > 0;
+		private void refresh(ShaderPackListWidget packs) {
+			this.buttonEnabled = packs.packCount > 0;
+			if (!buttonEnabled) {
+				shadersEnabled = false;
+			}
 		}
 
 		@Override
 		public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
 			GuiUtil.bindIrisWidgetsTexture();
 
-			GuiUtil.drawButton(matrices, x - 2, y - 3, entryWidth, 18, hovered, canChange);
+			GuiUtil.drawButton(matrices, x - 2, y - 3, entryWidth, 18, buttonEnabled && hovered, buttonEnabled);
 
-			Text label = this.enabled ? SHADERS_ENABLED_LABEL : SHADERS_DISABLED_LABEL;
+			Text label = this.shadersEnabled ? SHADERS_ENABLED_LABEL : SHADERS_DISABLED_LABEL;
 
-			drawCenteredText(matrices, MinecraftClient.getInstance().textRenderer, label, (x + entryWidth / 2) - 2, y + (entryHeight - 11) / 2, canChange ? 0xFFFFFF : 0xAEAEAE);
+			drawCenteredText(matrices, MinecraftClient.getInstance().textRenderer, label, (x + entryWidth / 2) - 2, y + (entryHeight - 11) / 2, buttonEnabled ? 0xFFFFFF : 0xAEAEAE);
 		}
 
 		@Override
 		public boolean mouseClicked(double mouseX, double mouseY, int button) {
-			if (canChange && button == 0) {
-				this.enabled = !this.enabled;
+			if (buttonEnabled && button == 0) {
+				this.shadersEnabled = !this.shadersEnabled;
 				GuiUtil.playButtonClickSound();
 
 				return true;

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -27,6 +27,8 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 	private static final Text SHADERS_DISABLED_LABEL = new TranslatableText("options.iris.shaders.disabled");
 	private static final Text SHADERS_ENABLED_LABEL = new TranslatableText("options.iris.shaders.enabled");
 
+	private int packCount = 0;
+
 	private final EnableShadersButtonEntry enableShadersButton = new EnableShadersButtonEntry(Iris.getIrisConfig().areShadersEnabled());
 
 	public ShaderPackListWidget(MinecraftClient client, int width, int height, int top, int bottom, int left, int right) {
@@ -78,6 +80,8 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 			Iris.logger.error("Error reading files while constructing selection UI");
 			Iris.logger.catching(e);
 		}
+
+		enableShadersButton.refresh(this);
 	}
 
 	public void addEntry(int index, String name) {
@@ -86,6 +90,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 		if (Iris.getIrisConfig().getShaderPackName().equals(name)) {
 			this.setSelected(entry);
 		}
+		packCount++;
 
 		this.addEntry(entry);
 	}
@@ -185,25 +190,30 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 
 	public static class EnableShadersButtonEntry extends BaseEntry {
 		public boolean enabled;
+		private boolean canChange;
 
 		public EnableShadersButtonEntry(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public void refresh(ShaderPackListWidget packs) {
+			this.canChange = packs.packCount > 0;
 		}
 
 		@Override
 		public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
 			GuiUtil.bindIrisWidgetsTexture();
 
-			GuiUtil.drawButton(matrices, x - 2, y - 3, entryWidth, 18, hovered, false);
+			GuiUtil.drawButton(matrices, x - 2, y - 3, entryWidth, 18, hovered, canChange);
 
 			Text label = this.enabled ? SHADERS_ENABLED_LABEL : SHADERS_DISABLED_LABEL;
 
-			drawCenteredText(matrices, MinecraftClient.getInstance().textRenderer, label, (x + entryWidth / 2) - 2, y + (entryHeight - 11) / 2, 0xFFFFFF);
+			drawCenteredText(matrices, MinecraftClient.getInstance().textRenderer, label, (x + entryWidth / 2) - 2, y + (entryHeight - 11) / 2, canChange ? 0xFFFFFF : 0xAEAEAE);
 		}
 
 		@Override
 		public boolean mouseClicked(double mouseX, double mouseY, int button) {
-			if (button == 0) {
+			if (canChange && button == 0) {
 				this.enabled = !this.enabled;
 				GuiUtil.playButtonClickSound();
 

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -10,13 +10,11 @@ import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
-import org.apache.commons.io.FileUtils;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -239,7 +237,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 		ShaderPackListWidget.ShaderPackEntry entry = (ShaderPackListWidget.ShaderPackEntry)base;
 		String name = entry.getPackName();
 		Iris.getIrisConfig().setShaderPackName(name);
-		Iris.getIrisConfig().setShadersEnabled(this.shaderPackList.getEnableShadersButton().enabled);
+		Iris.getIrisConfig().setShadersEnabled(this.shaderPackList.getEnableShadersButton().shadersEnabled);
 
 		try {
 			Iris.getIrisConfig().save();


### PR DESCRIPTION
You can't click the Enable/Disable Shaders button when there are no shader packs, and the button is forced to false during this state

(It also makes use of what was previously an unused button texture in Iris's assets, the disabled button texture)