### PR TITLE
Separate Sodium, Iris, and Minecraft versions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,23 +31,28 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks. If you aren't sure what's relevant, drag and drop your entire log file (found in `.minecraft/logs`) into the "Additional context" section.
       render: shell
-
   - type: input
-    id: version
+    id: minecraft-version
     attributes:
-      label: Iris and Minecraft Version
-      description: What version of Iris are you running? Include the Minecraft version too. Every part is important! If you do not know what version you are using, look at the file name in your "mods" folder.
-      placeholder: ex. iris-mc1.16.5-1.0.0.jar for Minecraft 1.16.5
+      label: Minecraft Version
+      description: What version of Minecraft are you running? If you do not know what version you are using, look in the bottom left corner of the main menu in game.
+      placeholder: ex. Minecraft 1.16.5
     validations:
       required: true
-  - type: dropdown
-    id: sodium
+  - type: input
+    id: iris-version
     attributes:
-      label: Are you running Sodium along with Iris?
-      description: This is the case if you kept the default Sodium & Iris when running the installer or if you downloaded the release from Curseforge or Modrinth
-      options:
-        - 'Yes'
-        - 'No'
+      label: Iris Version
+      description: What version of Iris are you running? Every part is important! If you do not know what version you are using, look at the file name in your "mods" folder.
+      placeholder: ex. iris-mc1.17-1.1.3.jar
+    validations:
+      required: true
+  - type: input
+    id: sodium-version
+    attributes:
+      label: Sodium Version
+      description: What version of Sodium are you running along with Iris? Every part is important! If you do not know what version you are using, look at the file name in your "mods" folder. If you aren't running Sodium please put N/A.
+      placeholder: ex. sodium-fabric-mc1.17.1-0.3.3+build.8.jar
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -11,21 +11,27 @@ body:
         
         Also, make sure you are using the latest version of the mod! If not, try updating to see if it resolves your issue.
   - type: input
-    id: version
+    id: minecraft-version
     attributes:
-      label: Iris and Minecraft Version
-      description: What version of Iris are you running? Include the Minecraft version too. Every part is important! If you do not know what version you are using, look at the file name in your "mods" folder.
-      placeholder: ex. iris-mc1.16.5-1.0.0.jar for Minecraft 1.16.5
+      label: Minecraft Version
+      description: What version of Minecraft are you running? If you do not know what version you are using, look in the bottom left corner of the main menu in game.
+      placeholder: ex. Minecraft 1.16.5
     validations:
       required: true
-  - type: dropdown
-    id: sodium
+  - type: input
+    id: iris-version
     attributes:
-      label: Are you running Sodium along with Iris?
-      description: This is the case if you kept the default Sodium & Iris when running the installer or if you downloaded the release from Curseforge or Modrinth
-      options:
-        - 'Yes'
-        - 'No'
+      label: Iris Version
+      description: What version of Iris are you running? Every part is important! If you do not know what version you are using, look at the file name in your "mods" folder.
+      placeholder: ex. iris-mc1.17-1.1.3.jar
+    validations:
+      required: true
+  - type: input
+    id: sodium-version
+    attributes:
+      label: Sodium Version
+      description: What version of Sodium are you running along with Iris? Every part is important! If you do not know what version you are using, look at the file name in your "mods" folder. If you aren't running Sodium please put N/A.
+      placeholder: ex. sodium-fabric-mc1.17.1-0.3.3+build.8.jar
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Given that Iris no longer uses bundled Sodium it's important to be able to easily know what Sodium version a user has without going into their log file. This pull request separates the fields for Iris, Sodium, and Minecraft versions. I've seen several recent issues that would've been resolved faster if the information were presented in this format.