### PR TITLE
Use glsl-transformer for shader patching 1.17.1

### DIFF
--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -102,11 +102,10 @@ public class Buildscript extends MultiSrcDirFabricProject {
 	@Override
     public Path[] paths(String subdir, boolean onlyHeaders) {
         List<Path> r = new ArrayList<>();
-        if (tocompile) {
+        if (!onlyHeaders) {
             Collections.addAll(
                 r,
                 getProjectDir().resolve("src").resolve("main").resolve(subdir),
-                getProjectDir().resolve("src").resolve("headers").resolve(subdir),
                 getProjectDir().resolve("src").resolve("vendored").resolve(subdir)
             );
             if (SODIUM) {
@@ -115,9 +114,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
                 r.add(getProjectDir().resolve("src").resolve("noSodiumStub").resolve(subdir));
             }
         }
-        if (headers) {
-            r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
-        }
+        r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
         r.removeIf(p -> !Files.exists(p));
         return r.toArray(new Path[0]);
     }

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -2,6 +2,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,6 +17,7 @@ import io.github.coolcrabs.brachyura.maven.MavenId;
 import io.github.coolcrabs.brachyura.minecraft.Minecraft;
 import io.github.coolcrabs.brachyura.minecraft.VersionMeta;
 import io.github.coolcrabs.brachyura.processing.ProcessorChain;
+import io.github.coolcrabs.brachyura.dependency.JavaJarDependency;
 import net.fabricmc.accesswidener.AccessWidenerReader;
 import net.fabricmc.accesswidener.AccessWidenerVisitor;
 import net.fabricmc.mappingio.tree.MappingTree;
@@ -74,7 +76,14 @@ public class Buildscript extends MultiSrcDirFabricProject {
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-api-base", "0.4.0+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-data-attachment-v1", "0.1.6+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-fluids-v1", "0.2.1+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
-        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.16.0"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.16.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        /* d.add(new JavaJarDependency(
+            Paths.get(
+                "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0.jar"),
+            Paths.get(
+                "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0-sources.jar"),
+            new MavenId("io.github.douira:glsl-transformer:0.16.0")),
+            ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ); */
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -102,19 +102,20 @@ public class Buildscript extends MultiSrcDirFabricProject {
 	@Override
     public Path[] paths(String subdir, boolean onlyHeaders) {
         List<Path> r = new ArrayList<>();
-        // TODO: this may be broken, somebody how knows what they're doing should fix this
         if (tocompile) {
             Collections.addAll(
                 r,
                 getProjectDir().resolve("src").resolve("main").resolve(subdir),
                 getProjectDir().resolve("src").resolve("headers").resolve(subdir),
-                getProjectDir().resolve("src").resolve("vendored").resolve(subdir));
+                getProjectDir().resolve("src").resolve("vendored").resolve(subdir)
+            );
             if (SODIUM) {
                 r.add(getProjectDir().resolve("src").resolve("sodiumCompatibility").resolve(subdir));
             } else {
                 r.add(getProjectDir().resolve("src").resolve("noSodiumStub").resolve(subdir));
             }
-        } else if (headers) {
+        }
+        if (headers) {
             r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
         }
         r.removeIf(p -> !Files.exists(p));

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -2,7 +2,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +16,6 @@ import io.github.coolcrabs.brachyura.maven.MavenId;
 import io.github.coolcrabs.brachyura.minecraft.Minecraft;
 import io.github.coolcrabs.brachyura.minecraft.VersionMeta;
 import io.github.coolcrabs.brachyura.processing.ProcessorChain;
-import io.github.coolcrabs.brachyura.dependency.JavaJarDependency;
 import net.fabricmc.accesswidener.AccessWidenerReader;
 import net.fabricmc.accesswidener.AccessWidenerVisitor;
 import net.fabricmc.mappingio.tree.MappingTree;
@@ -76,13 +74,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-api-base", "0.4.0+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-data-attachment-v1", "0.1.6+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-fluids-v1", "0.2.1+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
-        /* d.add(new JavaJarDependency(
-            Paths.get(
-                "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0.jar"),
-            Paths.get(
-                "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0-sources.jar"),
-            new MavenId("io.github.douira:glsl-transformer:0.16.0")),
-            ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ); */
+
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.17.2"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -106,14 +106,14 @@ public class Buildscript extends MultiSrcDirFabricProject {
             Collections.addAll(
                 r,
                 getProjectDir().resolve("src").resolve("main").resolve(subdir),
-                getProjectDir().resolve("src").resolve("vendored").resolve(subdir)
-            );
+                getProjectDir().resolve("src").resolve("vendored").resolve(subdir));
             if (SODIUM) {
                 r.add(getProjectDir().resolve("src").resolve("sodiumCompatibility").resolve(subdir));
             } else {
                 r.add(getProjectDir().resolve("src").resolve("noSodiumStub").resolve(subdir));
             }
-        } else if (headers) {
+        }
+        if (headers) {
             r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
         }
         r.removeIf(p -> !Files.exists(p));

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -102,18 +102,19 @@ public class Buildscript extends MultiSrcDirFabricProject {
 	@Override
     public Path[] paths(String subdir, boolean onlyHeaders) {
         List<Path> r = new ArrayList<>();
-        if (!onlyHeaders) {
+        // TODO: this may be broken, somebody how knows what they're doing should fix this
+        if (tocompile) {
             Collections.addAll(
                 r,
                 getProjectDir().resolve("src").resolve("main").resolve(subdir),
+                getProjectDir().resolve("src").resolve("headers").resolve(subdir),
                 getProjectDir().resolve("src").resolve("vendored").resolve(subdir));
             if (SODIUM) {
                 r.add(getProjectDir().resolve("src").resolve("sodiumCompatibility").resolve(subdir));
             } else {
                 r.add(getProjectDir().resolve("src").resolve("noSodiumStub").resolve(subdir));
             }
-        }
-        if (headers) {
+        } else if (headers) {
             r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
         }
         r.removeIf(p -> !Files.exists(p));

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -76,7 +76,6 @@ public class Buildscript extends MultiSrcDirFabricProject {
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-api-base", "0.4.0+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-data-attachment-v1", "0.1.6+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-fluids-v1", "0.2.1+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
-        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.16.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         /* d.add(new JavaJarDependency(
             Paths.get(
                 "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0.jar"),
@@ -84,6 +83,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
                 "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0-sources.jar"),
             new MavenId("io.github.douira:glsl-transformer:0.16.0")),
             ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ); */
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.17.0"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -83,7 +83,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
                 "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0-sources.jar"),
             new MavenId("io.github.douira:glsl-transformer:0.16.0")),
             ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ); */
-        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.17.0"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.17.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -74,7 +74,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-api-base", "0.4.0+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-data-attachment-v1", "0.1.6+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-fluids-v1", "0.2.1+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
-        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.15.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.16.0"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -74,6 +74,8 @@ public class Buildscript extends MultiSrcDirFabricProject {
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-api-base", "0.4.0+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-data-attachment-v1", "0.1.6+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-fluids-v1", "0.2.1+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.14.0"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {
 			if (CUSTOM_SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -83,7 +83,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
                 "~/.m2/repository/io/github/douira/glsl-transformer/0.16.0/glsl-transformer-0.16.0-sources.jar"),
             new MavenId("io.github.douira:glsl-transformer:0.16.0")),
             ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ); */
-        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.17.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.17.2"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -74,7 +74,7 @@ public class Buildscript extends MultiSrcDirFabricProject {
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-api-base", "0.4.0+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-data-attachment-v1", "0.1.6+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
 		d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-rendering-fluids-v1", "0.2.1+cf39a74318"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME);
-        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.14.0"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
+        d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:0.15.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
         d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.9.3"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME, ModDependencyFlag.JIJ);
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -113,8 +113,9 @@ public class Buildscript extends MultiSrcDirFabricProject {
             } else {
                 r.add(getProjectDir().resolve("src").resolve("noSodiumStub").resolve(subdir));
             }
+        } else if (headers) {
+            r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
         }
-        r.add(getProjectDir().resolve("src").resolve("headers").resolve(subdir));
         r.removeIf(p -> !Files.exists(p));
         return r.toArray(new Path[0]);
     }

--- a/buildscript/src/main/java/MultiSrcDirFabricProject.java
+++ b/buildscript/src/main/java/MultiSrcDirFabricProject.java
@@ -53,7 +53,8 @@ public abstract class MultiSrcDirFabricProject extends FabricProject {
 			for (Path p : paths("java", false)) {
 				compilation.addSourceDir(p);
 			}
-			for (Path p : paths("java", true, true)) {
+			for (Path p : paths("java", true, false)) {
+				compilation.addSourcePathDir(p);
 				headerSourceSets.add(p);
 			}
 			ProcessingSponge compilationOutput = new ProcessingSponge();

--- a/buildscript/src/main/java/MultiSrcDirFabricProject.java
+++ b/buildscript/src/main/java/MultiSrcDirFabricProject.java
@@ -53,10 +53,6 @@ public abstract class MultiSrcDirFabricProject extends FabricProject {
 			for (Path p : paths("java", false)) {
 				compilation.addSourceDir(p);
 			}
-			for (Path p : paths("java", true, false)) {
-				compilation.addSourcePathDir(p);
-				headerSourceSets.add(p);
-			}
 			ProcessingSponge compilationOutput = new ProcessingSponge();
 			JavaCompilationResult compileResult = compilation.compile();
 

--- a/buildscript/src/main/java/MultiSrcDirFabricProject.java
+++ b/buildscript/src/main/java/MultiSrcDirFabricProject.java
@@ -53,6 +53,9 @@ public abstract class MultiSrcDirFabricProject extends FabricProject {
 			for (Path p : paths("java", false)) {
 				compilation.addSourceDir(p);
 			}
+			for (Path p : paths("java", true, true)) {
+				headerSourceSets.add(p);
+			}
 			ProcessingSponge compilationOutput = new ProcessingSponge();
 			JavaCompilationResult compileResult = compilation.compile();
 

--- a/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
@@ -18,8 +18,8 @@ import net.coderbot.iris.gl.program.ProgramSamplers;
 import net.coderbot.iris.gl.program.ProgramUniforms;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.pipeline.newshader.FogMode;
+import net.coderbot.iris.pipeline.newshader.Patcher;
 import net.coderbot.iris.pipeline.newshader.ShaderAttributeInputs;
-import net.coderbot.iris.pipeline.newshader.TriforcePatcher;
 import net.coderbot.iris.rendertarget.RenderTargets;
 import net.coderbot.iris.shaderpack.ProgramSet;
 import net.coderbot.iris.shaderpack.ProgramSource;
@@ -121,45 +121,45 @@ public class SodiumTerrainPipeline {
 		});
 
 		if (terrainVertex != null) {
-			terrainVertex = TriforcePatcher.patchSodium(terrainVertex, ShaderType.VERTEX, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			terrainVertex = Patcher.getInstance().patchSodium(terrainVertex, ShaderType.VERTEX, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (translucentVertex != null) {
-			translucentVertex = TriforcePatcher.patchSodium(translucentVertex, ShaderType.VERTEX, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			translucentVertex = Patcher.getInstance().patchSodium(translucentVertex, ShaderType.VERTEX, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (shadowVertex != null) {
-			shadowVertex = TriforcePatcher.patchSodium(shadowVertex, ShaderType.VERTEX, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			shadowVertex = Patcher.getInstance().patchSodium(shadowVertex, ShaderType.VERTEX, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (terrainGeometry != null) {
-			terrainGeometry = TriforcePatcher.patchSodium(terrainGeometry, ShaderType.GEOMETRY, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			terrainGeometry = Patcher.getInstance().patchSodium(terrainGeometry, ShaderType.GEOMETRY, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (translucentGeometry != null) {
-			translucentGeometry = TriforcePatcher.patchSodium(translucentGeometry, ShaderType.GEOMETRY, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			translucentGeometry = Patcher.getInstance().patchSodium(translucentGeometry, ShaderType.GEOMETRY, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (shadowGeometry != null) {
-			shadowGeometry = TriforcePatcher.patchSodium(shadowGeometry, ShaderType.GEOMETRY, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			shadowGeometry = Patcher.getInstance().patchSodium(shadowGeometry, ShaderType.GEOMETRY, null, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (terrainFragment != null) {
 			String fragment = terrainFragment;
 
-			terrainFragment = TriforcePatcher.patchSodium(fragment, ShaderType.FRAGMENT, AlphaTest.ALWAYS, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
-			terrainCutoutFragment = TriforcePatcher.patchSodium(fragment, ShaderType.FRAGMENT, cutoutAlpha, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			terrainFragment = Patcher.getInstance().patchSodium(fragment, ShaderType.FRAGMENT, AlphaTest.ALWAYS, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			terrainCutoutFragment = Patcher.getInstance().patchSodium(fragment, ShaderType.FRAGMENT, cutoutAlpha, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (translucentFragment != null) {
-			translucentFragment = TriforcePatcher.patchSodium(translucentFragment, ShaderType.FRAGMENT, AlphaTest.ALWAYS, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			translucentFragment = Patcher.getInstance().patchSodium(translucentFragment, ShaderType.FRAGMENT, AlphaTest.ALWAYS, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 
 		if (shadowFragment != null) {
 			String fragment = shadowFragment;
 
-			shadowFragment = TriforcePatcher.patchSodium(fragment, ShaderType.FRAGMENT, AlphaTest.ALWAYS, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
-			shadowCutoutFragment = TriforcePatcher.patchSodium(fragment, ShaderType.FRAGMENT, cutoutAlpha, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			shadowFragment = Patcher.getInstance().patchSodium(fragment, ShaderType.FRAGMENT, AlphaTest.ALWAYS, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
+			shadowCutoutFragment = Patcher.getInstance().patchSodium(fragment, ShaderType.FRAGMENT, cutoutAlpha, inputs, vertexType.getPositionScale(), vertexType.getPositionOffset(), vertexType.getTextureScale());
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/NewShaderTests.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/NewShaderTests.java
@@ -38,12 +38,12 @@ public class NewShaderTests {
 		BlendModeOverride blendModeOverride = source.getDirectives().getBlendModeOverride();
 
 		ShaderAttributeInputs inputs = new ShaderAttributeInputs(vertexFormat, isFullbright);
-		String vertex = TriforcePatcher.patchVanilla(source.getVertexSource().orElseThrow(RuntimeException::new), ShaderType.VERTEX, alpha, true, inputs);
+		String vertex = Patcher.getInstance().patchVanilla(source.getVertexSource().orElseThrow(RuntimeException::new), ShaderType.VERTEX, alpha, true, inputs);
 		String geometry = null;
 		if (source.getGeometrySource().isPresent()) {
-			geometry = TriforcePatcher.patchVanilla(source.getGeometrySource().get(), ShaderType.GEOMETRY, alpha, true, inputs);
+			geometry = Patcher.getInstance().patchVanilla(source.getGeometrySource().get(), ShaderType.GEOMETRY, alpha, true, inputs);
 		}
-		String fragment = TriforcePatcher.patchVanilla(source.getFragmentSource().orElseThrow(RuntimeException::new), ShaderType.FRAGMENT, alpha, true, inputs);
+		String fragment = Patcher.getInstance().patchVanilla(source.getFragmentSource().orElseThrow(RuntimeException::new), ShaderType.FRAGMENT, alpha, true, inputs);
 
 		StringBuilder shaderJson = new StringBuilder("{\n" +
 				"    \"blend\": {\n" +

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/Patcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/Patcher.java
@@ -1,0 +1,23 @@
+package net.coderbot.iris.pipeline.newshader;
+
+import net.coderbot.iris.gl.blending.AlphaTest;
+import net.coderbot.iris.gl.shader.ShaderType;
+
+public interface Patcher {
+  // static Patcher INSTANCE = new TriforcePatcher();
+  static Patcher INSTANCE = new TransformPatcher();
+
+  public static Patcher getInstance() {
+    // create an instance only when needed or statically like this?
+    return INSTANCE;
+  }
+
+  public String patchVanilla(
+      String source, ShaderType type, AlphaTest alpha,
+      boolean hasChunkOffset, ShaderAttributeInputs inputs);
+
+  public String patchSodium(String source, ShaderType type, AlphaTest alpha,
+      ShaderAttributeInputs inputs, float positionScale, float positionOffset, float textureScale);
+
+  public String patchComposite(String source, ShaderType type);
+}

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/ReplaceDeclarations.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/ReplaceDeclarations.java
@@ -1,0 +1,126 @@
+package net.coderbot.iris.pipeline.newshader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.antlr.v4.runtime.tree.pattern.ParseTreeMatch;
+import org.antlr.v4.runtime.tree.pattern.ParseTreePattern;
+
+import io.github.douira.glsl_transformer.GLSLParser;
+import io.github.douira.glsl_transformer.GLSLParser.ExternalDeclarationContext;
+import io.github.douira.glsl_transformer.GLSLParser.FunctionHeaderContext;
+import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
+import io.github.douira.glsl_transformer.GLSLParser.VariableIdentifierContext;
+import io.github.douira.glsl_transformer.transform.SemanticException;
+import io.github.douira.glsl_transformer.transform.Transformation;
+import io.github.douira.glsl_transformer.transform.WalkPhase;
+import io.github.douira.glsl_transformer.tree.ExtendedContext;
+
+//TODO: treat each found declaration with the same location=0 as the same declaration and replace all of them identically
+/**
+ * The declaration replacement finds layout declarations and replaces all
+ * references to them with function calls and other code.
+ */
+public class ReplaceDeclarations<T> extends Transformation<T> {
+  private static class Declaration {
+    private final String type;
+    private final String name;
+
+    public Declaration(String type, String name) {
+      this.type = type;
+      this.name = name;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+
+  private Map<String, Declaration> declarations;
+
+  @Override
+  protected void resetState() {
+    declarations = new HashMap<>();
+  }
+
+  /**
+   * Creates a new declaration replacement transformation with a walk phase for
+   * finding declarations and one for inserting calls to the generated functions.
+   */
+  {
+    addPhase(new WalkPhase<T>() {
+      ParseTreePattern declarationPattern;
+
+      @Override
+      protected void init() {
+        declarationPattern = compilePattern("layout (location = 0) <type:storageQualifier> vec4 <name:IDENTIFIER>;",
+            GLSLParser.RULE_externalDeclaration);
+      }
+
+      @Override
+      public void enterExternalDeclaration(ExternalDeclarationContext ctx) {
+        ParseTreeMatch match = declarationPattern.match(ctx);
+        if (match.succeeded()) {
+          // check for valid format and add to the list if it is valid
+          String type = match.get("type").getText();
+          String name = match.get("name").getText();
+
+          if (name == "iris_Position") {
+            throw new SemanticException(String.format("Disallowed GLSL declaration with the name \"{0}\"!", name), ctx);
+          }
+
+          if (type.equals("in") || type.equals("attribute")) {
+            declarations.put(name, new Declaration(type, name));
+            removeNode((ExtendedContext) match.getTree());
+          }
+        }
+      }
+
+      @Override
+      public void enterFunctionHeader(FunctionHeaderContext ctx) {
+        if (ctx.IDENTIFIER().getText().equals("iris_getModelSpaceVertexPosition")) {
+          throw new SemanticException(
+              String.format("Disallowed GLSL declaration with the name \"{0}\"!", "iris_getModelSpaceVertexPosition"),
+              ctx);
+        }
+      }
+
+      @Override
+      protected boolean isActiveAfterWalk() {
+        return !declarations.isEmpty();
+      }
+
+      @Override
+      protected void afterWalk(TranslationUnitContext ctx) {
+        // is only run if phase is found to be active
+        // TODO: the function content and the new attribute declaration
+        injectExternalDeclaration(InjectionPoint.BEFORE_EOF, "void iris_getModelSpaceVertexPosition() { }");
+        injectExternalDeclaration(InjectionPoint.BEFORE_FUNCTIONS,
+            "layout (location = 0) attribute vec4 iris_Position;");
+      }
+    });
+
+    addPhase(new WalkPhase<T>() {
+      @Override
+      protected boolean isActive() {
+        return !declarations.isEmpty();
+      }
+
+      @Override
+      public void enterVariableIdentifier(VariableIdentifierContext ctx) {
+        // check for one of the identifiers we're looking for
+        TerminalNode identifier = ctx.IDENTIFIER();
+        Declaration matchingDeclaration = declarations.get(identifier.getText());
+        if (matchingDeclaration != null) {
+          // perform replacement of this reference
+          replaceNode(ctx, "iris_getModelSpaceVertexPosition()", GLSLParser::expression);
+        }
+      }
+    });
+  }
+}

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/ReplaceDeclarations.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/ReplaceDeclarations.java
@@ -21,6 +21,9 @@ import io.github.douira.glsl_transformer.tree.ExtendedContext;
 /**
  * The declaration replacement finds layout declarations and replaces all
  * references to them with function calls and other code.
+ * 
+ * NOTE: this class is here because it was in glsl-transformer before but it's
+ * actually not supposed to be part of that so I moved it.
  */
 public class ReplaceDeclarations<T> extends Transformation<T> {
   private static class Declaration {

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -575,7 +575,10 @@ public class TransformPatcher implements Patcher {
         manager.registerTransformation(detectReserved);
         manager.registerTransformation(fixVersion);
         manager.registerTransformation(wrapFogSetup);
-        manager.registerTransformation(wrapFogFragCoord);
+
+        // TODO:investigate why the duplicate definition of this doesn't cause the throw
+        // target to trigger
+        // manager.registerTransformation(wrapFogFragCoord);
 
         if (type == ShaderType.VERTEX || type == ShaderType.FRAGMENT) {
           manager.registerTransformation(wrapFogFragCoord);

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -52,18 +52,16 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
  * The transform patcher (triforce 2) uses glsl-transformer to do shader
  * transformation.
  * 
+ * A separate TransformationManager is created for each ShaderType.
+ * That makes each of them more efficient as they don't need to run unnecessary
+ * transformation phases.
+ * 
  * NOTE: This patcher expects the string to not contain any (!) preprocessor
  * directives. The only allowed ones are #extension and #pragma as they are
  * considered "parsed" directives. If any other directive appears in the string,
  * it will throw.
  * 
- * TODO: Require the callers of this patcher to have already removed
- * preprocessor directives. This is probably just a matter of telling JCPC to
- * remove them.
- * 
- * NOTE: A separate TransformationManager should be created for each ShaderType.
- * That makes each of them more efficient as they don't need to run unnecessary
- * transformation phases.
+ * TODO: JCPP has to be configured to remove preprocessor directives entirely
  * 
  * TODO: good examples for more complex transformation in triforce patcher?
  * ideas: BuiltinUniformReplacementTransformer, defines/replacements with loops,
@@ -71,6 +69,8 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
  * 
  * TODO: how are defines handled? glsl-transformer can't deal with code that is
  * not valid GLSL code. Directives like #if will mess it up.
+ * TODO: use new glsl-transformer features on RunPhase to make all the RunPhase
+ * subclasses much more comapct (just one method call)
  */
 public class TransformPatcher implements Patcher {
   private static final Logger LOGGER = LogManager.getLogger(TransformPatcher.class);
@@ -686,6 +686,8 @@ public class TransformPatcher implements Patcher {
       }
     };
 
+    // TODO: do iris_LightmapTextureMatrix and iris_TextureMat here
+
     // TODO: in triforce this is confusing because iris_Color is used even when
     // !hasColor in which case it's not defined anywhere
     Transformation<Parameters> wrapColorVanilla = new Transformation<Parameters>() {
@@ -724,6 +726,19 @@ public class TransformPatcher implements Patcher {
             injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS, "uniform vec4 iris_ColorModulator;");
           }
         });
+      }
+    };
+
+    Transformation<Parameters> wrapModelViewMatrix = new Transformation<Parameters>() {
+      {
+        append(WrapIdentifier.fromExpression(
+            "gl_NormalMatrix", "gl_ModelViewMatrix", "mat3(transpose(inverse(gl_ModelViewMatrix)))",
+            new RunPhase<Parameters>() {
+              @Override
+              protected void run(TranslationUnitContext ctx) {
+
+              }
+            }));
       }
     };
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -160,19 +160,13 @@ public class TransformPatcher implements Patcher {
         new RunPhase<Parameters>() {
           @Override
           protected void run(TranslationUnitContext ctx) {
-            injectExternalDeclaration(
-                InjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_FogDensity;");
-            injectExternalDeclaration(
-                InjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_FogStart;");
-            injectExternalDeclaration(
-                InjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_FogEnd;");
-            injectExternalDeclaration(
-                InjectionPoint.BEFORE_DECLARATIONS, "uniform vec4 iris_FogColor;");
-            injectExternalDeclaration(
+            injectExternalDeclarations(
                 InjectionPoint.BEFORE_DECLARATIONS,
-                "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };");
-            injectExternalDeclaration(
-                InjectionPoint.BEFORE_DECLARATIONS,
+                "uniform float iris_FogDensity;",
+                "uniform float iris_FogStart;",
+                "uniform float iris_FogEnd;",
+                "uniform vec4 iris_FogColor;",
+                "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };",
                 "iris_FogParameters iris_Fog = iris_FogParameters(iris_FogColor, iris_FogDensity, iris_FogStart, iris_FogEnd, 1.0 / (iris_FogEnd - iris_FogStart));");
           }
         });

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -265,14 +265,18 @@ public class TransformPatcher implements Patcher {
     // 3. add location 0 to that declaration
 
     Transformation<Parameters> replaceStorageQualifierVertex = new Transformation<Parameters>(
-        new SearchTerminalsImpl<Parameters>() {
+        new SearchTerminalsImpl<Parameters>(SearchTerminals.ANY_TYPE) {
           {
             addReplacementTerminal("attribute", "in");
-            addReplacementTerminal("varying", "in");
+            addReplacementTerminal("varying", "out");
           }
         });
     Transformation<Parameters> replaceStorageQualifierFragment = new Transformation<Parameters>(
-        SearchTerminalsImpl.<Parameters>withReplacementTerminal("varying", "in"));
+        new SearchTerminalsImpl<Parameters>(SearchTerminals.ANY_TYPE) {
+          {
+            addReplacementTerminal("varying", "in");
+          }
+        });
 
     // PREV TODO: Add similar functions for all legacy texture sampling functions
     Transformation<Parameters> injectTextureFunctions = new Transformation<Parameters>(new RunPhase<Parameters>() {

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -29,9 +29,17 @@ import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
 
 /**
- * The transform patcher uses glsl-transformer to do shader transformation. It
- * delegates the things it doesn't do itself to TriforcePatcher by either not
- * overwriting methods or calling them itself.
+ * The transform patcher (triforce 2) uses glsl-transformer to do shader
+ * transformation.
+ * 
+ * NOTE: This patcher expects the string to not contain any (!) preprocessor
+ * directives. The only allowed ones are #extension and #pragma as they are
+ * considered "parsed" directives. If any other directive appears in the string,
+ * it will throw.
+ * 
+ * TODO: Require the callers of this patcher to have already removed
+ * preprocessor directives. This is probably just a matter of telling JCPC to
+ * remove them.
  * 
  * NOTE: A separate TransformationManager should be created for each ShaderType.
  * That makes each of them more efficient as they don't need to run unnecessary

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -24,7 +24,6 @@ import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.SemanticException;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
-import io.github.douira.glsl_transformer.transform.TransformationPhase;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
@@ -220,6 +219,18 @@ public class TransformPatcher implements Patcher {
           };
         });
 
+    // TODO: fragColor/fragData patching, see discord messages
+
+    Transformation<Parameters> replaceStorageQualifierVertex = new Transformation<Parameters>(
+        new SearchTerminals<Parameters>() {
+          {
+            addReplacementTerminal("attribute", "in");
+            addReplacementTerminal("varying", "in");
+          }
+        });
+    Transformation<Parameters> replaceStorageQualifierFragment = new Transformation<Parameters>(
+        SearchTerminals.<Parameters>withReplacementTerminal("varying", "in"));
+
     // PREV TODO: Add similar functions for all legacy texture sampling functions
     Transformation<Parameters> injectTextureFunctions = new Transformation<Parameters>(new RunPhase<Parameters>() {
       @Override
@@ -257,8 +268,6 @@ public class TransformPatcher implements Patcher {
           }
         });
 
-    // TODO: fragColor/fragData patching, see discord messages
-
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
       for (ShaderType type : ShaderType.values()) {
@@ -278,12 +287,15 @@ public class TransformPatcher implements Patcher {
 
         if (type == ShaderType.VERTEX) {
           manager.registerTransformation(wrapFrontColor);
+          manager.registerTransformation(replaceStorageQualifierVertex);
+        }
+
+        if (type == ShaderType.FRAGMENT) {
+          manager.registerTransformation(replaceStorageQualifierFragment);
+          manager.registerTransformation(injectTextureFunctionsFragment);
         }
 
         manager.registerTransformation(injectTextureFunctions);
-        if (type == ShaderType.FRAGMENT) {
-          manager.registerTransformation(injectTextureFunctionsFragment);
-        }
       }
     }
   }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -686,8 +686,6 @@ public class TransformPatcher implements Patcher {
       }
     };
 
-    // TODO: do iris_LightmapTextureMatrix and iris_TextureMat here
-
     // TODO: in triforce this is confusing because iris_Color is used even when
     // !hasColor in which case it's not defined anywhere
     Transformation<Parameters> wrapColorVanilla = new Transformation<Parameters>() {
@@ -729,6 +727,13 @@ public class TransformPatcher implements Patcher {
       }
     };
 
+    // TODO: do iris_LightmapTextureMatrix and iris_TextureMat here
+    Transformation<Parameters> replaceTextureMatrices = new Transformation<Parameters>() {
+      {
+        
+      }
+    };
+
     Transformation<Parameters> wrapModelViewMatrix = new Transformation<Parameters>() {
       {
         addPhase(new SearchTerminalsImpl<Parameters>(new WrapThrowTargetImpl<Parameters>("iris_ModelViewMat")));
@@ -740,13 +745,13 @@ public class TransformPatcher implements Patcher {
                 injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS, "uniform mat4 iris_ModelViewMat;");
                 VanillaParameters vanillaParameters = (VanillaParameters) getJobParameters();
 
-                //TODO these, some of the injections in triforce are actually replacements
+                // TODO these, some of the injections in triforce are actually replacements
                 if (vanillaParameters.hasChunkOffset) {
-                  //TODO
+                  // TODO
                 } else if (vanillaParameters.inputs.isNewLines()) {
-                  //TODO
+                  // TODO
                 } else {
-                  //TODO
+                  // TODO
                 }
               }
             }));

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -1,21 +1,31 @@
 package net.coderbot.iris.pipeline.newshader;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.pattern.ParseTreeMatch;
+import org.antlr.v4.runtime.tree.pattern.ParseTreePattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.douira.glsl_transformer.GLSLParser;
+import io.github.douira.glsl_transformer.GLSLParser.ExternalDeclarationContext;
 import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.core.ReplaceTerminals;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
 import io.github.douira.glsl_transformer.core.WrapIdentifier;
+import io.github.douira.glsl_transformer.core.target.HandlerTarget;
 import io.github.douira.glsl_transformer.core.target.ThrowTarget;
 import io.github.douira.glsl_transformer.print.filter.ChannelFilter;
 import io.github.douira.glsl_transformer.print.filter.TokenFilter;
@@ -24,6 +34,8 @@ import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.SemanticException;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
+import io.github.douira.glsl_transformer.transform.WalkPhase;
+import io.github.douira.glsl_transformer.tree.TreeMember;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
@@ -67,6 +79,10 @@ public class TransformPatcher implements Patcher {
       this.patch = patch;
       this.type = type;
     }
+
+    public AlphaTest getAlphaTest() {
+      return null;
+    }
   }
 
   private static class VanillaParameters extends Parameters {
@@ -80,6 +96,11 @@ public class TransformPatcher implements Patcher {
       this.alpha = alpha;
       this.hasChunkOffset = hasChunkOffset;
       this.inputs = inputs;
+    }
+
+    @Override
+    public AlphaTest getAlphaTest() {
+      return alpha;
     }
   }
 
@@ -99,6 +120,15 @@ public class TransformPatcher implements Patcher {
       this.positionOffset = positionOffset;
       this.textureScale = textureScale;
     }
+
+    @Override
+    public AlphaTest getAlphaTest() {
+      return alpha;
+    }
+  }
+
+  private enum FragColorOutput {
+    COLOR, DATA, CUSTOM
   }
 
   /**
@@ -227,7 +257,193 @@ public class TransformPatcher implements Patcher {
           };
         });
 
-    // TODO: fragColor/fragData patching, see discord messages
+    Transformation<Parameters> wrapFragColorOutput = new Transformation<Parameters>() {
+      private FragColorOutput type;
+      private boolean usesFragColor;
+      private boolean usesFragData;
+      private boolean usesCustomPossible;
+      private boolean usesCustom;
+
+      // a list of the declared custom names
+      private Collection<String> declaredCustomNames;
+
+      // the single custom name that has been used in the code
+      private String usedCustomName;
+
+      @Override
+      protected void resetState() {
+        type = null;
+        usesFragColor = false;
+        usesFragData = false;
+        usesCustomPossible = true;
+        usesCustom = false;
+      }
+
+      {
+        /**
+         * 1. detect use of gl_FragColor, gl_FragData or custom color outputs
+         * custom: find which color outputs write to location 0
+         * syntax: out vec4 <IDENTIFIER>; combined with actual use
+         * throw if there is more than one at the same location being used
+         * (multiple declaration at the same location without multiple use is fine)
+         * 1a. throw if more than one of these options is being used
+         */
+
+        // detect use of gl_FragColor
+        addConcurrentPhase(new SearchTerminals<Parameters>(
+            new HandlerTarget<Parameters>("gl_FragColor") {
+              @Override
+              public void handleResult(TreeMember node, String match) {
+                usesFragColor = true;
+              }
+            }));
+
+        // detect use of gl_FragData
+        addConcurrentPhase(new SearchTerminals<Parameters>(
+            new HandlerTarget<Parameters>("gl_FragData") {
+              @Override
+              public void handleResult(TreeMember node, String match) {
+                usesFragData = true;
+              }
+            }) {
+
+          // throw if there more than one of the two integrated methods is being used
+          @Override
+          protected void afterWalk(TranslationUnitContext ctx) {
+            if (usesFragColor && usesFragData) {
+              throw new SemanticException("gl_FragColor and gl_FragData can't be used at the same time!");
+            }
+          }
+        });
+
+        // detect use of custom color outputs like
+        // "layout (location = 0) out vec4 <IDENTIFIER>"
+        // TODO: what happens when there is no location?
+        addPhase(new WalkPhase<Parameters>() {
+          ParseTreePattern customColorOutPattern;
+
+          @Override
+          protected void init() {
+            customColorOutPattern = compilePattern(
+                "layout (location = 0) out vec4 <name:IDENTIFIER>;",
+                GLSLParser.RULE_externalDeclaration);
+          }
+
+          // if it hasn't thrown yet, using custom is still possible.
+          // init the datastructures for custom name detection
+          @Override
+          protected void beforeWalk(TranslationUnitContext ctx) {
+            declaredCustomNames = new ArrayList<>();
+            usedCustomName = null;
+          }
+
+          // always run the before walk to update the possible variable
+          @Override
+          protected boolean isActiveBeforeWalk() {
+            return true;
+          }
+
+          // only run the walk and after walk if using custom is possible at all
+          @Override
+          protected boolean isActive() {
+            return usesCustomPossible;
+          }
+
+          // using custom names is not possible anymore if none are declared
+          @Override
+          protected void afterWalk(TranslationUnitContext ctx) {
+            usesCustomPossible = !declaredCustomNames.isEmpty();
+          }
+
+          @Override
+          public void enterExternalDeclaration(ExternalDeclarationContext ctx) {
+            ParseTreeMatch match = customColorOutPattern.match(ctx);
+            if (match.succeeded()) {
+              declaredCustomNames.add(match.get("name").getText());
+            }
+          }
+        });
+
+        // if we are doing custom, check if any of the declared names are being used
+        // (and if they are being used multiple times)
+        addPhase(new SearchTerminals<Parameters>(
+            declaredCustomNames.stream()
+                .map(name -> new HandlerTarget<Parameters>(name) {
+                  @Override
+                  public void handleResult(TreeMember node, String match) {
+                    // name is being used, make sure it's the only one
+                    if (usedCustomName == null) {
+                      usedCustomName = name;
+                    } else if (usedCustomName != name) {
+                      // a second name is being used, this is illegal
+                      throw new SemanticException(
+                          "More than two custom color output names can't be used as the same time! '" + name + "' and '"
+                              + usedCustomName + "' were used at the same time.");
+                    }
+                  }
+                })
+                .collect(Collectors.toList())) {
+
+          // only run the walk if there are any names to find but run the after walk for
+          // determining the final frag color type
+          @Override
+          protected boolean isActive() {
+            return usesCustomPossible;
+          }
+
+          @Override
+          protected boolean isActiveAfterWalk() {
+            return true;
+          }
+
+          @Override
+          protected void afterWalk(TranslationUnitContext ctx) {
+            // check if any declared custom names were actually used
+            usesCustom = usedCustomName != null;
+
+            // throw if it's being used together with one of the other two methods
+            // we know that only one of the two can be true at this point
+            if (usesCustom && (usesFragColor || usesFragData)) {
+              throw new SemanticException("Custom color outputs can't be used at the same time as "
+                  + (usesFragColor ? "gl_FragColor" : "gl_FragData") + "!");
+            }
+
+            // finally it's clear which one method is being used
+            type = usesFragColor
+                ? FragColorOutput.COLOR
+                : usesFragData
+                    ? FragColorOutput.DATA
+                    : FragColorOutput.CUSTOM;
+          }
+        });
+
+        // 2. wrap their use: create a new output like
+        // "out vec4 iris_FragColor/iris_FragData[8];"
+        // 3. redirect gl_Frag* to the newly created output (replace identifiers)
+
+        // TODO: merge a wrap identifier phase into this one
+
+        /**
+         * 4. if alpha test is given, apply it with iris_FragColor/iris_FragData[0].
+         * use the custom color output at location 0 for the alpha test requires
+         * adjustment
+         * of the alpha test code?
+         **/
+        addPhase(new RunPhase<TransformPatcher.Parameters>() {
+          @Override
+          protected boolean isActive() {
+            return getJobParameters().getAlphaTest() != null;
+          }
+
+          @Override
+          protected void run(TranslationUnitContext ctx) {
+            AlphaTest alpha = getJobParameters().getAlphaTest();
+
+            // TODO: handle alpha test
+          }
+        });
+      }
+    };
 
     Transformation<Parameters> replaceStorageQualifierVertex = new Transformation<Parameters>(
         new SearchTerminals<Parameters>() {
@@ -296,9 +512,8 @@ public class TransformPatcher implements Patcher {
         if (type == ShaderType.VERTEX) {
           manager.registerTransformation(wrapFrontColor);
           manager.registerTransformation(replaceStorageQualifierVertex);
-        }
-
-        if (type == ShaderType.FRAGMENT) {
+        } else if (type == ShaderType.FRAGMENT) {
+          manager.registerTransformation(wrapFragColorOutput);
           manager.registerTransformation(replaceStorageQualifierFragment);
           manager.registerTransformation(injectTextureFunctionsFragment);
         }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -731,12 +731,23 @@ public class TransformPatcher implements Patcher {
 
     Transformation<Parameters> wrapModelViewMatrix = new Transformation<Parameters>() {
       {
+        addPhase(new SearchTerminalsImpl<Parameters>(new WrapThrowTargetImpl<Parameters>("iris_ModelViewMat")));
         append(WrapIdentifier.fromExpression(
             "gl_NormalMatrix", "gl_ModelViewMatrix", "mat3(transpose(inverse(gl_ModelViewMatrix)))",
             new RunPhase<Parameters>() {
               @Override
               protected void run(TranslationUnitContext ctx) {
+                injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS, "uniform mat4 iris_ModelViewMat;");
+                VanillaParameters vanillaParameters = (VanillaParameters) getJobParameters();
 
+                //TODO these, some of the injections in triforce are actually replacements
+                if (vanillaParameters.hasChunkOffset) {
+                  //TODO
+                } else if (vanillaParameters.inputs.isNewLines()) {
+                  //TODO
+                } else {
+                  //TODO
+                }
               }
             }));
       }
@@ -782,6 +793,7 @@ public class TransformPatcher implements Patcher {
             manager.registerTransformation(wrapAttributeInputsVanillaVertex);
           }
           manager.registerTransformation(wrapColorVanilla);
+          manager.registerTransformation(wrapModelViewMatrix);
         }
 
         // patchSodium

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -16,6 +16,17 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
  * The transform patcher uses glsl-transformer to do shader transformation. It
  * delegates the things it doesn't do itself to TriforcePatcher by either not
  * overwriting methods or calling them itself.
+ * 
+ * NOTE: A separate TransformationManager should be created for each ShaderType.
+ * That makes each of them more efficient as they don't need to run unnecessary
+ * transformation phases.
+ * 
+ * TODO: good examples for more complex transformation in triforce patcher?
+ * ideas: BuiltinUniformReplacementTransformer, defines/replacements with loops,
+ * replacements that account for whitespace like the one for gl_TextureMatrix
+ * 
+ * TODO: how are defines handled? glsl-transformer can't deal with code that is
+ * not valid GLSL code. Directives like #if will mess it up.
  */
 public class TransformPatcher extends TriforcePatcher {
   /*

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -15,12 +15,10 @@ import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.core.ReplaceTerminals;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
 import io.github.douira.glsl_transformer.core.WrapIdentifier;
-import io.github.douira.glsl_transformer.core.target.TerminalReplaceTarget;
 import io.github.douira.glsl_transformer.core.target.ThrowTarget;
 import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
-import io.github.douira.glsl_transformer.transform.TransformationPhase;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
@@ -157,10 +155,8 @@ public class TransformPatcher implements Patcher {
      * passes. A shader that relies on this behavior is SEUS v11 - it reads
      * gl_Fog.color and breaks if it is not properly defined.
      */
-    // TODO: use terminal wrapper method
-    Transformation<Parameters> wrapFogSetup = new WrapIdentifier<>(
+    Transformation<Parameters> wrapFogSetup = WrapIdentifier.fromTerminal(
         "gl_Fog", "iris_Fog",
-        new TerminalReplaceTarget<>("gl_Fog", "iris_Fog"),
         new RunPhase<Parameters>() {
           @Override
           protected void run(TranslationUnitContext ctx) {
@@ -182,10 +178,8 @@ public class TransformPatcher implements Patcher {
         });
 
     // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
-    // TODO: use terminal wrapper method
-    Transformation<Parameters> wrapFogFragCoord = new WrapIdentifier<>(
+    Transformation<Parameters> wrapFogFragCoord = WrapIdentifier.fromTerminal(
         "gl_FogFragCoord", "iris_FogFragCoord",
-        new TerminalReplaceTarget<>("gl_FogFragCoord", "iris_FogFragCoord"),
         new RunPhase<Parameters>() {
           @Override
           protected void run(TranslationUnitContext ctx) {
@@ -205,10 +199,8 @@ public class TransformPatcher implements Patcher {
      * & Renewed to compile. It works because they don't actually use gl_FrontColor
      * even though they write to it.
      */
-    // TODO: use terminal wrapper method
-    Transformation<Parameters> wrapFrontColor = new WrapIdentifier<>(
+    Transformation<Parameters> wrapFrontColor = WrapIdentifier.fromTerminal(
         "gl_FrontColor", "iris_FrontColor",
-        new TerminalReplaceTarget<>("gl_FrontColor", "iris_FrontColor"),
         new RunPhase<Parameters>() {
           @Override
           protected void run(TranslationUnitContext ctx) {

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -406,6 +406,7 @@ public class TransformPatcher implements Patcher {
           protected void afterWalk(TranslationUnitContext ctx) {
             // check if any declared custom names were actually used
             usesCustom = usedCustomName != null;
+            usesCustomPossible = usesCustom;
 
             // throw if it's being used together with one of the other two methods
             // we know that only one of the two can be true at this point
@@ -427,7 +428,7 @@ public class TransformPatcher implements Patcher {
         // "out vec4 iris_FragColor/iris_FragData[8];"
         // 3. redirect gl_Frag* to the newly created output (replace identifiers)
 
-        
+        // TODO: use WrapIdentifier but make it extensible and dynamic in glsl-transformer first
 
         /**
          * 4. if alpha test is given, apply it with iris_FragColor/iris_FragData[0].

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -42,21 +42,56 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
 public class TransformPatcher implements Patcher {
   private static final Logger LOGGER = LogManager.getLogger(TransformPatcher.class);
 
-  private Table<Patch, ShaderType, TransformationManager> managers = HashBasedTable.create(
-      Patch.values().length,
-      ShaderType.values().length);
-
   private static enum Patch {
     VANILLA, SODIUM, COMPOSITE
   }
+
+  private static class VanillaParameters {
+    public final AlphaTest alpha;
+    public final boolean hasChunkOffset;
+    public final ShaderAttributeInputs inputs;
+
+    public VanillaParameters(AlphaTest alpha, boolean hasChunkOffset, ShaderAttributeInputs inputs) {
+      this.alpha = alpha;
+      this.hasChunkOffset = hasChunkOffset;
+      this.inputs = inputs;
+    }
+  }
+
+  private static class SodiumParameters {
+    public final AlphaTest alpha;
+    public final ShaderAttributeInputs inputs;
+    public final float positionScale;
+    public final float positionOffset;
+    public final float textureScale;
+
+    public SodiumParameters(AlphaTest alpha, ShaderAttributeInputs inputs, float positionScale,
+        float positionOffset, float textureScale) {
+      this.alpha = alpha;
+      this.inputs = inputs;
+      this.positionScale = positionScale;
+      this.positionOffset = positionOffset;
+      this.textureScale = textureScale;
+    }
+  }
+
+  /**
+   * A transformation manager is kept for each patch type and shader type for
+   * better performance since it allows the phase collector to compact the whole
+   * run better. The object parameter can be filled with one of the parameter
+   * classes and the transformation phases have to do their own casts.
+   */
+  private Table<Patch, ShaderType, TransformationManager<Object>> managers = HashBasedTable.create(
+      Patch.values().length,
+      ShaderType.values().length);
 
   public TransformPatcher() {
     // PREV TODO: Only do the NewLines patches if the source code isn't from
     // gbuffers_lines
 
     // setup the transformations and even loose phases if necessary
-    Transformation detectReserved = new Transformation(
-        new SearchTerminals(SearchTerminals.IDENTIFIER,
+    Transformation<Object> detectReserved = new Transformation<>(
+        new SearchTerminals<>(SearchTerminals.IDENTIFIER,
             ImmutableSet.of(
                 ThrowTarget.fromMessage(
                     "moj_import", "Iris shader programs may not use moj_import directives."),
@@ -64,7 +99,7 @@ public class TransformPatcher implements Patcher {
                     "iris_",
                     "Detected a potential reference to unstable and internal Iris shader interfaces (iris_). This isn't currently supported."))));
 
-    Transformation fixVersion = new Transformation(new RunPhase() {
+    Transformation<Object> fixVersion = new Transformation<>(new RunPhase<Object>() {
       /**
        * This largely replicates the behavior of
        * {@link net.coderbot.iris.pipeline.newshader.TriforcePatcher#fixVersion(Transformations)}
@@ -105,7 +140,7 @@ public class TransformPatcher implements Patcher {
      * passes. A shader that relies on this behavior is SEUS v11 - it reads
      * gl_Fog.color and breaks if it is not properly defined.
      */
-    TransformationPhase sharedFogSetup = new RunPhase() {
+    TransformationPhase<Object> sharedFogSetup = new RunPhase<Object>() {
       @Override
       protected void run(TranslationUnitContext ctx) {
         injectExternalDeclaration(
@@ -127,11 +162,14 @@ public class TransformPatcher implements Patcher {
 
     // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
     // TODO: update to use new glsl-transformer features to make this compact
-    ReplaceTerminals wrapFogFragCoord = new ReplaceTerminals(ReplaceTerminals.IDENTIFIER);
-    wrapFogFragCoord.addReplacementTerminal("gl_FogFragCoord", "iris_FogFragCoord");
+    SearchTerminals<Object> wrapFogFragCoord = new SearchTerminals<Object>() {
+      {
+        addReplacementTerminal("gl_FogFragCoord", "iris_FogFragCoord");
+      }
+    };
 
     // PREV TODO: This doesn't handle geometry shaders... How do we do that?
-    TransformationPhase injectOutFogFragCoord = new RunPhase() {
+    TransformationPhase<Object> injectOutFogFragCoord = new RunPhase<Object>() {
       @Override
       protected void run(TranslationUnitContext ctx) {
         injectExternalDeclaration(
@@ -139,7 +177,7 @@ public class TransformPatcher implements Patcher {
       };
     };
 
-    TransformationPhase injectInFogFragCoord = new RunPhase() {
+    TransformationPhase<Object> injectInFogFragCoord = new RunPhase<Object>() {
       @Override
       protected void run(TranslationUnitContext ctx) {
         injectExternalDeclaration(
@@ -153,26 +191,31 @@ public class TransformPatcher implements Patcher {
      * even though they write to it.
      */
     // TODO: use glsl-transformer core wrapping transformation for this
-    TransformationPhase frontColorInjection = new RunPhase() {
+    TransformationPhase<Object> frontColorInjection = new RunPhase<Object>() {
       @Override
       protected void run(TranslationUnitContext ctx) {
         injectExternalDeclaration(
             "vec4 iris_FrontColor;", InjectionPoint.BEFORE_DECLARATIONS);
       };
     };
-    ReplaceTerminals wrapFrontColor = new ReplaceTerminals(ReplaceTerminals.IDENTIFIER);
-    wrapFogFragCoord.addReplacementTerminal("gl_FrontColor", "iris_FrontColor");
+
+    // TODO use shorthand method
+    SearchTerminals<Object> wrapFrontColor = new SearchTerminals<Object>() {
+      {
+        addReplacementTerminal("gl_FrontColor", "iris_FrontColor");
+      }
+    };
 
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
       for (ShaderType type : ShaderType.values()) {
-        TransformationManager manager = new TransformationManager();
+        TransformationManager<Object> manager = new TransformationManager<>();
         managers.put(patch, type, manager);
 
         manager.registerTransformation(detectReserved);
         manager.registerTransformation(fixVersion);
 
-        Transformation commonInjections = new Transformation();
+        Transformation<Object> commonInjections = new Transformation<>();
         manager.registerTransformation(commonInjections);
 
         //TODO: use addConcurrentPhase to make this more compact
@@ -197,18 +240,20 @@ public class TransformPatcher implements Patcher {
   public String patchVanilla(
       String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset,
       ShaderAttributeInputs inputs) {
-    return managers.get(Patch.VANILLA, type).transform(source);
+    return managers.get(Patch.VANILLA, type)
+        .transform(source, new VanillaParameters(alpha, hasChunkOffset, inputs));
   }
 
   @Override
   public String patchSodium(
       String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs,
       float positionScale, float positionOffset, float textureScale) {
-    return null;
+    return managers.get(Patch.VANILLA, type)
+        .transform(source, new SodiumParameters(alpha, inputs, positionScale, positionOffset, textureScale));
   }
 
   @Override
   public String patchComposite(String source, ShaderType type) {
-    return null;
+    return managers.get(Patch.VANILLA, type).transform(source, null);
   }
 }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -446,11 +446,12 @@ public class TransformPatcher implements Patcher {
           }
         });
 
-        // 2. wrap their use: create a new output like
-        // "out vec4 iris_FragColor/iris_FragData[8];"
-        // 3. redirect gl_Frag* to the newly created output (replace identifiers)
-
-        // throw if the replacement target is present already
+        /**
+         * 2. wrap their use: create a new output like
+         * "out vec4 iris_FragColor/iris_FragData[8];"
+         * (throw if the replacement target is present already)
+         * 3. redirect gl_Frag* to the newly created output (replace identifiers)
+         */
         append(new WrapIdentifierExternalDeclaration<Parameters>() {
           @Override
           protected String getInjectionContent() {

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -533,8 +533,6 @@ public class TransformPatcher implements Patcher {
           }
         });
 
-    // foo =
-
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
       for (ShaderType type : ShaderType.values()) {
@@ -563,10 +561,6 @@ public class TransformPatcher implements Patcher {
         }
 
         manager.registerTransformation(injectTextureFunctions);
-
-        if (patch == Patch.VANILLA) {
-          // manager.registerTransformation(foo);
-        }
       }
     }
   }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -19,13 +19,10 @@ import io.github.douira.glsl_transformer.GLSLParser;
 import io.github.douira.glsl_transformer.GLSLParser.ExternalDeclarationContext;
 import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
-import io.github.douira.glsl_transformer.ast.StringNode;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
-import io.github.douira.glsl_transformer.core.WrapIdentifierImpl;
+import io.github.douira.glsl_transformer.core.WrapIdentifier;
+import io.github.douira.glsl_transformer.core.WrapIdentifierExternalDeclaration;
 import io.github.douira.glsl_transformer.core.target.HandlerTargetImpl;
-import io.github.douira.glsl_transformer.core.target.ReplaceTarget;
-import io.github.douira.glsl_transformer.core.target.TerminalReplaceTarget;
-import io.github.douira.glsl_transformer.core.target.ThrowTarget;
 import io.github.douira.glsl_transformer.core.target.ThrowTargetImpl;
 import io.github.douira.glsl_transformer.print.filter.ChannelFilter;
 import io.github.douira.glsl_transformer.print.filter.TokenChannel;
@@ -209,7 +206,7 @@ public class TransformPatcher implements Patcher {
      * passes. A shader that relies on this behavior is SEUS v11 - it reads
      * gl_Fog.color and breaks if it is not properly defined.
      */
-    Transformation<Parameters> wrapFogSetup = WrapIdentifierImpl.fromTerminal(
+    Transformation<Parameters> wrapFogSetup = WrapIdentifier.fromTerminal(
         "gl_Fog", "iris_Fog",
         new RunPhase<Parameters>() {
           @Override
@@ -226,7 +223,7 @@ public class TransformPatcher implements Patcher {
         });
 
     // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
-    Transformation<Parameters> wrapFogFragCoord = WrapIdentifierImpl.fromTerminal(
+    Transformation<Parameters> wrapFogFragCoord = WrapIdentifier.fromTerminal(
         "gl_FogFragCoord", "iris_FogFragCoord",
         new RunPhase<Parameters>() {
           @Override
@@ -247,7 +244,7 @@ public class TransformPatcher implements Patcher {
      * & Renewed to compile. It works because they don't actually use gl_FrontColor
      * even though they write to it.
      */
-    Transformation<Parameters> wrapFrontColor = WrapIdentifierImpl.fromTerminal(
+    Transformation<Parameters> wrapFrontColor = WrapIdentifier.fromTerminal(
         "gl_FrontColor", "iris_FrontColor",
         new RunPhase<Parameters>() {
           @Override
@@ -454,52 +451,24 @@ public class TransformPatcher implements Patcher {
         // 3. redirect gl_Frag* to the newly created output (replace identifiers)
 
         // throw if the replacement target is present already
-        //TODO: use new glsl-transformer features to make this more compact (WrapTarget)
-        addPhase(new SearchTerminals<Parameters>(new ThrowTarget<Parameters>() {
+        append(new WrapIdentifierExternalDeclaration<Parameters>() {
           @Override
-          public String getMessage(TreeMember node, String match) {
-            // TODO: do this better instead of copying from glsl-transformer's
-            // WrapIdentifier
-            return "The wrapper '" + match + "' shouldn't already be present in the code!";
+          protected String getInjectionContent() {
+            return "out vec4 " + (type == FragColorOutput.COLOR ? "iris_FragColor" : "iris_FragData[8]") + ";";
           }
 
           @Override
-          public String getNeedle() {
-            return fragColorWrapResult;
-          }
-        }) {
-          @Override
-          protected boolean isActive() {
-            return type == FragColorOutput.COLOR || type == FragColorOutput.DATA;
-          }
-        });
-
-        addPhase(new SearchTerminals<Parameters>(new TerminalReplaceTarget<Parameters>() {
-          @Override
-          protected String getTerminalContent() {
+          protected String getWrapResultDynamic() {
             return fragColorWrapResult;
           }
 
           @Override
-          public String getNeedle() {
+          protected String getWrapTargetDynamic() {
             return fragColorWrapTarget;
           }
-        }) {
-          @Override
-          protected boolean isActive() {
-            return type == FragColorOutput.COLOR || type == FragColorOutput.DATA;
-          }
-        });
-
-        addPhase(new RunPhase<Parameters>() {
-          @Override
-          protected void run(TranslationUnitContext ctx) {
-            injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS,
-                "out vec4 " + (type == FragColorOutput.COLOR ? "iris_FragColor" : "iris_FragData[8]") + ";");
-          }
 
           @Override
-          protected boolean isActive() {
+          protected boolean isActiveDynamic() {
             return type == FragColorOutput.COLOR || type == FragColorOutput.DATA;
           }
         });

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -1,0 +1,105 @@
+package net.coderbot.iris.pipeline.newshader;
+
+import java.util.Optional;
+
+import io.github.douira.glsl_transformer.GLSLParser;
+import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
+import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
+import io.github.douira.glsl_transformer.transform.RunPhase;
+import io.github.douira.glsl_transformer.transform.Transformation;
+import io.github.douira.glsl_transformer.transform.TransformationManager;
+import net.coderbot.iris.gl.blending.AlphaTest;
+import net.coderbot.iris.gl.shader.ShaderType;
+import net.coderbot.iris.shaderpack.transform.Transformations;
+
+/**
+ * The transform patcher uses glsl-transformer to do shader transformation. It
+ * delegates the things it doesn't do itself to TriforcePatcher by either not
+ * overwriting methods or calling them itself.
+ */
+public class TransformPatcher extends TriforcePatcher {
+  /*
+   * if glsl-transformer is used for everything, then there is no common, just
+   * three managers that share some but not all transformations
+   * private static TransformationManager vanillaManager = new
+   * TransformationManager();
+   * private static TransformationManager sodiumManager = new
+   * TransformationManager();
+   * private static TransformationManager compositeManager = new
+   * TransformationManager();
+   */
+  private static TransformationManager commonManager = new TransformationManager();
+
+  static {
+    Transformation fixVersion = new Transformation(new RunPhase() {
+      /**
+       * This largely replicates the behavior of
+       * {@link net.coderbot.iris.pipeline.newshader.TriforcePatcher#fixVersion(Transformations)}
+       */
+      @Override
+      protected void run(TranslationUnitContext ctx) {
+        VersionStatementContext versionStatement = ctx.versionStatement();
+        if (versionStatement == null) {
+          throw new IllegalStateException("Missing the version statement!");
+        }
+
+        String profile = Optional.ofNullable(versionStatement.NR_IDENTIFIER())
+            .map(terminal -> terminal.getText())
+            .orElse("");
+        int version = Integer.parseInt(versionStatement.NR_INTCONSTANT().getText());
+
+        if (profile.equals("core")) {
+          throw new IllegalStateException("Transforming a shader that is already built against the core profile???");
+        }
+
+        if (version >= 200) {
+          if (!profile.equals("compatibility")) {
+            throw new IllegalStateException(
+                "Expected \"compatibility\" after the GLSL version: #version " + version + " " + profile);
+          }
+        } else {
+          version = 150;
+        }
+        profile = "core";
+
+        replaceNode(versionStatement, "#version " + version + " " + profile, GLSLParser::versionStatement);
+      }
+    });
+
+    commonManager.registerTransformation(fixVersion);
+  }
+
+  @Override
+  public String patchVanilla(
+      String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset,
+      ShaderAttributeInputs inputs) {
+    return super.patchVanilla(source, type, alpha, hasChunkOffset, inputs);
+  }
+
+  @Override
+  public String patchSodium(
+      String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs,
+      float positionScale, float positionOffset, float textureScale) {
+    return super.patchSodium(
+        source, type, alpha, inputs, positionScale, positionOffset, textureScale);
+  }
+
+  @Override
+  public String patchComposite(String source, ShaderType type) {
+    return super.patchComposite(source, type);
+  }
+
+  @Override
+  String patchCommon(String input, ShaderType type) {
+    System.out.println(input);
+    input = commonManager.transform(input);
+    System.out.println(input);
+
+    return super.patchCommon(input, type);
+  }
+
+  @Override
+  void fixVersion(Transformations transformations) {
+    // do nothing because this patcher does itself
+  }
+}

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -14,14 +14,12 @@ import com.google.common.collect.Table;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.pattern.ParseTreeMatch;
 import org.antlr.v4.runtime.tree.pattern.ParseTreePattern;
-import org.antlr.v4.runtime.tree.xpath.XPath;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.douira.glsl_transformer.GLSLParser;
 import io.github.douira.glsl_transformer.GLSLParser.ExpressionContext;
 import io.github.douira.glsl_transformer.GLSLParser.ExternalDeclarationContext;
-import io.github.douira.glsl_transformer.GLSLParser.PostfixExpressionContext;
 import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
@@ -32,6 +30,7 @@ import io.github.douira.glsl_transformer.core.WrapIdentifierExternalDeclaration;
 import io.github.douira.glsl_transformer.core.target.HandlerTarget;
 import io.github.douira.glsl_transformer.core.target.HandlerTargetImpl;
 import io.github.douira.glsl_transformer.core.target.ParsedReplaceTarget;
+import io.github.douira.glsl_transformer.core.target.ParsedReplaceTargetImpl;
 import io.github.douira.glsl_transformer.core.target.TerminalReplaceTargetImpl;
 import io.github.douira.glsl_transformer.core.target.ThrowTargetImpl;
 import io.github.douira.glsl_transformer.core.target.WrapThrowTargetImpl;
@@ -42,7 +41,6 @@ import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.SemanticException;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
-import io.github.douira.glsl_transformer.transform.TransformationPhase;
 import io.github.douira.glsl_transformer.transform.TransformationPhase.InjectionPoint;
 import io.github.douira.glsl_transformer.transform.WalkPhase;
 import io.github.douira.glsl_transformer.tree.ExtendedContext;
@@ -75,7 +73,8 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
  * TODO: how are defines handled? glsl-transformer can't deal with code that is
  * not valid GLSL code. Directives like #if will mess it up.
  * TODO: use new glsl-transformer features on RunPhase to make all the RunPhase
- * subclasses much more comapct (just one method call)
+ * subclasses much more comapct (just one method call:
+ * withInjectExternalDeclarations)
  */
 public class TransformPatcher implements Patcher {
   private static final Logger LOGGER = LogManager.getLogger(TransformPatcher.class);
@@ -735,7 +734,7 @@ public class TransformPatcher implements Patcher {
 
     // PREV TODO: More solid way to handle texture matrices
     // TODO: test if this actually works
-    Transformation<Parameters> wrapTextureMatrices = new Transformation<Parameters>() {
+    Transformation<Parameters> wrapTextureMatricesVanilla = new Transformation<Parameters>() {
       boolean replacementHappened;
 
       @Override
@@ -792,29 +791,126 @@ public class TransformPatcher implements Patcher {
       }
     };
 
-    Transformation<Parameters> wrapModelViewMatrix = new Transformation<Parameters>() {
-      {
-        addPhase(new SearchTerminalsImpl<Parameters>(new WrapThrowTargetImpl<Parameters>("iris_ModelViewMat")));
-        append(WrapIdentifier.fromExpression(
-            "gl_NormalMatrix", "gl_ModelViewMatrix", "mat3(transpose(inverse(gl_ModelViewMatrix)))",
-            new RunPhase<Parameters>() {
-              @Override
-              protected void run(TranslationUnitContext ctx) {
-                injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS, "uniform mat4 iris_ModelViewMat;");
-                VanillaParameters vanillaParameters = (VanillaParameters) getJobParameters();
+    // PREV TODO: Should probably add the normal matrix as a proper uniform that's
+    // computed on the CPU-side of things
+    Transformation<Parameters> wrapModelViewMatrixVanilla = new Transformation<Parameters>() {
+      String modelViewMatrixResult;
+      ModelViewMatrixType type;
 
-                // TODO these, some of the injections in triforce are actually replacements
-                if (vanillaParameters.hasChunkOffset) {
-                  // TODO
-                } else if (vanillaParameters.inputs.isNewLines()) {
-                  // TODO
-                } else {
-                  // TODO
-                }
+      enum ModelViewMatrixType {
+        CHUNK_OFFSET, NEW_LINES, DEFAULT
+      }
+
+      {
+        addPhase(new SearchTerminalsDynamic<Parameters>() {
+          // determine the model view matrix result and what the mode is
+          @Override
+          protected void beforeWalk(TranslationUnitContext ctx) {
+            VanillaParameters vanillaParameters = (VanillaParameters) getJobParameters();
+            if (vanillaParameters.hasChunkOffset) {
+              modelViewMatrixResult = "(iris_ModelViewMat * _iris_internal_translate(iris_ChunkOffset))";
+              type = ModelViewMatrixType.CHUNK_OFFSET;
+            } else if (vanillaParameters.inputs.isNewLines()) {
+              modelViewMatrixResult = "(iris_VIEW_SCALE * iris_ModelViewMat)";
+              type = ModelViewMatrixType.NEW_LINES;
+            } else {
+              modelViewMatrixResult = "iris_ModelViewMat";
+              type = ModelViewMatrixType.DEFAULT;
+            }
+          }
+
+          // detect pre-existing injection results
+          @Override
+          protected Collection<HandlerTarget<Parameters>> getTargetsDynamic() {
+            Collection<HandlerTarget<Parameters>> targets = new ArrayList<>();
+            targets.add(new WrapThrowTargetImpl<Parameters>("iris_ModelViewMat"));
+
+            if (type == ModelViewMatrixType.CHUNK_OFFSET) {
+              targets.add(new WrapThrowTargetImpl<Parameters>("iris_ChunkOffset"));
+              targets.add(new WrapThrowTargetImpl<Parameters>("_iris_internal_translate"));
+            } else if (type == ModelViewMatrixType.NEW_LINES) {
+              targets.add(new WrapThrowTargetImpl<Parameters>("iris_VIEW_SCALE"));
+              targets.add(new WrapThrowTargetImpl<Parameters>("iris_VIEW_SHRINK"));
+            }
+
+            return targets;
+          }
+        });
+
+        // do variable replacements
+        addPhase(new SearchTerminalsImpl<>(List.of(
+            new ParsedReplaceTarget<>("gl_ModelViewMatrix") {
+              @Override
+              protected String getNewContent(TreeMember node, String match) {
+                return modelViewMatrixResult;
               }
-            }));
+
+              @Override
+              protected Function<GLSLParser, ExtendedContext> getParseMethod(TreeMember node, String match) {
+                return GLSLParser::expression;
+              }
+            },
+            new ParsedReplaceTarget<>("gl_NormalMatrix") {
+              @Override
+              protected String getNewContent(TreeMember node, String match) {
+                return "mat3(transpose(inverse(" + modelViewMatrixResult + ")))";
+              }
+
+              @Override
+              protected Function<GLSLParser, ExtendedContext> getParseMethod(TreeMember node, String match) {
+                return GLSLParser::expression;
+              }
+            },
+            new ParsedReplaceTarget<>("gl_ModelViewProjectionMatrix") {
+              @Override
+              protected String getNewContent(TreeMember node, String match) {
+                return "(gl_ProjectionMatrix * " + modelViewMatrixResult + ")";
+              }
+
+              @Override
+              protected Function<GLSLParser, ExtendedContext> getParseMethod(TreeMember node, String match) {
+                return GLSLParser::expression;
+              }
+            })));
+
+        // do fixed and conditional injections
+        addPhase(new RunPhase<Parameters>() {
+          @Override
+          protected void run(TranslationUnitContext ctx) {
+            injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS, "uniform mat4 iris_ModelViewMat;");
+
+            if (type == ModelViewMatrixType.CHUNK_OFFSET) {
+              injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS, "uniform vec3 iris_ChunkOffset;");
+              injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS,
+                  "mat4 _iris_internal_translate(vec3 offset) {\n" +
+                      "    // NB: Column-major order\n" +
+                      "    return mat4(1.0, 0.0, 0.0, 0.0,\n" +
+                      "                0.0, 1.0, 0.0, 0.0,\n" +
+                      "                0.0, 0.0, 1.0, 0.0,\n" +
+                      "                offset.x, offset.y, offset.z, 1.0);\n" +
+                      "}");
+            } else if (type == ModelViewMatrixType.NEW_LINES) {
+              injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS,
+                  "const float iris_VIEW_SHRINK = 1.0 - (1.0 / 256.0);");
+              injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS,
+                  "const mat4 iris_VIEW_SCALE = mat4(\n" +
+                      "    iris_VIEW_SHRINK, 0.0, 0.0, 0.0,\n" +
+                      "    0.0, iris_VIEW_SHRINK, 0.0, 0.0,\n" +
+                      "    0.0, 0.0, iris_VIEW_SHRINK, 0.0,\n" +
+                      "    0.0, 0.0, 0.0, 1.0\n" +
+                      ");");
+            }
+          }
+        });
       }
     };
+
+    Transformation<Parameters> replaceModelViewProjectionVanilla = new Transformation<Parameters>(
+        SearchTerminalsImpl.withReplacementExpression(
+            "gl_ModelViewProjectionMatrix",
+            "(gl_ProjectionMatrix * gl_ModelViewMatrix)"));
+
+    // TODO: continue with vanilla's vertex-specific block (the last one)
 
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
@@ -856,8 +952,9 @@ public class TransformPatcher implements Patcher {
             manager.registerTransformation(wrapAttributeInputsVanillaVertex);
           }
           manager.registerTransformation(wrapColorVanilla);
-          manager.registerTransformation(wrapTextureMatrices);
-          manager.registerTransformation(wrapModelViewMatrix);
+          manager.registerTransformation(wrapTextureMatricesVanilla);
+          manager.registerTransformation(wrapModelViewMatrixVanilla);
+          manager.registerTransformation(replaceModelViewProjectionVanilla);
         }
 
         // patchSodium

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.pipeline.newshader;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -31,6 +32,7 @@ import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.SemanticException;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
+import io.github.douira.glsl_transformer.transform.TransformationPhase.InjectionPoint;
 import io.github.douira.glsl_transformer.transform.WalkPhase;
 import io.github.douira.glsl_transformer.tree.TreeMember;
 import net.coderbot.iris.gl.blending.AlphaTest;
@@ -512,22 +514,36 @@ public class TransformPatcher implements Patcher {
 
         /**
          * 4. if alpha test is given, apply it with iris_FragColor/iris_FragData[0].
-         * use the custom color output at location 0 for the alpha test requires
-         * adjustment
-         * of the alpha test code?
          **/
-        addPhase(new RunPhase<Parameters>() {
+        append(new WrapIdentifierExternalDeclaration<Parameters>() {
           @Override
-          protected boolean isActive() {
-            Patch patch = getJobParameters().patch;
-            return (patch == Patch.VANILLA || patch == Patch.SODIUM) && getJobParameters().getAlphaTest() != null;
+          protected String getInjectionContent() {
+            // inserts the alpha test, it is not null because it shouldn't be
+            return "void main() { irisMain(); "
+                + getJobParameters().getAlphaTest().toExpression(
+                    type == FragColorOutput.COLOR ? "gl_FragColor.a" : "gl_FragData[0].a", "")
+                + "}";
           }
 
           @Override
-          protected void run(TranslationUnitContext ctx) {
-            AlphaTest alpha = getJobParameters().getAlphaTest();
+          protected InjectionPoint getInjectionLocation() {
+            return InjectionPoint.BEFORE_EOF;
+          }
 
-            // TODO: handle alpha test
+          @Override
+          protected String getWrapResultDynamic() {
+            return "irisMain";
+          }
+
+          @Override
+          protected String getWrapTargetDynamic() {
+            return "main";
+          }
+
+          @Override
+          protected boolean isActiveDynamic() {
+            Patch patch = getJobParameters().patch;
+            return (patch == Patch.VANILLA || patch == Patch.SODIUM) && getJobParameters().getAlphaTest() != null;
           }
         });
       }
@@ -567,17 +583,17 @@ public class TransformPatcher implements Patcher {
           manager.registerTransformation(wrapFragColorOutput);
         }
 
-        //patchVanilla
+        // patchVanilla
         if (patch == Patch.VANILLA) {
 
         }
-        
-        //patchSodium
+
+        // patchSodium
         if (patch == Patch.SODIUM) {
 
         }
 
-        //patchComposite
+        // patchComposite
         if (patch == Patch.COMPOSITE) {
 
         }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -2,16 +2,23 @@ package net.coderbot.iris.pipeline.newshader;
 
 import java.util.Optional;
 
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.douira.glsl_transformer.GLSLParser;
 import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
+import io.github.douira.glsl_transformer.core.ReplaceTerminals;
+import io.github.douira.glsl_transformer.core.SearchTerminals;
+import io.github.douira.glsl_transformer.core.target.ThrowTarget;
 import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
-import io.github.douira.glsl_transformer.transform.WalkPhase;
+import io.github.douira.glsl_transformer.transform.TransformationPhase;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
@@ -32,22 +39,31 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
  * TODO: how are defines handled? glsl-transformer can't deal with code that is
  * not valid GLSL code. Directives like #if will mess it up.
  */
-public class TransformPatcher extends TriforcePatcher {
+public class TransformPatcher implements Patcher {
   private static final Logger LOGGER = LogManager.getLogger(TransformPatcher.class);
 
-  /*
-   * if glsl-transformer is used for everything, then there is no common, just
-   * three managers that share some but not all transformations
-   * private static TransformationManager vanillaManager = new
-   * TransformationManager();
-   * private static TransformationManager sodiumManager = new
-   * TransformationManager();
-   * private static TransformationManager compositeManager = new
-   * TransformationManager();
-   */
-  private static TransformationManager commonManager = new TransformationManager();
+  private Table<Patch, ShaderType, TransformationManager> managers = HashBasedTable.create(
+      Patch.values().length,
+      ShaderType.values().length);
 
-  static {
+  private static enum Patch {
+    VANILLA, SODIUM, COMPOSITE
+  }
+
+  public TransformPatcher() {
+    // PREV TODO: Only do the NewLines patches if the source code isn't from
+    // gbuffers_lines
+
+    // setup the transformations and even loose phases if necessary
+    Transformation detectReserved = new Transformation(
+        new SearchTerminals(SearchTerminals.IDENTIFIER,
+            ImmutableSet.of(
+                ThrowTarget.fromMessage(
+                    "moj_import", "Iris shader programs may not use moj_import directives."),
+                ThrowTarget.fromMessage(
+                    "iris_",
+                    "Detected a potential reference to unstable and internal Iris shader interfaces (iris_). This isn't currently supported."))));
+
     Transformation fixVersion = new Transformation(new RunPhase() {
       /**
        * This largely replicates the behavior of
@@ -83,49 +99,116 @@ public class TransformPatcher extends TriforcePatcher {
       }
     });
 
-    // TODO: detection of moj_import and iris_ uses: see a subclass of FindTerminals in glsl-transformer
+    /**
+     * PREV NOTE:
+     * This must be defined and valid in all shader passes, including composite
+     * passes. A shader that relies on this behavior is SEUS v11 - it reads
+     * gl_Fog.color and breaks if it is not properly defined.
+     */
+    TransformationPhase sharedFogSetup = new RunPhase() {
+      @Override
+      protected void run(TranslationUnitContext ctx) {
+        injectExternalDeclaration(
+            "uniform float iris_FogDensity;", InjectionPoint.BEFORE_DECLARATIONS);
+        injectExternalDeclaration(
+            "uniform float iris_FogStart;", InjectionPoint.BEFORE_DECLARATIONS);
+        injectExternalDeclaration(
+            "uniform float iris_FogEnd;", InjectionPoint.BEFORE_DECLARATIONS);
+        injectExternalDeclaration(
+            "uniform vec4 iris_FogColor;", InjectionPoint.BEFORE_DECLARATIONS);
+        injectExternalDeclaration(
+            "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };",
+            InjectionPoint.BEFORE_DECLARATIONS);
+        injectExternalDeclaration(
+            "iris_FogParameters iris_Fog = iris_FogParameters(iris_FogColor, iris_FogDensity, iris_FogStart, iris_FogEnd, 1.0 / (iris_FogEnd - iris_FogStart));",
+            InjectionPoint.BEFORE_DECLARATIONS);
+      }
+    };
 
-    Transformation detectDisallowed = new Transformation(new WalkPhase() {
-      //TODO with a FindTerminals subclass
-    });
+    // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
+    // TODO: update to use new glsl-transformer features to make this compact
+    ReplaceTerminals wrapFogFragCoord = new ReplaceTerminals(ReplaceTerminals.IDENTIFIER);
+    wrapFogFragCoord.addReplacementTerminal("gl_FogFragCoord", "iris_FogFragCoord");
 
-    commonManager.registerTransformation(fixVersion);
+    // PREV TODO: This doesn't handle geometry shaders... How do we do that?
+    TransformationPhase injectOutFogFragCoord = new RunPhase() {
+      @Override
+      protected void run(TranslationUnitContext ctx) {
+        injectExternalDeclaration(
+            "out float iris_FogFragCoord;", InjectionPoint.BEFORE_DECLARATIONS);
+      };
+    };
+
+    TransformationPhase injectInFogFragCoord = new RunPhase() {
+      @Override
+      protected void run(TranslationUnitContext ctx) {
+        injectExternalDeclaration(
+            "in float iris_FogFragCoord;", InjectionPoint.BEFORE_DECLARATIONS);
+      };
+    };
+
+    /**
+     * PREV TODO: This is incorrect and is just the bare minimum needed for SEUS v11
+     * & Renewed to compile. It works because they don't actually use gl_FrontColor
+     * even though they write to it.
+     */
+    // TODO: use glsl-transformer core wrapping transformation for this
+    TransformationPhase frontColorInjection = new RunPhase() {
+      @Override
+      protected void run(TranslationUnitContext ctx) {
+        injectExternalDeclaration(
+            "vec4 iris_FrontColor;", InjectionPoint.BEFORE_DECLARATIONS);
+      };
+    };
+    ReplaceTerminals wrapFrontColor = new ReplaceTerminals(ReplaceTerminals.IDENTIFIER);
+    wrapFogFragCoord.addReplacementTerminal("gl_FrontColor", "iris_FrontColor");
+
+    // compose the transformations and phases into the managers
+    for (Patch patch : Patch.values()) {
+      for (ShaderType type : ShaderType.values()) {
+        TransformationManager manager = new TransformationManager();
+        managers.put(patch, type, manager);
+
+        manager.registerTransformation(detectReserved);
+        manager.registerTransformation(fixVersion);
+
+        Transformation commonInjections = new Transformation();
+        manager.registerTransformation(commonInjections);
+
+        //TODO: use addConcurrentPhase to make this more compact
+        commonInjections.addPhase(0, sharedFogSetup);
+        commonInjections.addPhase(0, wrapFogFragCoord);
+        if (type == ShaderType.VERTEX) {
+          commonInjections.addPhase(0, injectInFogFragCoord);
+        } else if (type == ShaderType.FRAGMENT) {
+          commonInjections.addPhase(0, injectOutFogFragCoord);
+        }
+        if (type == ShaderType.VERTEX) {
+          commonInjections.addPhase(0, frontColorInjection);
+          commonInjections.addPhase(0, wrapFrontColor);
+        }
+        
+        //TODO: the rest of the patchCommon things
+      }
+    }
   }
 
   @Override
   public String patchVanilla(
       String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset,
       ShaderAttributeInputs inputs) {
-    return super.patchVanilla(source, type, alpha, hasChunkOffset, inputs);
+    return managers.get(Patch.VANILLA, type).transform(source);
   }
 
   @Override
   public String patchSodium(
       String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs,
       float positionScale, float positionOffset, float textureScale) {
-    return super.patchSodium(
-        source, type, alpha, inputs, positionScale, positionOffset, textureScale);
+    return null;
   }
 
   @Override
   public String patchComposite(String source, ShaderType type) {
-    return super.patchComposite(source, type);
-  }
-
-  @Override
-  String patchCommon(String input, ShaderType type) {
-    // int index = input.indexOf("#version");
-    // LOGGER.debug(input.substring(index, index + 100).trim());
-    input = commonManager.transform(input);
-    // index = input.indexOf("#version");
-    // LOGGER.debug(input.substring(index, index + 100).trim());
-
-    return super.patchCommon(input, type);
-  }
-
-  @Override
-  void fixVersion(Transformations transformations) {
-    // do nothing because this patcher does itself
-    // super.fixVersion(transformations);
+    return null;
   }
 }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -1,6 +1,5 @@
 package net.coderbot.iris.pipeline.newshader;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -21,8 +20,11 @@ import io.github.douira.glsl_transformer.GLSLParser.ExternalDeclarationContext;
 import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
+import io.github.douira.glsl_transformer.core.SearchTerminalsDynamic;
+import io.github.douira.glsl_transformer.core.SearchTerminalsImpl;
 import io.github.douira.glsl_transformer.core.WrapIdentifier;
 import io.github.douira.glsl_transformer.core.WrapIdentifierExternalDeclaration;
+import io.github.douira.glsl_transformer.core.target.HandlerTarget;
 import io.github.douira.glsl_transformer.core.target.HandlerTargetImpl;
 import io.github.douira.glsl_transformer.core.target.ThrowTargetImpl;
 import io.github.douira.glsl_transformer.print.filter.ChannelFilter;
@@ -159,7 +161,7 @@ public class TransformPatcher implements Patcher {
 
     // setup the transformations and even loose phases if necessary
     Transformation<Parameters> detectReserved = new Transformation<Parameters>(
-        new SearchTerminals<Parameters>(SearchTerminals.IDENTIFIER,
+        new SearchTerminalsImpl<Parameters>(SearchTerminals.IDENTIFIER,
             ImmutableSet.of(
                 new ThrowTargetImpl<Parameters>(
                     "moj_import", "Iris shader programs may not use moj_import directives."),
@@ -263,14 +265,14 @@ public class TransformPatcher implements Patcher {
     // 3. add location 0 to that declaration
 
     Transformation<Parameters> replaceStorageQualifierVertex = new Transformation<Parameters>(
-        new SearchTerminals<Parameters>() {
+        new SearchTerminalsImpl<Parameters>() {
           {
             addReplacementTerminal("attribute", "in");
             addReplacementTerminal("varying", "in");
           }
         });
     Transformation<Parameters> replaceStorageQualifierFragment = new Transformation<Parameters>(
-        SearchTerminals.<Parameters>withReplacementTerminal("varying", "in"));
+        SearchTerminalsImpl.<Parameters>withReplacementTerminal("varying", "in"));
 
     // PREV TODO: Add similar functions for all legacy texture sampling functions
     Transformation<Parameters> injectTextureFunctions = new Transformation<Parameters>(new RunPhase<Parameters>() {
@@ -344,7 +346,7 @@ public class TransformPatcher implements Patcher {
          */
 
         // detect use of gl_FragColor
-        addConcurrentPhase(new SearchTerminals<Parameters>(
+        addConcurrentPhase(new SearchTerminalsImpl<Parameters>(
             new HandlerTargetImpl<Parameters>("gl_FragColor") {
               @Override
               public void handleResult(TreeMember node, String match) {
@@ -353,7 +355,7 @@ public class TransformPatcher implements Patcher {
             }));
 
         // detect use of gl_FragData
-        addConcurrentPhase(new SearchTerminals<Parameters>(
+        addConcurrentPhase(new SearchTerminalsImpl<Parameters>(
             new HandlerTargetImpl<Parameters>("gl_FragData") {
               @Override
               public void handleResult(TreeMember node, String match) {
@@ -429,8 +431,10 @@ public class TransformPatcher implements Patcher {
 
         // if we are doing custom, check if any of the declared names are being used
         // (and if they are being used multiple times)
-        addPhase(new SearchTerminals<Parameters>(
-            declaredCustomNames.stream()
+        addPhase(new SearchTerminalsDynamic<Parameters>() {
+          @Override
+          protected Collection<HandlerTarget<Parameters>> getTargetsDynamic() {
+            return declaredCustomNames.stream()
                 .map(name -> new HandlerTargetImpl<Parameters>(name) {
                   @Override
                   public void handleResult(TreeMember node, String match) {
@@ -445,12 +449,18 @@ public class TransformPatcher implements Patcher {
                     }
                   }
                 })
-                .collect(Collectors.toList())) {
+                .collect(Collectors.toList());
+          }
+
+          @Override
+          protected boolean isActiveBeforeWalk() {
+            return true;
+          };
 
           // only run the walk if there are any names to find but run the after walk for
           // determining the final frag color type
           @Override
-          protected boolean isActive() {
+          protected boolean isActiveAtWalk() {
             return usesCustomPossible;
           }
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -21,10 +21,12 @@ import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.ast.StringNode;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
-import io.github.douira.glsl_transformer.core.WrapIdentifier;
-import io.github.douira.glsl_transformer.core.target.HandlerTarget;
+import io.github.douira.glsl_transformer.core.WrapIdentifierImpl;
+import io.github.douira.glsl_transformer.core.target.HandlerTargetImpl;
 import io.github.douira.glsl_transformer.core.target.ReplaceTarget;
+import io.github.douira.glsl_transformer.core.target.TerminalReplaceTarget;
 import io.github.douira.glsl_transformer.core.target.ThrowTarget;
+import io.github.douira.glsl_transformer.core.target.ThrowTargetImpl;
 import io.github.douira.glsl_transformer.print.filter.ChannelFilter;
 import io.github.douira.glsl_transformer.print.filter.TokenChannel;
 import io.github.douira.glsl_transformer.print.filter.TokenFilter;
@@ -145,7 +147,7 @@ public class TransformPatcher implements Patcher {
      * gbuffers_lines
      */
 
-    TokenFilter parseTokenFilter = new ChannelFilter(TokenChannel.PREPROCESSOR) {
+    TokenFilter<Parameters> parseTokenFilter = new ChannelFilter<Parameters>(TokenChannel.PREPROCESSOR) {
       @Override
       public boolean isTokenAllowed(Token token) {
         if (!super.isTokenAllowed(token)) {
@@ -160,9 +162,9 @@ public class TransformPatcher implements Patcher {
     Transformation<Parameters> detectReserved = new Transformation<Parameters>(
         new SearchTerminals<Parameters>(SearchTerminals.IDENTIFIER,
             ImmutableSet.of(
-                ThrowTarget.fromMessage(
+                new ThrowTargetImpl<Parameters>(
                     "moj_import", "Iris shader programs may not use moj_import directives."),
-                ThrowTarget.fromMessage(
+                new ThrowTargetImpl<Parameters>(
                     "iris_",
                     "Detected a potential reference to unstable and internal Iris shader interfaces (iris_). This isn't currently supported."))));
 
@@ -207,7 +209,7 @@ public class TransformPatcher implements Patcher {
      * passes. A shader that relies on this behavior is SEUS v11 - it reads
      * gl_Fog.color and breaks if it is not properly defined.
      */
-    Transformation<Parameters> wrapFogSetup = WrapIdentifier.fromTerminal(
+    Transformation<Parameters> wrapFogSetup = WrapIdentifierImpl.fromTerminal(
         "gl_Fog", "iris_Fog",
         new RunPhase<Parameters>() {
           @Override
@@ -224,7 +226,7 @@ public class TransformPatcher implements Patcher {
         });
 
     // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
-    Transformation<Parameters> wrapFogFragCoord = WrapIdentifier.fromTerminal(
+    Transformation<Parameters> wrapFogFragCoord = WrapIdentifierImpl.fromTerminal(
         "gl_FogFragCoord", "iris_FogFragCoord",
         new RunPhase<Parameters>() {
           @Override
@@ -245,7 +247,7 @@ public class TransformPatcher implements Patcher {
      * & Renewed to compile. It works because they don't actually use gl_FrontColor
      * even though they write to it.
      */
-    Transformation<Parameters> wrapFrontColor = WrapIdentifier.fromTerminal(
+    Transformation<Parameters> wrapFrontColor = WrapIdentifierImpl.fromTerminal(
         "gl_FrontColor", "iris_FrontColor",
         new RunPhase<Parameters>() {
           @Override
@@ -308,7 +310,7 @@ public class TransformPatcher implements Patcher {
 
         // detect use of gl_FragColor
         addConcurrentPhase(new SearchTerminals<Parameters>(
-            new HandlerTarget<Parameters>("gl_FragColor") {
+            new HandlerTargetImpl<Parameters>("gl_FragColor") {
               @Override
               public void handleResult(TreeMember node, String match) {
                 usesFragColor = true;
@@ -317,7 +319,7 @@ public class TransformPatcher implements Patcher {
 
         // detect use of gl_FragData
         addConcurrentPhase(new SearchTerminals<Parameters>(
-            new HandlerTarget<Parameters>("gl_FragData") {
+            new HandlerTargetImpl<Parameters>("gl_FragData") {
               @Override
               public void handleResult(TreeMember node, String match) {
                 usesFragData = true;
@@ -394,7 +396,7 @@ public class TransformPatcher implements Patcher {
         // (and if they are being used multiple times)
         addPhase(new SearchTerminals<Parameters>(
             declaredCustomNames.stream()
-                .map(name -> new HandlerTarget<Parameters>(name) {
+                .map(name -> new HandlerTargetImpl<Parameters>(name) {
                   @Override
                   public void handleResult(TreeMember node, String match) {
                     // name is being used, make sure it's the only one
@@ -452,12 +454,13 @@ public class TransformPatcher implements Patcher {
         // 3. redirect gl_Frag* to the newly created output (replace identifiers)
 
         // throw if the replacement target is present already
-        addPhase(new SearchTerminals<Parameters>(new ThrowTarget<Parameters>(null) {
+        //TODO: use new glsl-transformer features to make this more compact (WrapTarget)
+        addPhase(new SearchTerminals<Parameters>(new ThrowTarget<Parameters>() {
           @Override
-          public SemanticException getException(TreeMember node, String match) {
+          public String getMessage(TreeMember node, String match) {
             // TODO: do this better instead of copying from glsl-transformer's
             // WrapIdentifier
-            return new SemanticException("The wrapper '" + match + "' shouldn't already be present in the code!");
+            return "The wrapper '" + match + "' shouldn't already be present in the code!";
           }
 
           @Override
@@ -471,24 +474,33 @@ public class TransformPatcher implements Patcher {
           }
         });
 
-        addPhase(new SearchTerminals<Parameters>(new ReplaceTarget<Parameters>(null) {
-          // TODO: make use of a more extensible TerminalReplaceTarget
+        addPhase(new SearchTerminals<Parameters>(new TerminalReplaceTarget<Parameters>() {
           @Override
-          public TreeMember getReplacement(TreeMember node, String match) {
-            return new StringNode(fragColorWrapResult);
-          };
+          protected String getTerminalContent() {
+            return fragColorWrapResult;
+          }
 
           @Override
           public String getNeedle() {
             return fragColorWrapTarget;
           }
-        }));
+        }) {
+          @Override
+          protected boolean isActive() {
+            return type == FragColorOutput.COLOR || type == FragColorOutput.DATA;
+          }
+        });
 
         addPhase(new RunPhase<Parameters>() {
           @Override
           protected void run(TranslationUnitContext ctx) {
             injectExternalDeclaration(InjectionPoint.BEFORE_DECLARATIONS,
                 "out vec4 " + (type == FragColorOutput.COLOR ? "iris_FragColor" : "iris_FragData[8]") + ";");
+          }
+
+          @Override
+          protected boolean isActive() {
+            return type == FragColorOutput.COLOR || type == FragColorOutput.DATA;
           }
         });
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -254,23 +254,13 @@ public class TransformPatcher implements Patcher {
           };
         });
 
-    // // fixes locations of outs in fragment shaders
-    // Transformation<Parameters> fixFragLayouts = new Transformation<Parameters>()
-    // {
-    // {
-    // // 1. find all the outs and determine their location
-    // addPhase(1, -1, new WalkPhase<Parameters>() {
+    // TOOD: this is missing for now as it's quite involved
+    // fixes locations of outs in fragment shaders
+    // 1. find all the outs and determine their location
+    // 2. check if there is a single non-located out that could receive location
+    // 3. add location 0 to that declaration
 
-    // });
-
-    // // 2. check if there is a single non-located out that could receive location
-    // 0
-
-    // // 3. add location 0 to that declaration
-
-    // }
-    // };
-
+    //
     Transformation<Parameters> wrapFragColorOutput = new Transformation<Parameters>() {
       private FragColorOutput type;
       private boolean usesFragColor;

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -11,6 +11,7 @@ import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
+import io.github.douira.glsl_transformer.transform.WalkPhase;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
@@ -80,6 +81,12 @@ public class TransformPatcher extends TriforcePatcher {
 
         replaceNode(versionStatement, "#version " + version + " " + profile + "\n", GLSLParser::versionStatement);
       }
+    });
+
+    // TODO: detection of moj_import and iris_ uses: see a subclass of FindTerminals in glsl-transformer
+
+    Transformation detectDisallowed = new Transformation(new WalkPhase() {
+      //TODO with a FindTerminals subclass
     });
 
     commonManager.registerTransformation(fixVersion);

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -105,8 +105,8 @@ public class TransformPatcher implements Patcher {
      */
 
     // setup the transformations and even loose phases if necessary
-    Transformation<Parameters> detectReserved = new Transformation<>(
-        new SearchTerminals<>(SearchTerminals.IDENTIFIER,
+    Transformation<Parameters> detectReserved = new Transformation<Parameters>(
+        new SearchTerminals<Parameters>(SearchTerminals.IDENTIFIER,
             ImmutableSet.of(
                 ThrowTarget.fromMessage(
                     "moj_import", "Iris shader programs may not use moj_import directives."),
@@ -114,7 +114,7 @@ public class TransformPatcher implements Patcher {
                     "iris_",
                     "Detected a potential reference to unstable and internal Iris shader interfaces (iris_). This isn't currently supported."))));
 
-    Transformation<Parameters> fixVersion = new Transformation<>(new RunPhase<Parameters>() {
+    Transformation<Parameters> fixVersion = new Transformation<Parameters>(new RunPhase<Parameters>() {
       /**
        * This largely replicates the behavior of
        * {@link net.coderbot.iris.pipeline.newshader.TriforcePatcher#fixVersion(Transformations)}
@@ -208,7 +208,7 @@ public class TransformPatcher implements Patcher {
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
       for (ShaderType type : ShaderType.values()) {
-        TransformationManager<Parameters> manager = new TransformationManager<>();
+        TransformationManager<Parameters> manager = new TransformationManager<Parameters>();
         managers.put(patch, type, manager);
 
         manager.registerTransformation(detectReserved);
@@ -216,7 +216,7 @@ public class TransformPatcher implements Patcher {
         manager.registerTransformation(wrapFogSetup);
         manager.registerTransformation(wrapFogFragCoord);
 
-        // Transformation<Parameters> commonInjections = new Transformation<>();
+        // Transformation<Parameters> commonInjections = new Transformation<Parameters>();
         // manager.registerTransformation(commonInjections);
 
         if (type == ShaderType.VERTEX || type == ShaderType.FRAGMENT) {

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -14,6 +14,8 @@ import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
 import io.github.douira.glsl_transformer.core.ReplaceTerminals;
 import io.github.douira.glsl_transformer.core.SearchTerminals;
+import io.github.douira.glsl_transformer.core.WrapIdentifier;
+import io.github.douira.glsl_transformer.core.target.TerminalReplaceTarget;
 import io.github.douira.glsl_transformer.core.target.ThrowTarget;
 import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.Transformation;
@@ -46,27 +48,40 @@ public class TransformPatcher implements Patcher {
     VANILLA, SODIUM, COMPOSITE
   }
 
-  private static class VanillaParameters {
+  private static class Parameters {
+    public final Patch patch;
+    public final ShaderType type;
+
+    public Parameters(Patch patch, ShaderType type) {
+      this.patch = patch;
+      this.type = type;
+    }
+  }
+
+  private static class VanillaParameters extends Parameters {
     public final AlphaTest alpha;
     public final boolean hasChunkOffset;
     public final ShaderAttributeInputs inputs;
 
-    public VanillaParameters(AlphaTest alpha, boolean hasChunkOffset, ShaderAttributeInputs inputs) {
+    public VanillaParameters(Patch patch, ShaderType type, AlphaTest alpha, boolean hasChunkOffset,
+        ShaderAttributeInputs inputs) {
+      super(patch, type);
       this.alpha = alpha;
       this.hasChunkOffset = hasChunkOffset;
       this.inputs = inputs;
     }
   }
 
-  private static class SodiumParameters {
+  private static class SodiumParameters extends Parameters {
     public final AlphaTest alpha;
     public final ShaderAttributeInputs inputs;
     public final float positionScale;
     public final float positionOffset;
     public final float textureScale;
 
-    public SodiumParameters(AlphaTest alpha, ShaderAttributeInputs inputs, float positionScale,
-        float positionOffset, float textureScale) {
+    public SodiumParameters(Patch patch, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs,
+        float positionScale, float positionOffset, float textureScale) {
+      super(patch, type);
       this.alpha = alpha;
       this.inputs = inputs;
       this.positionScale = positionScale;
@@ -81,16 +96,18 @@ public class TransformPatcher implements Patcher {
    * run better. The object parameter can be filled with one of the parameter
    * classes and the transformation phases have to do their own casts.
    */
-  private Table<Patch, ShaderType, TransformationManager<Object>> managers = HashBasedTable.create(
+  private Table<Patch, ShaderType, TransformationManager<Parameters>> managers = HashBasedTable.create(
       Patch.values().length,
       ShaderType.values().length);
 
   public TransformPatcher() {
-    // PREV TODO: Only do the NewLines patches if the source code isn't from
-    // gbuffers_lines
+    /**
+     * PREV TODO: Only do the NewLines patches if the source code isn't from
+     * gbuffers_lines
+     */
 
     // setup the transformations and even loose phases if necessary
-    Transformation<Object> detectReserved = new Transformation<>(
+    Transformation<Parameters> detectReserved = new Transformation<>(
         new SearchTerminals<>(SearchTerminals.IDENTIFIER,
             ImmutableSet.of(
                 ThrowTarget.fromMessage(
@@ -99,7 +116,7 @@ public class TransformPatcher implements Patcher {
                     "iris_",
                     "Detected a potential reference to unstable and internal Iris shader interfaces (iris_). This isn't currently supported."))));
 
-    Transformation<Object> fixVersion = new Transformation<>(new RunPhase<Object>() {
+    Transformation<Parameters> fixVersion = new Transformation<>(new RunPhase<Parameters>() {
       /**
        * This largely replicates the behavior of
        * {@link net.coderbot.iris.pipeline.newshader.TriforcePatcher#fixVersion(Transformations)}
@@ -140,120 +157,115 @@ public class TransformPatcher implements Patcher {
      * passes. A shader that relies on this behavior is SEUS v11 - it reads
      * gl_Fog.color and breaks if it is not properly defined.
      */
-    TransformationPhase<Object> sharedFogSetup = new RunPhase<Object>() {
-      @Override
-      protected void run(TranslationUnitContext ctx) {
-        injectExternalDeclaration(
-            "uniform float iris_FogDensity;", InjectionPoint.BEFORE_DECLARATIONS);
-        injectExternalDeclaration(
-            "uniform float iris_FogStart;", InjectionPoint.BEFORE_DECLARATIONS);
-        injectExternalDeclaration(
-            "uniform float iris_FogEnd;", InjectionPoint.BEFORE_DECLARATIONS);
-        injectExternalDeclaration(
-            "uniform vec4 iris_FogColor;", InjectionPoint.BEFORE_DECLARATIONS);
-        injectExternalDeclaration(
-            "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };",
-            InjectionPoint.BEFORE_DECLARATIONS);
-        injectExternalDeclaration(
-            "iris_FogParameters iris_Fog = iris_FogParameters(iris_FogColor, iris_FogDensity, iris_FogStart, iris_FogEnd, 1.0 / (iris_FogEnd - iris_FogStart));",
-            InjectionPoint.BEFORE_DECLARATIONS);
-      }
-    };
+    // TODO: use terminal wrapper method
+    Transformation<Parameters> wrapFogSetup = new WrapIdentifier<>(
+        "gl_Fog", "iris_Fog",
+        new TerminalReplaceTarget<>("gl_Fog", "iris_Fog"),
+        new RunPhase<Parameters>() {
+          @Override
+          protected void run(TranslationUnitContext ctx) {
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_FogDensity;");
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_FogStart;");
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_FogEnd;");
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS, "uniform vec4 iris_FogColor;");
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS,
+                "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };");
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS,
+                "iris_FogParameters iris_Fog = iris_FogParameters(iris_FogColor, iris_FogDensity, iris_FogStart, iris_FogEnd, 1.0 / (iris_FogEnd - iris_FogStart));");
+          }
+        });
 
     // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
-    // TODO: update to use new glsl-transformer features to make this compact
-    SearchTerminals<Object> wrapFogFragCoord = new SearchTerminals<Object>() {
-      {
-        addReplacementTerminal("gl_FogFragCoord", "iris_FogFragCoord");
-      }
-    };
-
-    // PREV TODO: This doesn't handle geometry shaders... How do we do that?
-    TransformationPhase<Object> injectOutFogFragCoord = new RunPhase<Object>() {
-      @Override
-      protected void run(TranslationUnitContext ctx) {
-        injectExternalDeclaration(
-            "out float iris_FogFragCoord;", InjectionPoint.BEFORE_DECLARATIONS);
-      };
-    };
-
-    TransformationPhase<Object> injectInFogFragCoord = new RunPhase<Object>() {
-      @Override
-      protected void run(TranslationUnitContext ctx) {
-        injectExternalDeclaration(
-            "in float iris_FogFragCoord;", InjectionPoint.BEFORE_DECLARATIONS);
-      };
-    };
+    // TODO: use terminal wrapper method
+    Transformation<Parameters> wrapFogFragCoord = new WrapIdentifier<>(
+        "gl_FogFragCoord", "iris_FogFragCoord",
+        new TerminalReplaceTarget<>("gl_FogFragCoord", "iris_FogFragCoord"),
+        new RunPhase<Parameters>() {
+          @Override
+          protected void run(TranslationUnitContext ctx) {
+            // PREV TODO: This doesn't handle geometry shaders... How do we do that?
+            if (getJobParameters().type == ShaderType.VERTEX) {
+              injectExternalDeclaration(
+                  InjectionPoint.BEFORE_DECLARATIONS, "out float iris_FogFragCoord;");
+            } else if (getJobParameters().type == ShaderType.FRAGMENT) {
+              injectExternalDeclaration(
+                  InjectionPoint.BEFORE_DECLARATIONS, "in float iris_FogFragCoord;");
+            }
+          }
+        });
 
     /**
      * PREV TODO: This is incorrect and is just the bare minimum needed for SEUS v11
      * & Renewed to compile. It works because they don't actually use gl_FrontColor
      * even though they write to it.
      */
-    // TODO: use glsl-transformer core wrapping transformation for this
-    TransformationPhase<Object> frontColorInjection = new RunPhase<Object>() {
-      @Override
-      protected void run(TranslationUnitContext ctx) {
-        injectExternalDeclaration(
-            "vec4 iris_FrontColor;", InjectionPoint.BEFORE_DECLARATIONS);
-      };
-    };
+    // TODO: use terminal wrapper method
+    Transformation<Parameters> wrapFrontColor = new WrapIdentifier<>(
+        "gl_FrontColor", "iris_FrontColor",
+        new TerminalReplaceTarget<>("gl_FrontColor", "iris_FrontColor"),
+        new RunPhase<Parameters>() {
+          @Override
+          protected void run(TranslationUnitContext ctx) {
+            injectExternalDeclaration(
+                InjectionPoint.BEFORE_DECLARATIONS, "vec4 iris_FrontColor;");
+          };
+        });
 
-    // TODO use shorthand method
-    SearchTerminals<Object> wrapFrontColor = new SearchTerminals<Object>() {
-      {
-        addReplacementTerminal("gl_FrontColor", "iris_FrontColor");
-      }
-    };
+    // NOTE: converted up until line 63 of TriforcePatcher (right after frontColor)
 
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
       for (ShaderType type : ShaderType.values()) {
-        TransformationManager<Object> manager = new TransformationManager<>();
+        TransformationManager<Parameters> manager = new TransformationManager<>();
         managers.put(patch, type, manager);
 
         manager.registerTransformation(detectReserved);
         manager.registerTransformation(fixVersion);
+        manager.registerTransformation(wrapFogSetup);
+        manager.registerTransformation(wrapFogFragCoord);
 
-        Transformation<Object> commonInjections = new Transformation<>();
-        manager.registerTransformation(commonInjections);
+        // Transformation<Parameters> commonInjections = new Transformation<>();
+        // manager.registerTransformation(commonInjections);
 
-        //TODO: use addConcurrentPhase to make this more compact
-        commonInjections.addPhase(0, sharedFogSetup);
-        commonInjections.addPhase(0, wrapFogFragCoord);
-        if (type == ShaderType.VERTEX) {
-          commonInjections.addPhase(0, injectInFogFragCoord);
-        } else if (type == ShaderType.FRAGMENT) {
-          commonInjections.addPhase(0, injectOutFogFragCoord);
+        if (type == ShaderType.VERTEX || type == ShaderType.FRAGMENT) {
+          manager.registerTransformation(wrapFogFragCoord);
         }
+
         if (type == ShaderType.VERTEX) {
-          commonInjections.addPhase(0, frontColorInjection);
-          commonInjections.addPhase(0, wrapFrontColor);
+          manager.registerTransformation(wrapFrontColor);
         }
-        
-        //TODO: the rest of the patchCommon things
       }
     }
+  }
+
+  private String transform(String source, Parameters parameters) {
+    return managers.get(parameters.patch, parameters.type).transform(source, parameters);
   }
 
   @Override
   public String patchVanilla(
       String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset,
       ShaderAttributeInputs inputs) {
-    return managers.get(Patch.VANILLA, type)
-        .transform(source, new VanillaParameters(alpha, hasChunkOffset, inputs));
+    return transform(source,
+        new VanillaParameters(Patch.VANILLA, type, alpha, hasChunkOffset, inputs));
   }
 
   @Override
   public String patchSodium(
       String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs,
       float positionScale, float positionOffset, float textureScale) {
-    return managers.get(Patch.VANILLA, type)
-        .transform(source, new SodiumParameters(alpha, inputs, positionScale, positionOffset, textureScale));
+    return transform(source,
+        new SodiumParameters(Patch.VANILLA, type, alpha, inputs, positionScale, positionOffset, textureScale));
   }
 
   @Override
   public String patchComposite(String source, ShaderType type) {
-    return managers.get(Patch.VANILLA, type).transform(source, null);
+    return transform(source, new Parameters(Patch.COMPOSITE, type));
   }
 }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -2,6 +2,9 @@ package net.coderbot.iris.pipeline.newshader;
 
 import java.util.Optional;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.github.douira.glsl_transformer.GLSLParser;
 import io.github.douira.glsl_transformer.GLSLParser.TranslationUnitContext;
 import io.github.douira.glsl_transformer.GLSLParser.VersionStatementContext;
@@ -29,6 +32,8 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
  * not valid GLSL code. Directives like #if will mess it up.
  */
 public class TransformPatcher extends TriforcePatcher {
+  private static final Logger LOGGER = LogManager.getLogger(TransformPatcher.class);
+
   /*
    * if glsl-transformer is used for everything, then there is no common, just
    * three managers that share some but not all transformations
@@ -73,7 +78,7 @@ public class TransformPatcher extends TriforcePatcher {
         }
         profile = "core";
 
-        replaceNode(versionStatement, "#version " + version + " " + profile, GLSLParser::versionStatement);
+        replaceNode(versionStatement, "#version " + version + " " + profile + "\n", GLSLParser::versionStatement);
       }
     });
 
@@ -102,9 +107,11 @@ public class TransformPatcher extends TriforcePatcher {
 
   @Override
   String patchCommon(String input, ShaderType type) {
-    System.out.println(input);
+    // int index = input.indexOf("#version");
+    // LOGGER.debug(input.substring(index, index + 100).trim());
     input = commonManager.transform(input);
-    System.out.println(input);
+    // index = input.indexOf("#version");
+    // LOGGER.debug(input.substring(index, index + 100).trim());
 
     return super.patchCommon(input, type);
   }
@@ -112,5 +119,6 @@ public class TransformPatcher extends TriforcePatcher {
   @Override
   void fixVersion(Transformations transformations) {
     // do nothing because this patcher does itself
+    // super.fixVersion(transformations);
   }
 }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -2,10 +2,7 @@ package net.coderbot.iris.pipeline.newshader;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.HashBasedTable;
@@ -28,8 +25,8 @@ import io.github.douira.glsl_transformer.core.WrapIdentifier;
 import io.github.douira.glsl_transformer.core.target.HandlerTarget;
 import io.github.douira.glsl_transformer.core.target.ThrowTarget;
 import io.github.douira.glsl_transformer.print.filter.ChannelFilter;
+import io.github.douira.glsl_transformer.print.filter.TokenChannel;
 import io.github.douira.glsl_transformer.print.filter.TokenFilter;
-import io.github.douira.glsl_transformer.print.filter.TokenFilter.TokenChannel;
 import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.SemanticException;
 import io.github.douira.glsl_transformer.transform.Transformation;
@@ -318,14 +315,17 @@ public class TransformPatcher implements Patcher {
 
         // detect use of custom color outputs like
         // "layout (location = 0) out vec4 <IDENTIFIER>"
-        // TODO: what happens when there is no location?
         addPhase(new WalkPhase<Parameters>() {
           ParseTreePattern customColorOutPattern;
+          ParseTreePattern illegalOutPattern;
 
           @Override
           protected void init() {
             customColorOutPattern = compilePattern(
                 "layout (location = 0) out vec4 <name:IDENTIFIER>;",
+                GLSLParser.RULE_externalDeclaration);
+            illegalOutPattern = compilePattern(
+                "out vec4 <name:IDENTIFIER>;",
                 GLSLParser.RULE_externalDeclaration);
           }
 
@@ -357,6 +357,12 @@ public class TransformPatcher implements Patcher {
 
           @Override
           public void enterExternalDeclaration(ExternalDeclarationContext ctx) {
+            ParseTreeMatch illegalMatch = illegalOutPattern.match(ctx);
+            if (illegalMatch.succeeded()) {
+              throw new SemanticException("The declaration with the name '" + illegalMatch.get("name").getText()
+                  + "' is missing a location specifier!");
+            }
+
             ParseTreeMatch match = customColorOutPattern.match(ctx);
             if (match.succeeded()) {
               declaredCustomNames.add(match.get("name").getText());
@@ -421,7 +427,7 @@ public class TransformPatcher implements Patcher {
         // "out vec4 iris_FragColor/iris_FragData[8];"
         // 3. redirect gl_Frag* to the newly created output (replace identifiers)
 
-        // TODO: merge a wrap identifier phase into this one
+        
 
         /**
          * 4. if alpha test is given, apply it with iris_FragColor/iris_FragData[0].

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -24,6 +24,7 @@ import io.github.douira.glsl_transformer.transform.RunPhase;
 import io.github.douira.glsl_transformer.transform.SemanticException;
 import io.github.douira.glsl_transformer.transform.Transformation;
 import io.github.douira.glsl_transformer.transform.TransformationManager;
+import io.github.douira.glsl_transformer.transform.TransformationPhase;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.shaderpack.transform.Transformations;
@@ -219,7 +220,44 @@ public class TransformPatcher implements Patcher {
           };
         });
 
-    // NOTE: converted up until line 63 of TriforcePatcher (right after frontColor)
+    // PREV TODO: Add similar functions for all legacy texture sampling functions
+    Transformation<Parameters> injectTextureFunctions = new Transformation<Parameters>(new RunPhase<Parameters>() {
+      @Override
+      protected void run(TranslationUnitContext ctx) {
+        injectExternalDeclarations(
+            InjectionPoint.BEFORE_DECLARATIONS,
+            "vec4 texture2D(sampler2D sampler, vec2 coord) { return texture(sampler, coord); }",
+            "vec4 texture3D(sampler3D sampler, vec3 coord) { return texture(sampler, coord); }",
+            "vec4 texture2DLod(sampler2D sampler, vec2 coord, float lod) { return textureLod(sampler, coord, lod); }",
+            "vec4 texture3DLod(sampler3D sampler, vec3 coord, float lod) { return textureLod(sampler, coord, lod); }",
+            "vec4 shadow2D(sampler2DShadow sampler, vec3 coord) { return vec4(texture(sampler, coord)); }",
+            "vec4 shadow2DLod(sampler2DShadow sampler, vec3 coord, float lod) { return vec4(textureLod(sampler, coord, lod)); }",
+            "vec4 texture2DGrad(sampler2D sampler, vec2 coord, vec2 dPdx, vec2 dPdy) { return textureGrad(sampler, coord, dPdx, dPdy); }",
+            "vec4 texture2DGradARB(sampler2D sampler, vec2 coord, vec2 dPdx, vec2 dPdy) { return textureGrad(sampler, coord, dPdx, dPdy); }",
+            "vec4 texture3DGrad(sampler3D sampler, vec3 coord, vec3 dPdx, vec3 dPdy) { return textureGrad(sampler, coord, dPdx, dPdy); }",
+            "vec4 texelFetch2D(sampler2D sampler, ivec2 coord, int lod) { return texelFetch(sampler, coord, lod); }",
+            "vec4 texelFetch3D(sampler3D sampler, ivec3 coord, int lod) { return texelFetch(sampler, coord, lod); }");
+      }
+    });
+
+    /**
+     * PREV NOTE:
+     * GLSL 1.50 Specification, Section 8.7:
+     * In all functions below, the bias parameter is optional for fragment shaders.
+     * The bias parameter is not accepted in a vertex or geometry shader.
+     */
+    Transformation<Parameters> injectTextureFunctionsFragment = new Transformation<Parameters>(
+        new RunPhase<Parameters>() {
+          @Override
+          protected void run(TranslationUnitContext ctx) {
+            injectExternalDeclarations(
+                InjectionPoint.BEFORE_DECLARATIONS,
+                "vec4 texture2D(sampler2D sampler, vec2 coord, float bias) { return texture(sampler, coord, bias); }",
+                "vec4 texture3D(sampler3D sampler, vec3 coord, float bias) { return texture(sampler, coord, bias); }");
+          }
+        });
+
+    // TODO: fragColor/fragData patching, see discord messages
 
     // compose the transformations and phases into the managers
     for (Patch patch : Patch.values()) {
@@ -234,16 +272,17 @@ public class TransformPatcher implements Patcher {
         manager.registerTransformation(wrapFogSetup);
         manager.registerTransformation(wrapFogFragCoord);
 
-        // Transformation<Parameters> commonInjections = new
-        // Transformation<Parameters>();
-        // manager.registerTransformation(commonInjections);
-
         if (type == ShaderType.VERTEX || type == ShaderType.FRAGMENT) {
           manager.registerTransformation(wrapFogFragCoord);
         }
 
         if (type == ShaderType.VERTEX) {
           manager.registerTransformation(wrapFrontColor);
+        }
+
+        manager.registerTransformation(injectTextureFunctions);
+        if (type == ShaderType.FRAGMENT) {
+          manager.registerTransformation(injectTextureFunctionsFragment);
         }
       }
     }

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TransformPatcher.java
@@ -30,7 +30,6 @@ import io.github.douira.glsl_transformer.core.WrapIdentifierExternalDeclaration;
 import io.github.douira.glsl_transformer.core.target.HandlerTarget;
 import io.github.douira.glsl_transformer.core.target.HandlerTargetImpl;
 import io.github.douira.glsl_transformer.core.target.ParsedReplaceTarget;
-import io.github.douira.glsl_transformer.core.target.ParsedReplaceTargetImpl;
 import io.github.douira.glsl_transformer.core.target.TerminalReplaceTargetImpl;
 import io.github.douira.glsl_transformer.core.target.ThrowTargetImpl;
 import io.github.douira.glsl_transformer.core.target.WrapThrowTargetImpl;
@@ -223,19 +222,13 @@ public class TransformPatcher implements Patcher {
      */
     Transformation<Parameters> wrapFogSetup = WrapIdentifier.fromTerminal(
         "gl_Fog", "iris_Fog",
-        new RunPhase<Parameters>() {
-          @Override
-          protected void run(TranslationUnitContext ctx) {
-            injectExternalDeclarations(
-                InjectionPoint.BEFORE_DECLARATIONS,
-                "uniform float iris_FogDensity;",
-                "uniform float iris_FogStart;",
-                "uniform float iris_FogEnd;",
-                "uniform vec4 iris_FogColor;",
-                "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };",
-                "iris_FogParameters iris_Fog = iris_FogParameters(iris_FogColor, iris_FogDensity, iris_FogStart, iris_FogEnd, 1.0 / (iris_FogEnd - iris_FogStart));");
-          }
-        });
+        RunPhase.withInjectExternalDeclarations(InjectionPoint.BEFORE_DECLARATIONS,
+            "uniform float iris_FogDensity;",
+            "uniform float iris_FogStart;",
+            "uniform float iris_FogEnd;",
+            "uniform vec4 iris_FogColor;",
+            "struct iris_FogParameters { vec4 color; float density; float start; float end; float scale; };",
+            "iris_FogParameters iris_Fog = iris_FogParameters(iris_FogColor, iris_FogDensity, iris_FogStart, iris_FogEnd, 1.0 / (iris_FogEnd - iris_FogStart));"));
 
     // PREV TODO: What if the shader does gl_PerVertex.gl_FogFragCoord ?
     Transformation<Parameters> wrapFogFragCoord = WrapIdentifier.fromTerminal(
@@ -290,11 +283,8 @@ public class TransformPatcher implements Patcher {
         });
 
     // PREV TODO: Add similar functions for all legacy texture sampling functions
-    Transformation<Parameters> injectTextureFunctions = new Transformation<Parameters>(new RunPhase<Parameters>() {
-      @Override
-      protected void run(TranslationUnitContext ctx) {
-        injectExternalDeclarations(
-            InjectionPoint.BEFORE_DECLARATIONS,
+    Transformation<Parameters> injectTextureFunctions = new Transformation<Parameters>(
+        RunPhase.withInjectExternalDeclarations(InjectionPoint.BEFORE_DECLARATIONS,
             "vec4 texture2D(sampler2D sampler, vec2 coord) { return texture(sampler, coord); }",
             "vec4 texture3D(sampler3D sampler, vec3 coord) { return texture(sampler, coord); }",
             "vec4 texture2DLod(sampler2D sampler, vec2 coord, float lod) { return textureLod(sampler, coord, lod); }",
@@ -305,9 +295,7 @@ public class TransformPatcher implements Patcher {
             "vec4 texture2DGradARB(sampler2D sampler, vec2 coord, vec2 dPdx, vec2 dPdy) { return textureGrad(sampler, coord, dPdx, dPdy); }",
             "vec4 texture3DGrad(sampler3D sampler, vec3 coord, vec3 dPdx, vec3 dPdy) { return textureGrad(sampler, coord, dPdx, dPdy); }",
             "vec4 texelFetch2D(sampler2D sampler, ivec2 coord, int lod) { return texelFetch(sampler, coord, lod); }",
-            "vec4 texelFetch3D(sampler3D sampler, ivec3 coord, int lod) { return texelFetch(sampler, coord, lod); }");
-      }
-    });
+            "vec4 texelFetch3D(sampler3D sampler, ivec3 coord, int lod) { return texelFetch(sampler, coord, lod); }"));
 
     /**
      * PREV NOTE:
@@ -316,15 +304,10 @@ public class TransformPatcher implements Patcher {
      * The bias parameter is not accepted in a vertex or geometry shader.
      */
     Transformation<Parameters> injectTextureFunctionsFragment = new Transformation<Parameters>(
-        new RunPhase<Parameters>() {
-          @Override
-          protected void run(TranslationUnitContext ctx) {
-            injectExternalDeclarations(
-                InjectionPoint.BEFORE_DECLARATIONS,
-                "vec4 texture2D(sampler2D sampler, vec2 coord, float bias) { return texture(sampler, coord, bias); }",
-                "vec4 texture3D(sampler3D sampler, vec3 coord, float bias) { return texture(sampler, coord, bias); }");
-          }
-        });
+        RunPhase.withInjectExternalDeclarations(
+            InjectionPoint.BEFORE_DECLARATIONS,
+            "vec4 texture2D(sampler2D sampler, vec2 coord, float bias) { return texture(sampler, coord, bias); }",
+            "vec4 texture3D(sampler3D sampler, vec3 coord, float bias) { return texture(sampler, coord, bias); }"));
 
     Transformation<Parameters> wrapFragColorOutput = new Transformation<Parameters>() {
       private FragColorOutput type;

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
@@ -9,8 +9,19 @@ import net.coderbot.iris.shaderpack.transform.BuiltinUniformReplacementTransform
 import net.coderbot.iris.shaderpack.transform.StringTransformations;
 import net.coderbot.iris.shaderpack.transform.Transformations;
 
-public class TriforcePatcher {
-	public static void patchCommon(StringTransformations transformations, ShaderType type) {
+public class TriforcePatcher implements Patcher {
+	/**
+	 * Patches the shader string without using triforce's transform system.
+	 * 
+	 * @param input The input string to patch
+	 * @param type The type of the shader being patched
+	 * @return The patched shader string
+	 */
+	String patchCommon(String input, ShaderType type) {
+		return input;
+	}
+
+	void patchCommon(StringTransformations transformations, ShaderType type) {
 		// TODO: Only do the NewLines patches if the source code isn't from gbuffers_lines
 
 		if (transformations.contains("moj_import")) {
@@ -107,7 +118,9 @@ public class TriforcePatcher {
 		//System.out.println(transformations.toString());
 	}
 
-	public static String patchVanilla(String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset, ShaderAttributeInputs inputs) {
+	public String patchVanilla(String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset, ShaderAttributeInputs inputs) {
+source = patchCommon(source, type);
+
 		StringTransformations transformations = new StringTransformations(source);
 
 		patchCommon(transformations, type);
@@ -269,7 +282,7 @@ public class TriforcePatcher {
 		return transformations.toString();
 	}
 
-	public static String patchSodium(String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs, float positionScale, float positionOffset, float textureScale) {
+	public String patchSodium(String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs, float positionScale, float positionOffset, float textureScale) {
 		StringTransformations transformations = new StringTransformations(source);
 
 		patchCommon(transformations, type);
@@ -367,7 +380,7 @@ public class TriforcePatcher {
 		return transformations.toString();
 	}
 
-	public static String patchComposite(String source, ShaderType type) {
+	public String patchComposite(String source, ShaderType type) {
 		StringTransformations transformations = new StringTransformations(source);
 		patchCommon(transformations, type);
 
@@ -419,7 +432,7 @@ public class TriforcePatcher {
 		return transformations.toString();
 	}
 
-	private static void addAlphaTest(StringTransformations transformations, ShaderType type, AlphaTest alpha) {
+	void addAlphaTest(StringTransformations transformations, ShaderType type, AlphaTest alpha) {
 		if (type == ShaderType.FRAGMENT) {
 			if (transformations.contains("irisMain")) {
 				throw new IllegalStateException("Shader already contains \"irisMain\"???");
@@ -436,7 +449,7 @@ public class TriforcePatcher {
 		}
 	}
 
-	private static void fixVersion(Transformations transformations) {
+	void fixVersion(Transformations transformations) {
 		String prefix = transformations.getPrefix();
 		int split = prefix.indexOf("#version");
 		String beforeVersion = prefix.substring(0, split);

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
@@ -10,13 +10,6 @@ import net.coderbot.iris.shaderpack.transform.StringTransformations;
 import net.coderbot.iris.shaderpack.transform.Transformations;
 
 public class TriforcePatcher implements Patcher {
-	/**
-	 * Patches the shader string without using triforce's transform system.
-	 */
-	String patchCommon(String input, ShaderType type) {
-		return input;
-	}
-
 	void patchCommon(StringTransformations transformations, ShaderType type) {
 		// TODO: Only do the NewLines patches if the source code isn't from gbuffers_lines
 
@@ -115,8 +108,6 @@ public class TriforcePatcher implements Patcher {
 	}
 
 	public String patchVanilla(String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset, ShaderAttributeInputs inputs) {
-		source = patchCommon(source, type);
-
 		StringTransformations transformations = new StringTransformations(source);
 
 		patchCommon(transformations, type);
@@ -279,8 +270,6 @@ public class TriforcePatcher implements Patcher {
 	}
 
 	public String patchSodium(String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs, float positionScale, float positionOffset, float textureScale) {
-		source = patchCommon(source, type);
-
 		StringTransformations transformations = new StringTransformations(source);
 
 		patchCommon(transformations, type);
@@ -379,8 +368,6 @@ public class TriforcePatcher implements Patcher {
 	}
 
 	public String patchComposite(String source, ShaderType type) {
-		source = patchCommon(source, type);
-		
 		StringTransformations transformations = new StringTransformations(source);
 		patchCommon(transformations, type);
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/TriforcePatcher.java
@@ -12,10 +12,6 @@ import net.coderbot.iris.shaderpack.transform.Transformations;
 public class TriforcePatcher implements Patcher {
 	/**
 	 * Patches the shader string without using triforce's transform system.
-	 * 
-	 * @param input The input string to patch
-	 * @param type The type of the shader being patched
-	 * @return The patched shader string
 	 */
 	String patchCommon(String input, ShaderType type) {
 		return input;
@@ -119,7 +115,7 @@ public class TriforcePatcher implements Patcher {
 	}
 
 	public String patchVanilla(String source, ShaderType type, AlphaTest alpha, boolean hasChunkOffset, ShaderAttributeInputs inputs) {
-source = patchCommon(source, type);
+		source = patchCommon(source, type);
 
 		StringTransformations transformations = new StringTransformations(source);
 
@@ -283,6 +279,8 @@ source = patchCommon(source, type);
 	}
 
 	public String patchSodium(String source, ShaderType type, AlphaTest alpha, ShaderAttributeInputs inputs, float positionScale, float positionOffset, float textureScale) {
+		source = patchCommon(source, type);
+
 		StringTransformations transformations = new StringTransformations(source);
 
 		patchCommon(transformations, type);
@@ -381,6 +379,8 @@ source = patchCommon(source, type);
 	}
 
 	public String patchComposite(String source, ShaderType type) {
+		source = patchCommon(source, type);
+		
 		StringTransformations transformations = new StringTransformations(source);
 		patchCommon(transformations, type);
 

--- a/src/main/java/net/coderbot/iris/postprocess/CompositeRenderer.java
+++ b/src/main/java/net/coderbot/iris/postprocess/CompositeRenderer.java
@@ -23,9 +23,9 @@ import net.coderbot.iris.gl.program.ProgramSamplers;
 import net.coderbot.iris.gl.sampler.SamplerLimits;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
-import net.coderbot.iris.pipeline.newshader.TriforcePatcher;
 import net.coderbot.iris.rendertarget.RenderTargets;
 import net.coderbot.iris.pipeline.newshader.FogMode;
+import net.coderbot.iris.pipeline.newshader.Patcher;
 import net.coderbot.iris.samplers.IrisImages;
 import net.coderbot.iris.samplers.IrisSamplers;
 import net.coderbot.iris.shaderpack.PackDirectives;
@@ -216,14 +216,14 @@ public class CompositeRenderer {
 	// TODO: Don't just copy this from DeferredWorldRenderingPipeline
 	private Program createProgram(ProgramSource source, ImmutableSet<Integer> flipped, ImmutableSet<Integer> flippedAtLeastOnceSnapshot,
 														   Supplier<ShadowMapRenderer> shadowMapRendererSupplier) {
-		String vertex = TriforcePatcher.patchComposite(source.getVertexSource().orElseThrow(RuntimeException::new), ShaderType.VERTEX);
+		String vertex = Patcher.getInstance().patchComposite(source.getVertexSource().orElseThrow(RuntimeException::new), ShaderType.VERTEX);
 
 		String geometry = null;
 		if (source.getGeometrySource().isPresent()) {
 			geometry = TriforcePatcher.patchComposite(source.getGeometrySource().orElseThrow(RuntimeException::new), ShaderType.GEOMETRY);
 		}
 
-		String fragment = TriforcePatcher.patchComposite(source.getFragmentSource().orElseThrow(RuntimeException::new), ShaderType.FRAGMENT);
+		String fragment = Patcher.getInstance().patchComposite(source.getFragmentSource().orElseThrow(RuntimeException::new), ShaderType.FRAGMENT);
 
 		ProgramBuilder builder;
 

--- a/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
+++ b/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
@@ -16,7 +16,7 @@ import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.gl.sampler.SamplerLimits;
 import net.coderbot.iris.gl.uniform.UniformUpdateFrequency;
 import net.coderbot.iris.pipeline.newshader.FogMode;
-import net.coderbot.iris.pipeline.newshader.TriforcePatcher;
+import net.coderbot.iris.pipeline.newshader.Patcher;
 import net.coderbot.iris.rendertarget.FramebufferBlitter;
 import net.coderbot.iris.rendertarget.RenderTarget;
 import net.coderbot.iris.rendertarget.RenderTargets;
@@ -249,14 +249,14 @@ public class FinalPassRenderer {
 	// TODO: Don't just copy this from DeferredWorldRenderingPipeline
 	private Program createProgram(ProgramSource source, ImmutableSet<Integer> flipped, ImmutableSet<Integer> flippedAtLeastOnceSnapshot,
 								  Supplier<ShadowMapRenderer> shadowMapRendererSupplier) {
-		String vertex = TriforcePatcher.patchComposite(source.getVertexSource().orElseThrow(RuntimeException::new), ShaderType.VERTEX);
+		String vertex = Patcher.getInstance().patchComposite(source.getVertexSource().orElseThrow(RuntimeException::new), ShaderType.VERTEX);
 
 		String geometry = null;
 		if (source.getGeometrySource().isPresent()) {
 			geometry = TriforcePatcher.patchComposite(source.getGeometrySource().orElseThrow(RuntimeException::new), ShaderType.GEOMETRY);
 		}
 
-		String fragment = TriforcePatcher.patchComposite(source.getFragmentSource().orElseThrow(RuntimeException::new), ShaderType.FRAGMENT);
+		String fragment = Patcher.getInstance().patchComposite(source.getFragmentSource().orElseThrow(RuntimeException::new), ShaderType.FRAGMENT);
 
 		Objects.requireNonNull(flipped);
 

--- a/src/main/java/net/coderbot/iris/shaderpack/transform/Transformations.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/transform/Transformations.java
@@ -10,8 +10,19 @@ public interface Transformations {
 	void define(String key, String value);
 
 	enum InjectionPoint {
+		/**
+		 * in glsl-transformer: InjectionLocation.BEFORE_DIRECTIVES (but only roughly)
+		 */
 		DEFINES,
+
+		/**
+		 * in glsl-transformer: InjectionLocation.BEFORE_DECLARATIONS
+		 */
 		BEFORE_CODE,
+
+		/**
+		 * in glsl-transformer: InjectionLocation.BEFORE_EOF
+		 */
 		END
 	}
 }


### PR DESCRIPTION
This PR adds an abstract system for shader patching through `Patcher` and re-implements `TriforcePatcher` in `TransformPatcher` (as Triforce 2) using `glsl-transformer` for program transformation of the shaders.

Previous PR that was closed to rename the branch: https://github.com/IrisShaders/Iris/pull/1142
Created from https://github.com/IrisShaders/Iris/pull/1311 by cherry-picking the commits actually made to the branch.

This PR targets 1.17 so that a 1.18 version may be created as usual if Triforce isn't modified in 1.18 compared to 1.17.