### PR TITLE
Fix overlay texture unit, fixes hit flash without shaders

### DIFF
--- a/src/main/java/net/coderbot/iris/texunits/TextureUnit.java
+++ b/src/main/java/net/coderbot/iris/texunits/TextureUnit.java
@@ -5,8 +5,7 @@ import org.lwjgl.opengl.GL15;
 public enum TextureUnit {
 	TERRAIN(0),
 	LIGHTMAP(1),
-	// TODO: Relocate this to a different texture unit, this is used by depthtex0...
-	OVERLAY(6);
+	OVERLAY(2);
 
 	private final int samplerId;
 	private final int unitId;


### PR DESCRIPTION
I couldn't find any reason this was set to 6, am I missing something?