### PR TITLE
Add missing translations to `de_de.json`

### DIFF
--- a/src/main/resources/assets/iris/lang/de_de.json
+++ b/src/main/resources/assets/iris/lang/de_de.json
@@ -1,7 +1,11 @@
 {
   "iris.shaders.reloaded": "Shader neu geladen!",
+  "iris.shaders.toggled": "Shader umgeschaltet auf: %s",
+  "iris.shaders.toggled.failure": "Shader umschalten fehlgeschlagen! Grund: %s",
   "iris.keybind.reload": "Shader neu laden",
   "iris.shaders.reloaded.failure": "Shader neu laden fehlgeschlagen! Grund: %s",
+  "iris.keybind.shaderPackSelection": "Shaderpack Auswahlbildschirm",
+  "iris.keybind.toggleShaders": "Shader umschalten",
 
   "options.iris.apply": "Anwenden",
   "options.iris.refresh": "Aktualisieren",


### PR DESCRIPTION
There were a few missing strings in the german translation file.