### PR TITLE
Allow using fabulous when shaders are not enabled

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/fabulous/MixinDisableFabulousGraphics.java
+++ b/src/main/java/net/coderbot/iris/mixin/fabulous/MixinDisableFabulousGraphics.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.mixin.fabulous;
 
+import net.coderbot.iris.Iris;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -20,7 +21,7 @@ public class MixinDisableFabulousGraphics {
 	private void iris$disableFabulousGraphics(CallbackInfo ci) {
 		GameOptions options = MinecraftClient.getInstance().options;
 
-		if (options.graphicsMode == GraphicsMode.FABULOUS) {
+		if (options.graphicsMode == GraphicsMode.FABULOUS && Iris.getIrisConfig().areShadersEnabled()) {
 			options.graphicsMode = GraphicsMode.FANCY;
 		}
 	}

--- a/src/main/java/net/coderbot/iris/mixin/fabulous/MixinOption.java
+++ b/src/main/java/net/coderbot/iris/mixin/fabulous/MixinOption.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.mixin.fabulous;
 
+import com.mojang.blaze3d.platform.GlStateManager;
 import net.coderbot.iris.Iris;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,6 +17,9 @@ public class MixinOption {
 	@Redirect(method = "method_18554", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/GlStateManager;supportsGl30()Z"))
 	private static boolean iris$onAttemptedToSelectFabulousGraphics() {
 		// Returning false here will cause Minecraft to cycle between Fancy and Fast, disabling Fabulous graphics
-		return !Iris.getIrisConfig().areShadersEnabled();
+		if(!Iris.getIrisConfig().areShadersEnabled()) {
+			return GlStateManager.supportsGl30();
+		}
+		return false;
 	}
 }

--- a/src/main/java/net/coderbot/iris/mixin/fabulous/MixinOption.java
+++ b/src/main/java/net/coderbot/iris/mixin/fabulous/MixinOption.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.mixin.fabulous;
 
+import net.coderbot.iris.Iris;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -15,6 +16,6 @@ public class MixinOption {
 	@Redirect(method = "method_18554", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/GlStateManager;supportsGl30()Z"))
 	private static boolean iris$onAttemptedToSelectFabulousGraphics() {
 		// Returning false here will cause Minecraft to cycle between Fancy and Fast, disabling Fabulous graphics
-		return false;
+		return !Iris.getIrisConfig().areShadersEnabled();
 	}
 }


### PR DESCRIPTION
This implements the same patch used in starline, to allow using fabulous graphics when there are no shaders enabled.

Closes #216 
