### PR TITLE
Translate mojang's overlay colors to replace entityColor

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinShader.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinShader.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Shader.class)
 public class MixinShader {
-	@Redirect(method = {"upload()V", "loadReferences()V"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gl/GlUniform;getUniformLocation(ILjava/lang/CharSequence;)I"))
+	@Redirect(method = {"bind()V", "loadReferences()V"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gl/GlUniform;getUniformLocation(ILjava/lang/CharSequence;)I"))
 	private int iris$redirectGetUniformLocation(int programId, CharSequence name) {
 		int location = GlUniform.getUniformLocation(programId, name);
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/ExtendedShader.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/ExtendedShader.java
@@ -80,6 +80,8 @@ public class ExtendedShader extends Shader implements SamplerHolder {
 
 			// "tex" is also a valid sampler name.
 			super.addSampler("tex", sampler);
+		} else if (name.equals("Sampler1")) {
+			name = "overlay";
 		} else if (name.equals("Sampler2")) {
 			name = "lightmap";
 		} else if (name.startsWith("Sampler")) {
@@ -90,8 +92,6 @@ public class ExtendedShader extends Shader implements SamplerHolder {
 			Iris.logger.warn("Iris: didn't recognize the sampler name " + name + " in addSampler, please use addIrisSampler for custom Iris-specific samplers instead.");
 			return;
 		}
-
-		// TODO: Expose Sampler1 (the mob overlay flash)
 
 		super.addSampler(name, sampler);
 	}

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/NewShaderTests.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/NewShaderTests.java
@@ -50,6 +50,7 @@ public class NewShaderTests {
 				"        \"Position\",\n" +
 				"        \"Color\",\n" +
 				"        \"UV0\",\n" +
+				"        \"UV1\",\n" +
 				"        \"UV2\",\n" +
 				"        \"Normal\"\n" +
 				"    ],\n" +
@@ -58,6 +59,7 @@ public class NewShaderTests {
 				"        { \"name\": \"texture\" },\n" +
 				"        { \"name\": \"tex\" },\n" +
 				"        { \"name\": \"lightmap\" },\n" +
+				"        { \"name\": \"overlay\" },\n" +
 				"        { \"name\": \"normals\" },\n" +
 				"        { \"name\": \"specular\" },\n" +
 				"        { \"name\": \"shadow\" },\n" +

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
@@ -121,12 +121,13 @@ public class TriforcePatcher {
 		if(inputs.hasOverlay()) {
 			transformations.replaceExact("entityColor", "overlayColor");
 			transformations.replaceExact("overlayColor.a", "1 - overlayColor.a");
+			//This doesn't work seemingly, although logically it's more correct
+			//transformations.replaceRegex("/([a-zA-Z0-9]+).rgb\\s?,\\s?overlayColor.rgb,/g", "overlayColor.rgb, $1, ");
 			if(type == ShaderType.VERTEX) {
 				transformations.injectLine(Transformations.InjectionPoint.BEFORE_CODE, "uniform sampler2D overlay;");
 				transformations.injectLine(Transformations.InjectionPoint.BEFORE_CODE, "in ivec2 UV1;");
+				transformations.replaceExact("uniform vec4 overlayColor;", "");
 				transformations.injectLine(Transformations.InjectionPoint.BEFORE_CODE, "out vec4 overlayColor;");
-				//This doesn't work seemingly, although logically it's more correct
-				//transformations.replaceRegex("/([a-zA-Z0-9]+).rgb\\s?,\\s?overlayColor.rgb,/g", "overlayColor.rgb, $1, ");
 				if (transformations.contains("irisMain")) {
 					throw new IllegalStateException("Shader already contains \"irisMain\"???");
 				}


### PR DESCRIPTION
This adds code to the vertex shader that gets the appropriate vec4 from UV1 and the sampler2d "overlay" (previously Sampler1), and passes it to the fragment shader. (This also replaces all instances of "entityColor.a" with "1 - entityColor.a", as for some unknown reason not doing this causes the entity to become a solid color.)