### PR TITLE
Trim Whitespace on #version Directives

### DIFF
--- a/src/main/java/net/coderbot/iris/shaderpack/ShaderPreprocessor.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/ShaderPreprocessor.java
@@ -39,13 +39,17 @@ public class ShaderPreprocessor {
 				continue;
 			}
 
-			lines.add(line);
+			if (trimmedLine.startsWith("#version")) {
+				// macOS cannot handle whitespace before the #version directive.
+				lines.add(trimmedLine);
 
-			if (line.startsWith("#version")) {
 				// That was the first line. Add our preprocessor lines
 				lines.add("#define MC_RENDER_QUALITY 1.0");
 				lines.add("#define MC_SHADOW_QUALITY 1.0");
+				continue;
 			}
+
+			lines.add(line);
 		}
 
 		return lines;


### PR DESCRIPTION
This addresses #451, fixing complementary in non-overworld dimensions on macOS.

As an alternative, I considered simply outputting only trimmed lines, but that made it harder to read the output of the patched shaders' source, so I chose this solution since it has more limited effects.

It also fixes Iris not recognizing `#version` directives with leading whitespace as the spot to insert its `MC_RENDER_QUALITY`/`MC_SHADOW_QUALITY` defines, though I'm not sure what effect this had, if any.