### PR TITLE
Remove duplicate draw call

### DIFF
--- a/src/main/java/net/coderbot/batchedentityrendering/mixin/MixinLevelRenderer.java
+++ b/src/main/java/net/coderbot/batchedentityrendering/mixin/MixinLevelRenderer.java
@@ -21,7 +21,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
  * Tracks whether or not the world is being rendered, and manages grouping
  * with different entities.
  */
-@Mixin(value = LevelRenderer.class)
+// Uses a priority of 999 to apply before the main Iris mixins to draw entities before deferred runs.
+@Mixin(value = LevelRenderer.class, priority = 999)
 public class MixinLevelRenderer {
 	private static final String RENDER_ENTITY =
 			"Lnet/minecraft/client/renderer/LevelRenderer;renderEntity(Lnet/minecraft/world/entity/Entity;DDDFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;)V";

--- a/src/main/java/net/coderbot/iris/mixin/MixinLevelRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinLevelRenderer.java
@@ -213,12 +213,7 @@ public class MixinLevelRenderer {
 	private void iris$beginTranslucents(PoseStack poseStack, float tickDelta, long limitTime,
 										boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer,
 										LightTexture lightTexture, Matrix4f projection,
-										CallbackInfo ci, ProfilerFiller profiler, Vec3 vec3, double d, double e, double f,
-										Matrix4f matrix4f, boolean bl, Frustum frustum2, boolean bl3,
-										MultiBufferSource.BufferSource bufferSource) {
-		profiler.popPush("iris_entity_draws");
-		bufferSource.endBatch();
-
+										CallbackInfo ci, ProfilerFiller profiler) {
 		profiler.popPush("iris_pre_translucent");
 		pipeline.beginTranslucents();
 	}


### PR DESCRIPTION
This has literally no reason to be here as far as I can tell, since the batched entity rendering code does this and this just hurts performance.