### PR TITLE
Fix alpha cutoff

### DIFF
--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/shader_overrides/MixinBlockRenderPass.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/shader_overrides/MixinBlockRenderPass.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BlockRenderPass.class)
 public class MixinBlockRenderPass {
-	@Shadow
+	@Shadow(remap = false)
 	@Final
 	@Mutable
 	private float alphaCutoff;

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/shader_overrides/MixinBlockRenderPass.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/shader_overrides/MixinBlockRenderPass.java
@@ -19,7 +19,7 @@ public class MixinBlockRenderPass {
 
     @Inject(method = "<init>", at = @At("RETURN"))
 	public void changeAlphaCutoff(String layer, int ordinal, RenderType renderType, boolean translucent, float alphaCutoff, CallbackInfo ci) {
-		if (alphaCutoff == 0.5F) {
+		if (renderType == RenderType.cutoutMipped()) {
 			this.alphaCutoff = 0.1F;
 		}
 	}

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/shader_overrides/MixinBlockRenderPass.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/shader_overrides/MixinBlockRenderPass.java
@@ -1,0 +1,26 @@
+package net.coderbot.iris.compat.sodium.mixin.shader_overrides;
+
+import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
+import net.minecraft.client.renderer.RenderType;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BlockRenderPass.class)
+public class MixinBlockRenderPass {
+	@Shadow
+	@Final
+	@Mutable
+	private float alphaCutoff;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+	public void changeAlphaCutoff(String layer, int ordinal, RenderType renderType, boolean translucent, float alphaCutoff, CallbackInfo ci) {
+		if (alphaCutoff == 0.5F) {
+			this.alphaCutoff = 0.1F;
+		}
+	}
+}

--- a/src/sodiumCompatibility/resources/mixins.iris.compat.sodium.json
+++ b/src/sodiumCompatibility/resources/mixins.iris.compat.sodium.json
@@ -20,6 +20,7 @@
     "options.MixinSodiumOptionsGUI",
     "separate_ao.MixinBlockRenderer",
     "separate_ao.MixinFluidRenderer",
+    "shader_overrides.MixinBlockRenderPass",
     "shader_overrides.MixinGlProgram",
     "shader_overrides.MixinRegionChunkRenderer",
     "shader_overrides.MixinShaderChunkRenderer",


### PR DESCRIPTION
Turns out the only render pass with a 0.5 alpha is cutoutMipped anyway, so we can just use an if statement.