### PR TITLE
change mention that Sodium isn't bundled in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,7 +52,7 @@ Dynamic Lights - [LambDynamicLights](https://www.curseforge.com/minecraft/mc-mod
 
 Smart Leaves - [Cull Leaves](https://www.curseforge.com/minecraft/mc-mods/cull-leaves)
 
-Performance - Iris is already bundled with Sodium but we also recommend [Lithium](https://modrinth.com/mod/lithium), [Hydrogen](https://modrinth.com/mod/hydrogen), and [FerriteCore](https://www.curseforge.com/minecraft/mc-mods/ferritecore-fabric). You can also use either [Phosphor](https://modrinth.com/mod/phosphor) or [Starlight](https://modrinth.com/mod/starlight). Phosphor does not have a 1.18 version yet.
+Performance - Iris already uses [Sodium](https://modrinth.com/mod/sodium), but we also recommend [Lithium](https://modrinth.com/mod/lithium), [Hydrogen](https://modrinth.com/mod/hydrogen), and [FerriteCore](https://www.curseforge.com/minecraft/mc-mods/ferritecore-fabric). You can also use either [Phosphor](https://modrinth.com/mod/phosphor) or [Starlight](https://modrinth.com/mod/starlight). Phosphor does not have a 1.18 version yet.
 
 Various OptiFine features including toggles for animations, particles, and fog - [Sodium Extra](https://www.curseforge.com/minecraft/mc-mods/sodium-extra)
 


### PR DESCRIPTION
Sodium isn't bundled any longer in Iris, but the FAQ still mentioned that, so I updated this, while also linking to the Sodium modrinth page