### PR TITLE
Restore Fabulous graphics if they were enabled before shaders were on

### DIFF
--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -26,17 +26,12 @@ public class IrisConfig {
 	 */
 	private boolean enableShaders;
 
-	/**
-	 * Whether the Graphics mode was Fabulous before enabling a shaderpack
-	 */
-	private boolean wasFabulous;
 
 	private final Path propertiesPath;
 
 	public IrisConfig(Path propertiesPath) {
 		shaderPackName = null;
 		enableShaders = true;
-		wasFabulous = false;
 		this.propertiesPath = propertiesPath;
 	}
 
@@ -96,22 +91,6 @@ public class IrisConfig {
 	public void setShadersEnabled(boolean enabled) {
 		this.enableShaders = enabled;
 	}
-
-	/**
-	 * Stores whether fabulous graphics should be restored upon turning shaders off
-	 *
-	 * @param wasFabulous Whether fabulous graphics were enabled prior to turning on shaders
-	 */
-	public void setWasFabulous(boolean wasFabulous) {
-		this.wasFabulous = wasFabulous;
-	}
-
-	/**
-	 * @return a boolean on whether fabulous graphics were enabled prior to turning on shaders
-	 */
-	 public boolean getWasFabulous() {
-		return wasFabulous;
-	 }
 
 	/**
 	 * loads the config file and then populates the string, int, and boolean entries with the parsed entries

--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -22,15 +22,21 @@ public class IrisConfig {
 	private String shaderPackName;
 
 	/**
-	 * Whether or not shaders are used for rendering. False to disable all shader-based rendering, true to enable it.
+	 * Whether shaders are used for rendering. False to disable all shader-based rendering, true to enable it.
 	 */
 	private boolean enableShaders;
+
+	/**
+	 * Whether the Graphics mode was Fabulous before enabling a shaderpack
+	 */
+	private boolean wasFabulous;
 
 	private final Path propertiesPath;
 
 	public IrisConfig(Path propertiesPath) {
 		shaderPackName = null;
 		enableShaders = true;
+		wasFabulous = false;
 		this.propertiesPath = propertiesPath;
 	}
 
@@ -92,11 +98,26 @@ public class IrisConfig {
 	}
 
 	/**
+	 * Stores whether fabulous graphics should be restored upon turning shaders off
+	 *
+	 * @param wasFabulous Whether fabulous graphics were enabled prior to turning on shaders
+	 */
+	public void setWasFabulous(boolean wasFabulous) {
+		this.wasFabulous = wasFabulous;
+	}
+
+	/**
+	 * @return a boolean on whether fabulous graphics were enabled prior to turning on shaders
+	 */
+	 public boolean getWasFabulous() {
+		return wasFabulous;
+	 }
+
+	/**
 	 * loads the config file and then populates the string, int, and boolean entries with the parsed entries
 	 *
 	 * @throws IOException if the file cannot be loaded
 	 */
-
 	public void load() throws IOException {
 		if (!Files.exists(propertiesPath)) {
 			return;

--- a/src/main/java/net/coderbot/iris/mixin/fabulous/MixinDisableFabulousGraphics.java
+++ b/src/main/java/net/coderbot/iris/mixin/fabulous/MixinDisableFabulousGraphics.java
@@ -1,6 +1,7 @@
 package net.coderbot.iris.mixin.fabulous;
 
 import net.coderbot.iris.Iris;
+import net.coderbot.iris.config.IrisConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -21,11 +22,22 @@ public class MixinDisableFabulousGraphics {
 		iris$disableFabulousGraphics();
 	}
 
+	@Inject(method = "onResourceManagerReload", at = @At("HEAD"))
+	private void iris$reenableFabulousGraphicsOnResourceReload(CallbackInfo ci) {
+		iris$reenableFabulousGraphics();
+	}
+
+
 	// This method is called whenever the user tries to change the graphics mode.
 	// We can still revert / intercept the change at the head of the method.
 	@Inject(method = "allChanged", at = @At("HEAD"))
 	private void iris$disableFabulousGraphicsOnLevelRendererReload(CallbackInfo ci) {
 		iris$disableFabulousGraphics();
+	}
+
+	@Inject(method = "allChanged", at = @At("HEAD"))
+	private void iris$reenableFabulousGraphicsOnLevelRendererReload(CallbackInfo ci) {
+		iris$reenableFabulousGraphics();
 	}
 
 	@Unique
@@ -40,6 +52,25 @@ public class MixinDisableFabulousGraphics {
 		if (options.graphicsMode == GraphicsStatus.FABULOUS) {
 			// Disable fabulous graphics when shaders are enabled.
 			options.graphicsMode = GraphicsStatus.FANCY;
+			// Store the fact that fabulous graphics were on
+			Iris.getIrisConfig().setWasFabulous(true);
+		}
+	}
+
+	@Unique
+	private void iris$reenableFabulousGraphics() {
+		Options options = Minecraft.getInstance().options;
+
+		if (Iris.getIrisConfig().areShadersEnabled()) {
+			// Nothing to do here, shaders are enabled
+			return;
+		}
+
+		// If fabulous graphics were on, restore this
+		if (Iris.getIrisConfig().getWasFabulous()) {
+			options.graphicsMode = GraphicsStatus.FABULOUS;
+			// Fabulous graphics were restored, so we can set this to false for the next check
+			Iris.getIrisConfig().setWasFabulous(false);
 		}
 	}
 }

--- a/src/main/java/net/coderbot/iris/mixin/fabulous/MixinDisableFabulousGraphics.java
+++ b/src/main/java/net/coderbot/iris/mixin/fabulous/MixinDisableFabulousGraphics.java
@@ -17,6 +17,9 @@ import net.minecraft.client.renderer.LevelRenderer;
 @Environment(EnvType.CLIENT)
 @Mixin(LevelRenderer.class)
 public class MixinDisableFabulousGraphics {
+
+	private static boolean wasFabulous;
+
 	@Inject(method = "onResourceManagerReload", at = @At("HEAD"))
 	private void iris$disableFabulousGraphicsOnResourceReload(CallbackInfo ci) {
 		iris$disableFabulousGraphics();
@@ -53,7 +56,7 @@ public class MixinDisableFabulousGraphics {
 			// Disable fabulous graphics when shaders are enabled.
 			options.graphicsMode = GraphicsStatus.FANCY;
 			// Store the fact that fabulous graphics were on
-			Iris.getIrisConfig().setWasFabulous(true);
+			wasFabulous = true;
 		}
 	}
 
@@ -67,10 +70,10 @@ public class MixinDisableFabulousGraphics {
 		}
 
 		// If fabulous graphics were on, restore this
-		if (Iris.getIrisConfig().getWasFabulous()) {
+		if (wasFabulous) {
 			options.graphicsMode = GraphicsStatus.FABULOUS;
 			// Fabulous graphics were restored, so we can set this to false for the next check
-			Iris.getIrisConfig().setWasFabulous(false);
+			wasFabulous = false;
 		}
 	}
 }


### PR DESCRIPTION
Prior to this, if fabulous graphics were enabled and a shader was then enabled, fabulous graphics would become fancy as intended. But then when shaders were turned of fabulous was not restored. This PR fixes this. (#860)