### PR TITLE
Deduplicate Sodium version references

### DIFF
--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -39,6 +39,8 @@ import net.fabricmc.loader.api.FabricLoader;
 public class Iris implements ClientModInitializer {
 	public static final String MODID = "iris";
 	public static final Logger logger = LogManager.getLogger(MODID);
+	// The recommended version of Sodium for use with Iris
+	private static final String SODIUM_VERSION = "0.3.0-IRIS2";
 
 	public static final Path SHADERPACKS_DIRECTORY = FabricLoader.getInstance().getGameDir().resolve("shaderpacks");
 
@@ -63,8 +65,8 @@ public class Iris implements ClientModInitializer {
 
 				// A lot of people are reporting visual bugs with Iris + Sodium. This makes it so that if we don't have
 				// the right fork of Sodium, it will just crash.
-				if (!versionString.startsWith("0.3.0+IRIS2")) {
-					throw new IllegalStateException("You do not have a compatible version of Sodium installed! You have " + versionString + " but 0.3.0+IRIS1 is expected");
+				if (!versionString.startsWith(SODIUM_VERSION)) {
+					throw new IllegalStateException("You do not have a compatible version of Sodium installed! You have " + versionString + " but" + SODIUM_VERSION + "is expected");
 				}
 			}
 		);


### PR DESCRIPTION
The required Sodium version was changed to 0.3.0-IRIS2 but the error string incorrectly still mentioned 0.3.0-IRIS1, causing quite a bit of lost time figuring out why my client wasn't working.