### PR TITLE
Add automatic release publishing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,11 +18,43 @@ jobs:
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/loom-cache
+            ~/.gradle/wrapper
+            ~/.m2/repository
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Upload artifacts to Curse, Modrinth and Github
-        run: ./gradlew build curseforge github modrinth
+
+      - run: chmod +x gradlew
+      - name: Build Release
+        run: ./gradlew build --stacktrace
+      - name: Upload release Builds to Github, Curseforge and Modrinth
+        run: ./gradlew github curseforge modrinth --stacktrace
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Switch to 1.17
+        run: git checkout 1.17
+
+      - name: Build 1.17
+        run: ./gradlew build --stacktrace
+      - name: Upload 1.17 Builds to Github, Curseforge and Modrinth
+        run: ./gradlew github curseforge modrinth --stacktrace
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Switch to 1.18
+        run: git checkout 1.18
+
+      - name: Build 1.18
+        run: ./gradlew build --stacktrace
+      - name: Upload 1.18 Builds to Github, Curseforge and Modrinth
+        run: ./gradlew github curseforge modrinth --stacktrace
         env:
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Upload artifacts to Curse/Modrinth
+      - name: Upload artifacts to Curse, Modrinth and Github
         run: ./gradlew build curseforge github modrinth
         env:
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,16 +15,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: FabricMC/fabric-action-scripts@v1
-        id : changelog
-        with:
-          context: changelog
-          workflow_id: build-release.yml
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Upload artifacts to Curse, Modrinth and Github
         run: ./gradlew build curseforge github modrinth

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,37 +1,34 @@
-name: Build Release
+name: build-release
+on: [workflow_dispatch]
 
-on: [ workflow_dispatch ]
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: eclipse-temurin:17-jdk
+      options: --user root
     steps:
+      - run: apt update && apt install git -y && git --version
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v1
         with:
-          java-version: 8
-      - name: Cache Iris
+          fetch-depth: 0
+      - uses: FabricMC/fabric-action-scripts@v1
+        id : changelog
+        with:
+          context: changelog
+          workflow_id: build-release.yml
+      - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/loom-cache
-            ~/.gradle/wrapper
-            ~/.m2/repository
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Build Iris jar
-        run: ./gradlew build
-      - name: Extract current branch name
-        shell: bash
-        # bash pattern expansion to grab branch name without slashes
-        run: ref="${GITHUB_REF#refs/heads/}" && echo "::set-output name=branch::${ref////-}"
-        id: ref
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: iris-artifacts-${{ steps.ref.outputs.branch }}
-          # Filter built files to disregard -sources and -dev, and leave only the minecraft-compatible jars.
-          path: build/libs/*[0-9].jar
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Upload artifacts to Curse/Modrinth
+        run: ./gradlew build curseforge github modrinth
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,19 @@
 //file:noinspection GroovyAssignabilityCheck
+//file:noinspection GrMethodMayBeStatic
 
-buildscript {
-	dependencies {
-		classpath 'org.kohsuke:github-api:1.135'
-	}
-}
 plugins {
 	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 	id 'org.ajoberstar.grgit' version '4.1.0'
-	id 'com.matthewprenger.cursegradle' version '1.4.0'
-	id 'com.modrinth.minotaur' version '1.1.0'
+	id 'com.matthewprenger.cursegradle' version '1.4.0' // I know this isn't ideal, however since CurseGradle doesn't using gradle tasking it's a pain
 }
+
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = project.archives_base_name
-version = "${project.mod_version}+${getVersionMetadata()}"
+version = "${project.mod_version}${getVersionMetadata()}"
 group = project.maven_group
 
 
@@ -69,10 +65,10 @@ test {
 }
 
 def includeFabricApiModule(String moduleName) {
-	Object dependency = fabricApi.module(moduleName, project.fabric_version);
+	Object dependency = fabricApi.module(moduleName, project.fabric_version)
 
-	dependencies.modImplementation(dependency);
-	dependencies.include(dependency);
+	dependencies.modImplementation(dependency)
+	dependencies.include(dependency)
 }
 
 processResources {
@@ -226,119 +222,30 @@ runClient {
 	jvmArgs "-Dmixin.debug.export=true"
 }
 
-@SuppressWarnings('GrMethodMayBeStatic')
 def getVersionMetadata() {
 	def build_id = System.getenv("GITHUB_RUN_NUMBER")
+	def workflow_id = System.getenv("GITHUB_WORKFLOW")
 
 	// CI builds only
-	if (build_id != null) {
-		return "build.${build_id}"
+	if (build_id != null && workflow_id != "build-release") {
+		return "+build.${build_id}"
+	// CI release builds only
+	} else if (workflow_id == "build-release") {
+		return ""
 	}
 
 	if (grgit != null) {
 		def head = grgit.head()
-		def id = head.abbreviatedId
+		def id = "+" + head.abbreviatedId
 
 		// Flag the build if the build tree is not clean
 		if (!grgit.status().clean) {
 			id += "-dirty"
 		}
 
-		return "rev.${id}"
+		return "+rev.${id}"
 	}
 }
 
-def ENV = System.getenv()
-
-def getBranch() {
-	def ENV = System.getenv()
-	if (ENV.GITHUB_REF) {
-		def branch = ENV.GITHUB_REF
-		return branch.substring(branch.lastIndexOf("/") + 1)
-	}
-
-	if (grgit != null) {
-		def head = grgit.head()
-		def id = head.abbreviatedId
-
-		// Flag the build if the build tree is not clean
-		if (!grgit.status().clean) {
-			id += "-dirty"
-		}
-	}
-
-	def branch = grgit.branch.current().name
-	return branch.substring(branch.lastIndexOf("/") + 1)
-}
-
-
-curseforge {
-	if (ENV.CURSEFORGE_TOKEN) {
-		apiKey = ENV.CURSEFORGE_TOKEN
-	}
-
-	project {
-		id = '470001'
-		changelog = "https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
-		releaseType = 'release'
-		relations {
-			requiredDependency 'sodium'
-		}
-		addGameVersion "$project.minecraft_version"
-		addGameVersion 'Fabric'
-
-		mainArtifact(remapJar) {
-			displayName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
-		}
-		afterEvaluate {
-			uploadTask.dependsOn(remapJar)
-		}
-	}
-	options {
-		forgeGradleIntegration = false
-	}
-}
-
-import com.modrinth.minotaur.TaskModrinthUpload
-
-task modrinth(type: TaskModrinthUpload, dependsOn: remapJar) {
-	onlyIf {
-		ENV.MODRINTH_TOKEN
-	}
-
-	token = ENV.MODRINTH_TOKEN
-	projectId = "5XACEUIs"
-	versionNumber = "mc$project.mod_version"
-	versionName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
-	releaseType = 'release'
-	changelog = "https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
-
-	uploadFile = remapJar
-
-	addGameVersion(project.minecraft_version)
-	addLoader('fabric')
-}
-
-
-import org.kohsuke.github.GHReleaseBuilder
-import org.kohsuke.github.GitHub
-
-task github(dependsOn: remapJar) {
-	onlyIf {
-		ENV.GITHUB_TOKEN
-	}
-
-	doLast {
-		def github = GitHub.connectUsingOAuth(ENV.GITHUB_TOKEN as String)
-		def repository = github.getRepository(ENV.GITHUB_REPOSITORY)
-
-		def releaseBuilder = new GHReleaseBuilder(repository, version as String)
-		releaseBuilder.name("Iris $project.mod_version for Minecraft $project.minecraft_version")
-		releaseBuilder.body("https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md")
-		releaseBuilder.commitish(getBranch())
-		releaseBuilder.prerelease(false)
-
-		def ghRelease = releaseBuilder.create()
-		ghRelease.uploadAsset(file("${project.buildDir}/libs/${project.archivesBaseName}-${project.mod_version}+build.${ENV.GITHUB_RUN_NUMBER}.jar"), "application/java-archive");
-	}
-}
+// Import the publish buildscript
+apply from: 'publish.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,7 @@ curseforge {
 
 	project {
 		id = '470001'
-		changelog = "https://github.com/NoComment1105/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
+		changelog = "https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
 		releaseType = 'release'
 		relations {
 			requiredDependency 'sodium'
@@ -311,7 +311,7 @@ task modrinth(type: TaskModrinthUpload, dependsOn: remapJar) {
 	versionNumber = "mc$project.mod_version"
 	versionName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
 	releaseType = 'release'
-	changelog = "https://github.com/NoComment1105/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
+	changelog = "https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
 
 	uploadFile = remapJar
 
@@ -334,7 +334,7 @@ task github(dependsOn: remapJar) {
 
 		def releaseBuilder = new GHReleaseBuilder(repository, version as String)
 		releaseBuilder.name("Iris $project.mod_version for Minecraft $project.minecraft_version")
-		releaseBuilder.body("https://github.com/NoComment1105/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md")
+		releaseBuilder.body("https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md")
 		releaseBuilder.commitish(getBranch())
 		releaseBuilder.prerelease(false)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,16 @@
+//file:noinspection GroovyAssignabilityCheck
+
+buildscript {
+	dependencies {
+		classpath 'org.kohsuke:github-api:1.135'
+	}
+}
 plugins {
 	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 	id 'org.ajoberstar.grgit' version '4.1.0'
+	id 'com.matthewprenger.cursegradle' version '1.4.0'
+	id 'com.modrinth.minotaur' version '1.1.0'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -92,7 +101,7 @@ tasks.withType(JavaCompile).configureEach {
 	// We'll use that if it's available, but otherwise we'll use the older option.
 	def targetVersion = 8
 	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = targetVersion
+		it.options.release.set(targetVersion)
 	}
 
 	// Enable this if you want to see deprecation warnings
@@ -217,6 +226,7 @@ runClient {
 	jvmArgs "-Dmixin.debug.export=true"
 }
 
+@SuppressWarnings('GrMethodMayBeStatic')
 def getVersionMetadata() {
 	def build_id = System.getenv("GITHUB_RUN_NUMBER")
 
@@ -235,5 +245,100 @@ def getVersionMetadata() {
 		}
 
 		return "rev.${id}"
+	}
+}
+
+def ENV = System.getenv()
+
+def getBranch() {
+	def ENV = System.getenv()
+	if (ENV.GITHUB_REF) {
+		def branch = ENV.GITHUB_REF
+		return branch.substring(branch.lastIndexOf("/") + 1)
+	}
+
+	if (grgit != null) {
+		def head = grgit.head()
+		def id = head.abbreviatedId
+
+		// Flag the build if the build tree is not clean
+		if (!grgit.status().clean) {
+			id += "-dirty"
+		}
+	}
+
+	def branch = grgit.branch.current().name
+	return branch.substring(branch.lastIndexOf("/") + 1)
+}
+
+
+curseforge {
+	if (ENV.CURSEFORGE_TOKEN) {
+		apiKey = ENV.CURSEFORGE_TOKEN
+	}
+
+	project {
+		id = '470001'
+		changelog = "https://github.com/NoComment1105/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
+		releaseType = 'release'
+		relations {
+			requiredDependency 'sodium'
+		}
+		addGameVersion "$project.minecraft_version"
+		addGameVersion 'Fabric'
+
+		mainArtifact(remapJar) {
+			displayName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
+		}
+		afterEvaluate {
+			uploadTask.dependsOn(remapJar)
+		}
+	}
+	options {
+		forgeGradleIntegration = false
+	}
+}
+
+import com.modrinth.minotaur.TaskModrinthUpload
+
+task modrinth(type: TaskModrinthUpload, dependsOn: remapJar) {
+	onlyIf {
+		ENV.MODRINTH_TOKEN
+	}
+
+	token = ENV.MODRINTH_TOKEN
+	projectId = "5XACEUIs"
+	versionNumber = "mc$project.mod_version"
+	versionName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
+	releaseType = 'release'
+	changelog = "https://github.com/NoComment1105/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md"
+
+	uploadFile = remapJar
+
+	addGameVersion(project.minecraft_version)
+	addLoader('fabric')
+}
+
+
+import org.kohsuke.github.GHReleaseBuilder
+import org.kohsuke.github.GitHub
+
+task github(dependsOn: remapJar) {
+	onlyIf {
+		ENV.GITHUB_TOKEN
+	}
+
+	doLast {
+		def github = GitHub.connectUsingOAuth(ENV.GITHUB_TOKEN as String)
+		def repository = github.getRepository(ENV.GITHUB_REPOSITORY)
+
+		def releaseBuilder = new GHReleaseBuilder(repository, version as String)
+		releaseBuilder.name("Iris $project.mod_version for Minecraft $project.minecraft_version")
+		releaseBuilder.body("https://github.com/NoComment1105/Iris/tree/trunk/docs/changelogs/${project.mod_version}summary.md")
+		releaseBuilder.commitish(getBranch())
+		releaseBuilder.prerelease(false)
+
+		def ghRelease = releaseBuilder.create()
+		ghRelease.uploadAsset(file("${project.buildDir}/libs/${project.archivesBaseName}-${project.mod_version}+build.${ENV.GITHUB_RUN_NUMBER}.jar"), "application/java-archive");
 	}
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,86 @@
+//file:noinspection GroovyAssignabilityCheck
+//file:noinspection GrMethodMayBeStatic
+buildscript {
+	repositories {
+		mavenCentral()
+		maven {
+			url 'https://plugins.gradle.org/m2/'
+		}
+	}
+	dependencies {
+		classpath 'org.kohsuke:github-api:1.135'
+		classpath group: 'gradle.plugin.com.modrinth.minotaur', name: 'Minotaur', version: '1.1.0'
+	}
+}
+
+def ENV = System.getenv()
+
+
+curseforge {
+	if (ENV.CURSEFORGE_TOKEN) {
+		apiKey = ENV.CURSEFORGE_TOKEN
+	}
+
+	project {
+		id = '455508'
+		changelog = "https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}/summary.md"
+		releaseType = 'release'
+		relations {
+			requiredDependency 'sodium'
+		}
+		addGameVersion "$project.minecraft_version"
+		addGameVersion 'Fabric'
+
+		mainArtifact(remapJar) {
+			displayName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
+		}
+		afterEvaluate {
+			uploadTask.dependsOn(remapJar)
+		}
+	}
+	options {
+		forgeGradleIntegration = false
+	}
+}
+
+import com.modrinth.minotaur.TaskModrinthUpload
+
+task modrinth(type: TaskModrinthUpload, dependsOn: remapJar) {
+	onlyIf {
+		ENV.MODRINTH_TOKEN
+	}
+
+	token = ENV.MODRINTH_TOKEN
+	projectId = "YL57xq9U"
+	versionNumber = "mc$project.mod_version"
+	versionName = "Iris $project.mod_version for Minecraft $project.minecraft_version"
+	releaseType = 'release'
+	changelog = "https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}/summary.md"
+
+	uploadFile = remapJar
+
+	addGameVersion(project.minecraft_version)
+	addLoader('fabric')
+}
+
+
+import org.kohsuke.github.GHReleaseBuilder
+import org.kohsuke.github.GitHub
+
+task github(dependsOn: remapJar) {
+	onlyIf {
+		ENV.GITHUB_TOKEN
+	}
+
+	doLast {
+		def github = GitHub.connectUsingOAuth(ENV.GITHUB_TOKEN as String)
+		def repository = github.getRepository(ENV.GITHUB_REPOSITORY)
+
+		def releaseBuilder = new GHReleaseBuilder(repository, version as String)
+		releaseBuilder.name("Iris $project.mod_version for Minecraft $project.minecraft_version")
+		releaseBuilder.body("https://github.com/IrisShaders/Iris/tree/trunk/docs/changelogs/${project.mod_version}/summary.md")
+
+		def ghRelease = releaseBuilder.create()
+		ghRelease.uploadAsset(file("${project.buildDir}/libs/${project.archivesBaseName}-${project.mod_version}.jar"), "application/java-archive");
+	}
+}


### PR DESCRIPTION
This alters the release workflow to automatically push builds to Curseforge Modrinth and Github. This will need to be copied over to 1.17 and 1.18 meaning 3 different workflows will need to be run at each release. The code is entirely copiable and not version bound

I know you wanterd  a seperate gradle file but pain :)