### PR TITLE
Add code for registering Iris-exclusive defines and uniforms

### DIFF
--- a/src/main/java/net/coderbot/iris/gl/program/ProgramBuilder.java
+++ b/src/main/java/net/coderbot/iris/gl/program/ProgramBuilder.java
@@ -24,6 +24,7 @@ public class ProgramBuilder extends ProgramUniforms.Builder implements SamplerHo
 		.define("MC_GLSL_VERSION", StandardMacros.getGlVersion(GL20C.GL_SHADING_LANGUAGE_VERSION))
 		.define(StandardMacros.getRenderer())
 		.define(StandardMacros.getVendor())
+		.defineAll(StandardMacros.getIrisDefines())
 		.defineAll(StandardMacros.getGlExtensions())
 		.build();
 

--- a/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
+++ b/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
@@ -1,6 +1,10 @@
 package net.coderbot.iris.gl.shader;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
+++ b/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
@@ -1,9 +1,6 @@
 package net.coderbot.iris.gl.shader;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -148,6 +145,19 @@ public class StandardMacros {
 		// see https://github.com/sp614x/optifine/blob/master/OptiFineDoc/doc/shaders.txt#L738
 
 		return Arrays.stream(extensions).map(s -> "MC_" + s).collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the list of Iris-exclusive uniforms supported in the current version of Iris.
+	 *
+	 * @return List of definitions corresponding to the uniform names prefixed with "MC_"
+	 */
+	public static List<String> getIrisDefines() {
+		List<String> defines = new ArrayList<>();
+		// All Iris-exclusive uniforms should have a corresponding definition here. Example:
+		// defines.add("MC_UNIFORM_DRAGON_DEATH_PROGRESS");
+
+		return defines;
 	}
 
 	/**

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -50,6 +50,7 @@ public final class CommonUniforms {
 		SystemTimeUniforms.addSystemTimeUniforms(uniforms);
 		new CelestialUniforms(directives.getSunPathRotation()).addCelestialUniforms(uniforms);
 		IdMapUniforms.addIdMapUniforms(uniforms, idMap);
+		IrisExclusiveUniforms.addIrisExclusiveUniforms(uniforms);
 		MatrixUniforms.addMatrixUniforms(uniforms, directives);
 		HardcodedCustomUniforms.addHardcodedCustomUniforms(uniforms, updateNotifier);
 		FogUniforms.addFogUniforms(uniforms);

--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -1,0 +1,11 @@
+package net.coderbot.iris.uniforms;
+
+import net.coderbot.iris.gl.uniform.UniformHolder;
+
+public class IrisExclusiveUniforms {
+
+	public static void addIrisExclusiveUniforms(UniformHolder uniforms) {
+		//All Iris-exclusive uniforms (uniforms which do not exist in either OptiFine or ShadersMod) should be registered here.
+	}
+
+}


### PR DESCRIPTION
This is the same as #771, however without the dragon uniform. (There are some issues with the dragon uniform yet to be sorted out, and I don't want to keep this stalled.)