### PR TITLE
Add isEyeInCave hardcoded uniform and uniforms for Complementary's biome check

### DIFF
--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -141,7 +141,7 @@ public final class CommonUniforms {
 		return client.level.getRainLevel(CapturedRenderingState.INSTANCE.getTickDelta());
 	}
 
-	private static Vec2 getEyeBrightness() {
+	static Vec2 getEyeBrightness() {
 		if (client.cameraEntity == null || client.level == null) {
 			return Vec2.ZERO;
 		}

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -182,7 +182,7 @@ public final class CommonUniforms {
 		return 0.0F;
 	}
 
-	private static int isEyeInWater() {
+	static int isEyeInWater() {
 		// Note: With certain utility / cheat mods, this method will return air even when the player is submerged when
 		// the "No Overlay" feature is enabled.
 		//

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -20,6 +20,7 @@ public class HardcodedCustomUniforms {
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "shadowFade", HardcodedCustomUniforms::getShadowFade);
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "rainStrengthS", rainStrengthS(updateNotifier));
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "blindFactor", HardcodedCustomUniforms::getBlindFactor);
+		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "caveFactor", caveFactor(updateNotifier));
 	}
 
 	private static float getTimeAngle() {
@@ -48,6 +49,18 @@ public class HardcodedCustomUniforms {
 
 	private static SmoothedFloat rainStrengthS(FrameUpdateNotifier updateNotifier) {
 		return new SmoothedFloat(15, CommonUniforms::getRainStrength, updateNotifier);
+	}
+
+	private static SmoothedFloat caveFactor(FrameUpdateNotifier updateNotifier) {
+		return new SmoothedFloat(12, HardcodedCustomUniforms::getCaveFactor, updateNotifier);
+	}
+
+	private static float getCaveFactor() {
+		if (Minecraft.getInstance().player.getEyeY() < 50.0) {
+			return CommonUniforms.getEyeBrightness().y / 240F;
+		} else {
+			return 1.0F;
+		}
 	}
 
 	private static float getBlindFactor() {

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -24,7 +24,7 @@ public class HardcodedCustomUniforms {
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "rainStrengthS", rainStrengthS(updateNotifier));
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "blindFactor", HardcodedCustomUniforms::getBlindFactor);
 		// The following uniforms are Complementary specific.
-		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "caveFactor", caveFactor(updateNotifier));
+		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isEyeInCave", isEyeInCave(updateNotifier));
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isDry", precipitationComparison(updateNotifier, 0));
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isRainy", precipitationComparison(updateNotifier, 1));
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isSnowy", precipitationComparison(updateNotifier, 2));
@@ -58,11 +58,11 @@ public class HardcodedCustomUniforms {
 		return new SmoothedFloat(15, CommonUniforms::getRainStrength, updateNotifier);
 	}
 
-	private static SmoothedFloat caveFactor(FrameUpdateNotifier updateNotifier) {
-		return new SmoothedFloat(12, HardcodedCustomUniforms::getCaveFactor, updateNotifier);
+	private static SmoothedFloat isEyeInCave(FrameUpdateNotifier updateNotifier) {
+		return new SmoothedFloat(12, HardcodedCustomUniforms::getCaveStatus, updateNotifier);
 	}
 
-	private static float getCaveFactor() {
+	private static float getCaveStatus() {
 		if (client.player.getEyeY() < 50.0) {
 			return 1.0F - (CommonUniforms.getEyeBrightness().y / 240F);
 		} else {

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -59,7 +59,7 @@ public class HardcodedCustomUniforms {
 	}
 
 	private static SmoothedFloat isEyeInCave(FrameUpdateNotifier updateNotifier) {
-		return new SmoothedFloat(12, HardcodedCustomUniforms::getCaveStatus, updateNotifier);
+		return new SmoothedFloat(6, HardcodedCustomUniforms::getCaveStatus, updateNotifier);
 	}
 
 	private static float getCaveStatus() {

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -64,9 +64,9 @@ public class HardcodedCustomUniforms {
 
 	private static float getCaveFactor() {
 		if (client.player.getEyeY() < 50.0) {
-			return CommonUniforms.getEyeBrightness().y / 240F;
+			return 1.0F - (CommonUniforms.getEyeBrightness().y / 240F);
 		} else {
-			return 1.0F;
+			return 0.0F;
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -25,9 +25,9 @@ public class HardcodedCustomUniforms {
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "blindFactor", HardcodedCustomUniforms::getBlindFactor);
 		// The following uniforms are Complementary specific.
 		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isEyeInCave", isEyeInCave(updateNotifier));
-		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isDry", precipitationComparison(updateNotifier, 0));
-		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isRainy", precipitationComparison(updateNotifier, 1));
-		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isSnowy", precipitationComparison(updateNotifier, 2));
+		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isDry", new SmoothedFloat(20, () -> getRawPrecipitation() == 0 ? 1 : 0, updateNotifier));
+		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isRainy", new SmoothedFloat(20, () -> getRawPrecipitation() == 1 ? 1 : 0, updateNotifier));
+		holder.uniform1f(UniformUpdateFrequency.PER_FRAME, "isSnowy", new SmoothedFloat(20, () -> getRawPrecipitation() == 2 ? 1 : 0, updateNotifier));
 	}
 
 	private static float getTimeAngle() {
@@ -68,16 +68,6 @@ public class HardcodedCustomUniforms {
 		} else {
 			return 0.0F;
 		}
-	}
-
-	private static SmoothedFloat precipitationComparison(FrameUpdateNotifier updateNotifier, float expectedPrecipitation) {
-		float comparison;
-		if (getRawPrecipitation() == expectedPrecipitation) {
-			comparison = 1;
-		} else {
-			comparison = 0;
-		}
-		return new SmoothedFloat(20, () -> comparison, updateNotifier);
 	}
 
 	private static float getRawPrecipitation() {

--- a/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/HardcodedCustomUniforms.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.uniforms;
 
+import net.coderbot.iris.gl.uniform.FloatSupplier;
 import net.coderbot.iris.gl.uniform.UniformHolder;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.mixin.DimensionTypeAccessor;
@@ -58,8 +59,12 @@ public class HardcodedCustomUniforms {
 		return new SmoothedFloat(15, CommonUniforms::getRainStrength, updateNotifier);
 	}
 
-	private static SmoothedFloat isEyeInCave(FrameUpdateNotifier updateNotifier) {
-		return new SmoothedFloat(6, HardcodedCustomUniforms::getCaveStatus, updateNotifier);
+	private static FloatSupplier isEyeInCave(FrameUpdateNotifier updateNotifier) {
+		if (CommonUniforms.isEyeInWater() == 0) {
+			return new SmoothedFloat(6, HardcodedCustomUniforms::getCaveStatus, updateNotifier);
+		} else {
+			return () -> 0.0F;
+		}
 	}
 
 	private static float getCaveStatus() {

--- a/src/main/java/net/coderbot/iris/uniforms/transforms/SmoothedFloat.java
+++ b/src/main/java/net/coderbot/iris/uniforms/transforms/SmoothedFloat.java
@@ -15,28 +15,28 @@ public class SmoothedFloat implements FloatSupplier {
 	/**
 	 * Natural logarithm of 2, ie. {@code ln(2)}
 	 */
-	private static final double LN_OF_2 = Math.log(2.0);
+	protected static final double LN_OF_2 = Math.log(2.0);
 
 	/**
 	 * The decay constant, k (as used in e^(-kt))
 	 */
-	private final float decayConstant;
+	protected final float decayConstant;
 
 	/**
 	 * The input sequence of unsmoothed values
 	 */
-	private final FloatSupplier unsmoothed;
+	protected final FloatSupplier unsmoothed;
 
 	/**
 	 * An accumulator for smoothed values.
 	 */
-	private float accumulator;
+	protected float accumulator;
 
 	/**
 	 * Tracks whether an initial value has already been generated, because otherwise there will be nothing to smooth
 	 * with.
 	 */
-	private boolean hasInitialValue;
+	protected boolean hasInitialValue;
 
 	/**
 	 * Creates a new SmoothedFloat with a given half life.
@@ -66,7 +66,7 @@ public class SmoothedFloat implements FloatSupplier {
 	/**
 	 * Takes one value from the unsmoothed value sequence, and smooths it into our accumulator
 	 */
-	private void update() {
+	protected void update() {
 		if (!hasInitialValue) {
 			// There is no smoothing on the first value.
 			// This is not an optimal approach to choosing the initial value:
@@ -114,7 +114,7 @@ public class SmoothedFloat implements FloatSupplier {
 	 * @param k the decay constant, derived from the half life
 	 * @param t the time that has passed since the decay started
 	 */
-	private static float exponentialDecayFactor(float k, float t) {
+	protected static float exponentialDecayFactor(float k, float t) {
 		// https://en.wikipedia.org/wiki/Exponential_decay
 		// e^(-kt)
 		return (float) Math.exp(-k * t);
@@ -127,7 +127,7 @@ public class SmoothedFloat implements FloatSupplier {
 	 * @param v1 the ending value (t = 1)
 	 * @param t  the time/progress value - should be in the range of 0.0 to 1.0
 	 */
-	private static float lerp(float v0, float v1, float t) {
+	protected static float lerp(float v0, float v1, float t) {
 		// https://en.wikipedia.org/wiki/Linear_interpolation
 		return (1 - t) * v0 + t * v1;
 	}


### PR DESCRIPTION
This fixes Complementary 4.2's sky. (This has been band-aid fixed on their side in the newest pre-release, but this is needed for it to properly function.)