### PR TITLE
Update for Minecraft 1.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// Critical, needed for loading our custom language files
 	includeFabricApiModule "fabric-resource-loader-v0"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// Critical, needed for loading our custom language files
 	includeFabricApiModule "fabric-resource-loader-v0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ mod_version=1.1.0
 maven_group=net.coderbot.iris_mc1_17_1
 archives_base_name=iris-mc1.17.1
 
-fabric_version=0.36.1+1.17
+fabric_version=0.35.2+1.17

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.17
-yarn_mappings=1.17+build.13
+minecraft_version=1.17.1
+yarn_mappings=1.17.1+build.10
 loader_version=0.11.3
 # Mod Properties
 mod_version=1.1.0
-maven_group=net.coderbot.iris_mc1_17
-archives_base_name=iris-mc1.17
+maven_group=net.coderbot.iris_mc1_17_1
+archives_base_name=iris-mc1.17.1
 
-fabric_version=0.35.2+1.17
+fabric_version=0.36.1+1.17

--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -134,7 +134,7 @@ public class Iris implements ClientModInitializer {
 					currentPackName = "(off) [fallback, check your logs for errors]";
 				}
 			} else if (shaderpackScreenKeybind.wasPressed()) {
-				minecraftClient.openScreen(new ShaderPackScreen(null));
+				minecraftClient.setScreen(new ShaderPackScreen(null));
 			}
 		});
 

--- a/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
+++ b/src/main/java/net/coderbot/iris/gui/element/ShaderPackListWidget.java
@@ -134,7 +134,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 
 		// Appears to be some accessibility thing
 		@Override
-		public Text method_37006() {
+		public Text getNarration() {
 			return new TranslatableText("narrator.select", packName);
 		}
 
@@ -188,7 +188,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 
 		// Appears to be some accessibility thing
 		@Override
-		public Text method_37006() {
+		public Text getNarration() {
 			return label;
 		}
 
@@ -218,7 +218,7 @@ public class ShaderPackListWidget extends IrisScreenEntryListWidget<ShaderPackLi
 
 		// Appears to be some accessibility thing
 		@Override
-		public Text method_37006() {
+		public Text getNarration() {
 			return new TranslatableText("narration.button", this.enabled ? SHADERS_ENABLED_LABEL : SHADERS_DISABLED_LABEL);
 		}
 

--- a/src/main/java/net/coderbot/iris/gui/option/ShaderPackSelectionButtonOption.java
+++ b/src/main/java/net/coderbot/iris/gui/option/ShaderPackSelectionButtonOption.java
@@ -24,7 +24,7 @@ public class ShaderPackSelectionButtonOption extends Option {
 		return new ButtonWidget(
 				x, y, width, 20,
 				new TranslatableText("options.iris.shaderPackSelection"),
-				button -> client.openScreen(new ShaderPackScreen(parent))
+				button -> client.setScreen(new ShaderPackScreen(parent))
 		);
 	}
 }

--- a/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
+++ b/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java
@@ -221,7 +221,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 			applyChanges();
 		}
 
-		this.client.openScreen(parent);
+		this.client.setScreen(parent);
 	}
 
 	private void dropChangesAndClose() {


### PR DESCRIPTION
Updates Iris to build for and run on 1.17.1, tested with iris-sodium, no issues whatsoever.