### PR TITLE
Physics Mod compatibility, alongside mod loading checks.

### DIFF
--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -43,9 +43,9 @@ public class Iris implements ClientModInitializer {
 
 	private static ShaderPack currentPack;
 	private static String currentPackName;
-	public static boolean internal;
-	public static boolean sodiumInstalled;
-	public static boolean physicsModInstalled;
+	private static boolean internal;
+	private static boolean sodiumInstalled;
+	private static boolean physicsModInstalled;
 
 	private static PipelineManager pipelineManager;
 	private static IrisConfig irisConfig;
@@ -457,5 +457,13 @@ public class Iris implements ClientModInitializer {
 		}
 
 		return color + version;
+	}
+
+	public static boolean isSodiumInstalled() {
+		return sodiumInstalled;
+	}
+
+	public static boolean isPhysicsModInstalled() {
+		return physicsModInstalled;
 	}
 }

--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -43,7 +43,9 @@ public class Iris implements ClientModInitializer {
 
 	private static ShaderPack currentPack;
 	private static String currentPackName;
-	private static boolean internal;
+	public static boolean internal;
+	public static boolean sodiumInstalled;
+	public static boolean physicsModInstalled;
 
 	private static PipelineManager pipelineManager;
 	private static IrisConfig irisConfig;
@@ -58,6 +60,7 @@ public class Iris implements ClientModInitializer {
 	public void onInitializeClient() {
 		FabricLoader.getInstance().getModContainer("sodium").ifPresent(
 				modContainer -> {
+					sodiumInstalled = true;
 					String versionString = modContainer.getMetadata().getVersion().getFriendlyString();
 
 					// A lot of people are reporting visual bugs with Iris + Sodium. This makes it so that if we don't have
@@ -73,6 +76,7 @@ public class Iris implements ClientModInitializer {
 					IRIS_VERSION = modContainer.getMetadata().getVersion().getFriendlyString();
 				}
 		);
+		physicsModInstalled = FabricLoader.getInstance().isModLoaded("physicsmod");
 		try {
 			Files.createDirectories(SHADERPACKS_DIRECTORY);
 		} catch (IOException e) {

--- a/src/main/java/net/coderbot/iris/mixin/MixinDebugHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinDebugHud.java
@@ -50,7 +50,7 @@ public abstract class MixinDebugHud {
 
 		messages.add(3, "Direct Buffers: +" + humanReadableByteCountBin(directPool.getMemoryUsed()));
 
-		if (!FabricLoader.getInstance().isModLoaded("sodium")) {
+		if (!Iris.sodiumInstalled) {
 			messages.add(3, "Native Memory: +" + humanReadableByteCountBin(getNativeMemoryUsage()));
 		}
     }
@@ -59,7 +59,7 @@ public abstract class MixinDebugHud {
 	private void appendShadowDebugText(CallbackInfoReturnable<List<String>> cir) {
 		List<String> messages = cir.getReturnValue();
 
-		if (!FabricLoader.getInstance().isModLoaded("sodium") && Iris.getCurrentPack().isPresent()) {
+		if (!Iris.sodiumInstalled && Iris.getCurrentPack().isPresent()) {
 			messages.add(1, Formatting.YELLOW + "[Iris] Sodium isn't installed; you will have poor performance.");
 			messages.add(2, Formatting.YELLOW + "[Iris] Install the compatible Sodium fork if you want to run benchmarks or get higher FPS!");
 		}

--- a/src/main/java/net/coderbot/iris/mixin/MixinDebugHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinDebugHud.java
@@ -50,7 +50,7 @@ public abstract class MixinDebugHud {
 
 		messages.add(3, "Direct Buffers: +" + humanReadableByteCountBin(directPool.getMemoryUsed()));
 
-		if (!Iris.sodiumInstalled) {
+		if (!Iris.isSodiumInstalled()) {
 			messages.add(3, "Native Memory: +" + humanReadableByteCountBin(getNativeMemoryUsage()));
 		}
     }
@@ -59,7 +59,7 @@ public abstract class MixinDebugHud {
 	private void appendShadowDebugText(CallbackInfoReturnable<List<String>> cir) {
 		List<String> messages = cir.getReturnValue();
 
-		if (!Iris.sodiumInstalled && Iris.getCurrentPack().isPresent()) {
+		if (!Iris.isSodiumInstalled() && Iris.getCurrentPack().isPresent()) {
 			messages.add(1, Formatting.YELLOW + "[Iris] Sodium isn't installed; you will have poor performance.");
 			messages.add(2, Formatting.YELLOW + "[Iris] Install the compatible Sodium fork if you want to run benchmarks or get higher FPS!");
 		}

--- a/src/main/java/net/coderbot/iris/mixin/MixinLivingEntityRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinLivingEntityRenderer.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.mixin;
 
+import net.coderbot.iris.Iris;
 import net.coderbot.iris.layer.EntityColorRenderPhase;
 import net.coderbot.iris.layer.EntityColorWrappedRenderLayer;
 import net.minecraft.client.render.VertexConsumerProvider;
@@ -18,7 +19,12 @@ public abstract class MixinLivingEntityRenderer {
 
 	@ModifyVariable(method = "render", at = @At("HEAD"))
 	private VertexConsumerProvider iris$wrapProvider(VertexConsumerProvider provider, LivingEntity entity, float yaw, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
-		boolean hurt = entity.hurtTime > 0 || entity.deathTime > 0;
+		boolean hurt;
+		if(Iris.physicsModInstalled) {
+			hurt = entity.hurtTime > 0 && !entity.isDead();
+		} else {
+			hurt = entity.hurtTime > 0 || entity.deathTime > 0;
+		}
 		float whiteFlash = getAnimationCounter(entity, tickDelta);
 
 		if (hurt || whiteFlash > 0.0) {

--- a/src/main/java/net/coderbot/iris/mixin/MixinLivingEntityRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinLivingEntityRenderer.java
@@ -20,7 +20,7 @@ public abstract class MixinLivingEntityRenderer {
 	@ModifyVariable(method = "render", at = @At("HEAD"))
 	private VertexConsumerProvider iris$wrapProvider(VertexConsumerProvider provider, LivingEntity entity, float yaw, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
 		boolean hurt;
-		if(Iris.physicsModInstalled) {
+		if(Iris.isPhysicsModInstalled()) {
 			hurt = entity.hurtTime > 0 && !entity.isDead();
 		} else {
 			hurt = entity.hurtTime > 0 || entity.deathTime > 0;

--- a/src/main/java/net/coderbot/iris/mixin/gui/MixinInGameHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/gui/MixinInGameHud.java
@@ -35,7 +35,7 @@ public class MixinInGameHud {
 	// TODO: Move this to a more appropriate mixin
 	@Inject(method = "render", at = @At("RETURN"))
 	public void iris$displayBigSodiumWarning(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
-		if (FabricLoader.getInstance().isModLoaded("sodium")
+		if (Iris.sodiumInstalled
 				|| MinecraftClient.getInstance().options.debugEnabled
 				|| !Iris.getCurrentPack().isPresent()) {
 			return;

--- a/src/main/java/net/coderbot/iris/mixin/gui/MixinInGameHud.java
+++ b/src/main/java/net/coderbot/iris/mixin/gui/MixinInGameHud.java
@@ -35,7 +35,7 @@ public class MixinInGameHud {
 	// TODO: Move this to a more appropriate mixin
 	@Inject(method = "render", at = @At("RETURN"))
 	public void iris$displayBigSodiumWarning(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
-		if (Iris.sodiumInstalled
+		if (Iris.isSodiumInstalled()
 				|| MinecraftClient.getInstance().options.debugEnabled
 				|| !Iris.getCurrentPack().isPresent()) {
 			return;


### PR DESCRIPTION
This changes the behavior of Iris to only check for Sodium/PhysicsMod once while the game loads and store it in a static variable, and not to check it during gameplay. This also changes the LivingEntityRenderer mixin to not activate a red tint when an entity is about to die if Physics Mod is installed, as not doing this causes unintended side effects.