### PR TITLE
Capture current atlas for use with the atlasSize uniform

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinTextureManager.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinTextureManager.java
@@ -1,0 +1,21 @@
+package net.coderbot.iris.mixin;
+
+import net.coderbot.iris.uniforms.CapturedRenderingState;
+import net.minecraft.client.texture.AbstractTexture;
+import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.client.texture.TextureManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(TextureManager.class)
+public class MixinTextureManager {
+	@Redirect(method = "bindTextureInner", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/texture/AbstractTexture;bindTexture()V"))
+	private void setAtlas(AbstractTexture abstractTexture) {
+		if(abstractTexture instanceof SpriteAtlasTexture) {
+			CapturedRenderingState.INSTANCE.setCurrentAtlas((SpriteAtlasTexture) abstractTexture);
+		}
+		abstractTexture.bindTexture();
+	}
+}

--- a/src/main/java/net/coderbot/iris/uniforms/CapturedRenderingState.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CapturedRenderingState.java
@@ -2,6 +2,7 @@ package net.coderbot.iris.uniforms;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Matrix4f;
 import net.minecraft.util.math.Vec3d;
@@ -15,6 +16,7 @@ public class CapturedRenderingState {
 	private float tickDelta;
 	private BlockEntity currentRenderedBlockEntity;
 	private Entity currentRenderedEntity;
+	private SpriteAtlasTexture currentAtlas;
 
 	private CapturedRenderingState() {
 	}
@@ -69,5 +71,13 @@ public class CapturedRenderingState {
 
 	public Entity getCurrentRenderedEntity() {
 		return currentRenderedEntity;
+	}
+
+	public void setCurrentAtlas(SpriteAtlasTexture atlas) {
+		this.currentAtlas = atlas;
+	}
+
+	public SpriteAtlasTexture getCurrentAtlas() {
+		return currentAtlas;
 	}
 }

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -3,7 +3,6 @@ package net.coderbot.iris.uniforms;
 import java.util.Objects;
 import java.util.function.IntSupplier;
 
-import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.uniform.LocationalUniformHolder;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.shaderpack.IdMap;
@@ -15,7 +14,6 @@ import net.coderbot.iris.uniforms.transforms.SmoothedVec2f;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -3,6 +3,7 @@ package net.coderbot.iris.uniforms;
 import java.util.Objects;
 import java.util.function.IntSupplier;
 
+import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.uniform.LocationalUniformHolder;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.shaderpack.IdMap;
@@ -75,8 +76,7 @@ public final class CommonUniforms {
 	}
 
 	private static Vec2f getAtlasSize() {
-		//TODO: is the block atlas used for this uniform all the time???
-		return ((SpriteAtlasTextureInterface) MinecraftClient.getInstance().getBakedModelManager().method_24153(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)).getAtlasSize();
+		return ((SpriteAtlasTextureInterface) CapturedRenderingState.INSTANCE.getCurrentAtlas()).getAtlasSize();
 	}
 
 	private static Vec3d getSkyColor() {

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -14,6 +14,7 @@
     "MixinModelViewBobbing",
     "MixinParticleManager",
     "MixinSpriteAtlasTexture",
+    "MixinTextureManager",
     "MixinTranslationStorage",
     "MixinTweakFarPlane",
     "MixinWorldRenderer",


### PR DESCRIPTION
I haven't been able to confirm this is completely correct, but it seems to work fine testing in Complementary.
In 1.17 we will likely need to mixin into setShaderTexture in RenderSystem instead.