### PR TITLE
Support for getNightVisionScale injections

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinGameRenderer.java
@@ -34,4 +34,11 @@ public class MixinGameRenderer {
 	private boolean disableVanillaHandRendering(GameRenderer gameRenderer) {
 		return !Iris.getCurrentPack().isPresent();
 	}
+	
+	@Inject(method = "getNightVisionScale", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/effect/MobEffectInstance;getDuration()I"), cancellable = true)
+	private static void iris$safecheckNightvisionStrength(LivingEntity livingEntity, float f, CallbackInfoReturnable<Float> cir){
+		if(livingEntity.getEffect(MobEffects.NIGHT_VISION) == null){
+			cir.setReturnValue(0.0f);
+		}
+	}
 }

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -169,8 +169,9 @@ public final class CommonUniforms {
 		if (cameraEntity instanceof LivingEntity) {
 			LivingEntity livingEntity = (LivingEntity) cameraEntity;
 
-			if (livingEntity.getEffect(MobEffects.NIGHT_VISION) != null) {
-				return GameRenderer.getNightVisionScale(livingEntity, CapturedRenderingState.INSTANCE.getTickDelta());
+			float nightVisionStrength = GameRenderer.getNightVisionScale(livingEntity, CapturedRenderingState.INSTANCE.getTickDelta());
+			if (nightVisionStrength > 0) {
+				return nightVisionStrength;
 			}
 		}
 


### PR DESCRIPTION
These changes allow nightvision to work for mods which achieve it by directly injecting code into getNightVisionScale (For example [Origins](https://github.com/apace100/apoli/blob/320b0ef547fbbf703de7154f60909d30366f6500/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java#L153)) 
This also means that non binary nightVision values are now possible.