### PR TITLE
Fix shaders using the wrong time when in a dimension with fixed time

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/DimensionTypeAccessor.java
+++ b/src/main/java/net/coderbot/iris/mixin/DimensionTypeAccessor.java
@@ -1,0 +1,15 @@
+package net.coderbot.iris.mixin;
+
+import net.minecraft.world.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.OptionalLong;
+
+@Mixin(DimensionType.class)
+public interface DimensionTypeAccessor {
+
+	@Accessor
+	OptionalLong getFixedTime();
+
+}

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -2,9 +2,11 @@ package net.coderbot.iris.uniforms;
 
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
+import net.coderbot.iris.mixin.DimensionTypeAccessor;
 import net.coderbot.iris.uniforms.transforms.SmoothedFloat;
 import net.coderbot.iris.vendored.joml.Math;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.world.World;
 
 // These expressions are copied directly from BSL
 //
@@ -25,8 +27,10 @@ public class HardcodedCustomUniforms {
 	}
 
 	private static int getWorldDayTime() {
-		long timeOfDay = MinecraftClient.getInstance().world.getTimeOfDay();
-		long dayTime = timeOfDay % 24000L;
+		World world     = MinecraftClient.getInstance().world;
+		long  timeOfDay = world.getTimeOfDay();
+		long dayTime = ((DimensionTypeAccessor) world.getDimension()).getFixedTime()
+																	 .orElse(timeOfDay % 24000L);
 
 		return (int) dayTime;
 	}

--- a/src/main/java/net/coderbot/iris/uniforms/WorldTimeUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/WorldTimeUniforms.java
@@ -5,7 +5,7 @@ import static net.coderbot.iris.gl.uniform.UniformUpdateFrequency.PER_TICK;
 import java.util.Objects;
 
 import net.coderbot.iris.gl.uniform.UniformHolder;
-
+import net.coderbot.iris.mixin.DimensionTypeAccessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 
@@ -27,7 +27,9 @@ public final class WorldTimeUniforms {
 
 	private static int getWorldDayTime() {
 		long timeOfDay = getWorld().getTimeOfDay();
-		long dayTime = timeOfDay % 24000L;
+
+		long dayTime = ((DimensionTypeAccessor) getWorld().getDimension()).getFixedTime()
+																		  .orElse(timeOfDay % 24000L);
 
 		return (int) dayTime;
 	}

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -39,7 +39,8 @@
     "texunits.MixinVertexFormats",
     "statelisteners.CapabilityTrackerAccessor",
     "statelisteners.GlStateManagerAccessor",
-    "statelisteners.MixinGlStateManager"
+    "statelisteners.MixinGlStateManager",
+    "DimensionTypeAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixes #547 by taking into account the fixed time of the dimension. 