### PR TITLE
Block type map support

### DIFF
--- a/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockMaterialMapping.java
@@ -3,9 +3,12 @@ package net.coderbot.iris.block_rendering;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.shaderpack.materialmap.BlockEntry;
+import net.coderbot.iris.shaderpack.materialmap.BlockRenderType;
 import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
@@ -29,6 +32,34 @@ public class BlockMaterialMapping {
 		});
 
 		return blockStateIds;
+	}
+
+	public static Map<Block, RenderType> createBlockTypeMap(Map<NamespacedId, BlockRenderType> blockPropertiesMap) {
+		Map<Block, RenderType> blockTypeIds = new Reference2ReferenceOpenHashMap<>();
+
+		blockPropertiesMap.forEach((id, blockType) -> {
+			ResourceLocation resourceLocation = new ResourceLocation(id.getNamespace(), id.getName());
+
+			Block block = Registry.BLOCK.get(resourceLocation);
+
+			blockTypeIds.put(block, convertBlockToRenderType(blockType));
+		});
+
+		return blockTypeIds;
+	}
+
+	private static RenderType convertBlockToRenderType(BlockRenderType type) {
+		if (type == null) {
+			return null;
+		}
+
+		switch (type) {
+			case SOLID: return RenderType.solid();
+			case CUTOUT: return RenderType.cutout();
+			case CUTOUT_MIPPED: return RenderType.cutoutMipped();
+			case TRANSLUCENT: return RenderType.translucent();
+			default: return null;
+		}
 	}
 
 	private static void addBlockStates(BlockEntry entry, Object2IntMap<BlockState> idMap, int intId) {

--- a/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
+++ b/src/main/java/net/coderbot/iris/block_rendering/BlockRenderingSettings.java
@@ -3,14 +3,19 @@ package net.coderbot.iris.block_rendering;
 import it.unimi.dsi.fastutil.objects.Object2IntFunction;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
 
 public class BlockRenderingSettings {
 	public static final BlockRenderingSettings INSTANCE = new BlockRenderingSettings();
 
 	private boolean reloadRequired;
 	private Object2IntMap<BlockState> blockStateIds;
+	private Map<Block, RenderType> blockTypeIds;
 	private Object2IntFunction<NamespacedId> entityIds;
 	private float ambientOcclusionLevel;
 	private boolean disableDirectionalShading;
@@ -19,6 +24,7 @@ public class BlockRenderingSettings {
 	public BlockRenderingSettings() {
 		reloadRequired = false;
 		blockStateIds = null;
+		blockTypeIds = null;
 		ambientOcclusionLevel = 1.0F;
 		disableDirectionalShading = false;
 		useSeparateAo = false;
@@ -37,6 +43,11 @@ public class BlockRenderingSettings {
 		return blockStateIds;
 	}
 
+	@Nullable
+	public Map<Block, RenderType> getBlockTypeIds() {
+		return blockTypeIds;
+	}
+
 	// TODO (coderbot): This doesn't belong here. But I couldn't think of a nicer place to put it.
 	@Nullable
 	public Object2IntFunction<NamespacedId> getEntityIds() {
@@ -50,6 +61,15 @@ public class BlockRenderingSettings {
 
 		this.reloadRequired = true;
 		this.blockStateIds = blockStateIds;
+	}
+
+	public void setBlockTypeIds(Map<Block, RenderType> blockTypeIds) {
+		if (this.blockTypeIds != null && this.blockTypeIds.equals(blockTypeIds)) {
+			return;
+		}
+
+		this.reloadRequired = true;
+		this.blockTypeIds = blockTypeIds;
 	}
 
 	public void setEntityIds(Object2IntFunction<NamespacedId> entityIds) {

--- a/src/main/java/net/coderbot/iris/mixin/MixinItemBlockRenderTypes.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinItemBlockRenderTypes.java
@@ -1,0 +1,23 @@
+package net.coderbot.iris.mixin;
+
+import net.coderbot.iris.block_rendering.BlockRenderingSettings;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemBlockRenderTypes.class)
+public class MixinItemBlockRenderTypes {
+	@Inject(method = "getChunkRenderType", at = @At("HEAD"), cancellable = true)
+	private static void iris$setCustomRenderType(BlockState arg, CallbackInfoReturnable<RenderType> cir) {
+		if (BlockRenderingSettings.INSTANCE.getBlockTypeIds() != null) {
+			RenderType type = BlockRenderingSettings.INSTANCE.getBlockTypeIds().get(arg.getBlock());
+			if (type != null) {
+				cir.setReturnValue(type);
+			}
+		}
+	}
+}

--- a/src/main/java/net/coderbot/iris/mixin/MixinItemBlockRenderTypes.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinItemBlockRenderTypes.java
@@ -3,18 +3,22 @@ package net.coderbot.iris.mixin;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.Map;
+
 @Mixin(ItemBlockRenderTypes.class)
 public class MixinItemBlockRenderTypes {
 	@Inject(method = "getChunkRenderType", at = @At("HEAD"), cancellable = true)
 	private static void iris$setCustomRenderType(BlockState arg, CallbackInfoReturnable<RenderType> cir) {
-		if (BlockRenderingSettings.INSTANCE.getBlockTypeIds() != null) {
-			RenderType type = BlockRenderingSettings.INSTANCE.getBlockTypeIds().get(arg.getBlock());
+		Map<Block, RenderType> idMap = BlockRenderingSettings.INSTANCE.getBlockTypeIds();
+		if (idMap != null) {
+			RenderType type = idMap.get(arg.getBlock());
 			if (type != null) {
 				cir.setReturnValue(type);
 			}

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -184,6 +184,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline {
 
 		BlockRenderingSettings.INSTANCE.setBlockStateIds(
 				BlockMaterialMapping.createBlockStateIdMap(programs.getPack().getIdMap().getBlockProperties()));
+		BlockRenderingSettings.INSTANCE.setBlockTypeIds(BlockMaterialMapping.createBlockTypeMap(programs.getPack().getIdMap().getBlockRenderTypeMap()));
 
 		BlockRenderingSettings.INSTANCE.setEntityIds(programs.getPack().getIdMap().getEntityIdMap());
 		BlockRenderingSettings.INSTANCE.setAmbientOcclusionLevel(programs.getPackDirectives().getAmbientOcclusionLevel());

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -21,6 +21,7 @@
     "MixinGlStateManager_AtlasTracking",
     "MixinGlStateManager_AlphaTestOverride",
     "MixinGlStateManager_BlendOverride",
+    "MixinItemBlockRenderTypes",
     "MixinItemInHandRenderer",
     "MixinLevelRenderer",
     "MixinMinecraft",


### PR DESCRIPTION
This adds the custom render layer feature of block.properties.

Uses a Reference2ReferenceOpenHashMap similar to Sodium for the best performance.