### PR TITLE
Add shaderpack name, profile and number of changed options to crash reports

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinCrashReport.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinCrashReport.java
@@ -1,0 +1,34 @@
+package net.coderbot.iris.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.coderbot.iris.Iris;
+import net.minecraft.CrashReport;
+import net.minecraft.CrashReportCategory;
+
+/**
+ * Adds the current shaderpack and number of changed options to crash reports
+ */
+@Mixin(CrashReport.class)
+public abstract class MixinCrashReport {
+    @Shadow
+    public abstract CrashReportCategory getSystemDetails();
+
+    @Inject(at = @At("RETURN"), method = "initDetails")
+    private void fillSystemDetails(CallbackInfo info) {
+        if (Iris.getCurrentPackName() == null) return; // this also gets called at startup for some reason
+
+        getSystemDetails().setDetail("Loaded Shaderpack", () -> {
+            StringBuilder sb = new StringBuilder(Iris.getCurrentPackName());
+            Iris.getCurrentPack().ifPresent(pack -> {
+                sb.append("\n\t\t");
+                sb.append(pack.getProfileInfo());
+            });
+            return sb.toString();
+        });
+    }
+}

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -36,6 +36,7 @@
     "MixinTntMinecartRenderer",
     "MixinMaxFpsCrashFix",
     "MixinTweakFarPlane",
+    "MixinCrashReport",
     "entity_render_context.MixinBlockEntityRenderDispatcher",
     "entity_render_context.MixinEntityRenderDispatcher",
     "fabulous.MixinDisableFabulousGraphics",


### PR DESCRIPTION
This pull request adds a field to crash reports indicating the loaded shaderpack name, as well as the profile and modified options (as shown in F3).

![imagen](https://user-images.githubusercontent.com/17107132/150583290-141289a1-3da4-44e4-8727-8839e5450992.png)
