### PR TITLE
Optimize atlas stitching

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
+++ b/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
@@ -47,10 +47,11 @@ public class MixinStitcher {
 		// Iris start
 		boolean growWidth;
 		/*
-		 * Iris short-circuits the logic if only one dimension can fit,
-		 * but vanilla does not. This can potentially lead to maxHeight
-		 * not being respected. Plus, doing it this way makes the code
-		 * easier to understand.
+		 * Vanilla performs logic that can result in the atlas height
+		 * exceeding the maximum allowed value. The easiest solution
+		 * is employed here - short-circuiting the logic if only one
+		 * dimension can fit. This entirely prevents the issue and has
+		 * the bonus of making the code easier to understand.
 		 */
 		if (canFitWidth & canFitHeight) {
 			// Effective size calculation moved from head to be inside if block

--- a/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
+++ b/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
@@ -46,7 +46,7 @@ public class MixinStitcher {
 
 		boolean growWidth;
 		if (canFitWidth & canFitHeight) {
-			// Effective size calculation moved from head to be inside else block
+			// Effective size calculation moved from head to be inside if block
 			int effectiveWidth = Mth.smallestEncompassingPowerOfTwo(storageX);
 			int effectiveHeight = Mth.smallestEncompassingPowerOfTwo(storageY);
 			boolean wouldGrowEffectiveWidth = effectiveWidth != newEffectiveWidth;

--- a/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
+++ b/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
@@ -44,7 +44,14 @@ public class MixinStitcher {
 			return false;
 		}
 
+		// Iris start
 		boolean growWidth;
+		/*
+		 * Iris short-circuits the logic if only one dimension can fit,
+		 * but vanilla does not. This can potentially lead to maxHeight
+		 * not being respected. Plus, doing it this way makes the code
+		 * easier to understand.
+		 */
 		if (canFitWidth & canFitHeight) {
 			// Effective size calculation moved from head to be inside if block
 			int effectiveWidth = Mth.smallestEncompassingPowerOfTwo(storageX);
@@ -53,6 +60,26 @@ public class MixinStitcher {
 			boolean wouldGrowEffectiveHeight = effectiveHeight != newEffectiveHeight;
 
 			if (wouldGrowEffectiveWidth) {
+				/*
+				 * The logic here differs from vanilla slightly as it combines the
+				 * vanilla checks together into the if statement.
+				 *
+				 * If the effective height would not be grown:
+				 *   Under the same conditions, vanilla would grow the width instead
+				 *   of the height. This is inefficient because it can potentially
+				 *   increase the atlas width, which is (usually) unnecessary since
+				 *   there is already enough free space on the bottom to not grow the
+				 *   atlas size.
+				 *
+				 * If the effective height would be grown but the width is greater
+				 * than the height:
+				 *   Under the same conditions, vanilla would always grow the height.
+				 *   However, not performing the additional check would cause some
+				 *   edge cases to result in cut-off sprites. The following case is
+				 *   one such example.
+				 *   1. The first sprite is added. Its dimensions measure 128x32.
+				 *   2. The second sprite is added. Its dimensions measure 256x16.
+				 */
 				if (wouldGrowEffectiveHeight && effectiveWidth <= effectiveHeight) {
 					/*
 					 * If both the width and height would be grown, definitively grow the
@@ -61,6 +88,10 @@ public class MixinStitcher {
 					growWidth = true;
 				} else {
 					/*
+					 * At this point, the height should be grown to maximize atlas space
+					 * usage, but this is not always possible to do. Hence, the following
+					 * check is employed to ensure that the height can actually be grown.
+					 *
 					 * If the height is grown, the new region's width is equal to the total
 					 * width. However, if the holder's width is larger than the total width,
 					 * the new region will not be able to contain it. Therefore, the width
@@ -76,6 +107,8 @@ public class MixinStitcher {
 					 * A similar check does not have to be performed for the heights due to
 					 * the sprite sorting - taller sprites are always added before shorter
 					 * ones.
+					 *
+					 * Vanilla does not perform this check.
 					 */
 					growWidth = holder.width > storageX;
 				}
@@ -84,6 +117,12 @@ public class MixinStitcher {
 					/*
 					 * If the height would be grown but the width would not be, grow the
 					 * width to fill up the unused space on the right.
+					 *
+					 * Under the same conditions, vanilla would grow the height instead
+					 * of the width. This is inefficient because it can potentially
+					 * increase the atlas height, which is unnecessary since there is
+					 * already enough free space on the right to not grow the atlas
+					 * size.
 					 */
 					growWidth = true;
 				} else {
@@ -98,6 +137,7 @@ public class MixinStitcher {
 		} else {
 			growWidth = canFitWidth;
 		}
+		// Iris end
 
 		Region region;
 		if (growWidth) {

--- a/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
+++ b/src/main/java/net/coderbot/iris/mixin/optimized_stitching/MixinStitcher.java
@@ -1,0 +1,119 @@
+package net.coderbot.iris.mixin.optimized_stitching;
+
+import net.minecraft.client.renderer.texture.Stitcher;
+import net.minecraft.client.renderer.texture.Stitcher.Holder;
+import net.minecraft.client.renderer.texture.Stitcher.Region;
+import net.minecraft.util.Mth;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+
+@Mixin(Stitcher.class)
+public class MixinStitcher {
+	@Shadow
+	@Final
+	private List<Region> storage;
+	@Shadow
+	private int storageX;
+	@Shadow
+	private int storageY;
+	@Shadow
+	@Final
+	private int maxWidth;
+	@Shadow
+	@Final
+	private int maxHeight;
+
+	/**
+	 * This method is a copy of the vanilla method with the growWidth calculation rewritten.
+	 *
+	 * @author PepperCode1
+	 * @reason Optimize region creation to allow for a smaller atlas
+	 */
+	@Overwrite
+	private boolean expand(Holder holder) {
+		int newEffectiveWidth = Mth.smallestEncompassingPowerOfTwo(storageX + holder.width);
+		int newEffectiveHeight = Mth.smallestEncompassingPowerOfTwo(storageY + holder.height);
+		boolean canFitWidth = newEffectiveWidth <= maxWidth;
+		boolean canFitHeight = newEffectiveHeight <= maxHeight;
+
+		if (!canFitWidth && !canFitHeight) {
+			return false;
+		}
+
+		boolean growWidth;
+		if (canFitWidth & canFitHeight) {
+			// Effective size calculation moved from head to be inside else block
+			int effectiveWidth = Mth.smallestEncompassingPowerOfTwo(storageX);
+			int effectiveHeight = Mth.smallestEncompassingPowerOfTwo(storageY);
+			boolean wouldGrowEffectiveWidth = effectiveWidth != newEffectiveWidth;
+			boolean wouldGrowEffectiveHeight = effectiveHeight != newEffectiveHeight;
+
+			if (wouldGrowEffectiveWidth) {
+				if (wouldGrowEffectiveHeight && effectiveWidth <= effectiveHeight) {
+					/*
+					 * If both the width and height would be grown, definitively grow the
+					 * width if it is less than or equal to the height.
+					 */
+					growWidth = true;
+				} else {
+					/*
+					 * If the height is grown, the new region's width is equal to the total
+					 * width. However, if the holder's width is larger than the total width,
+					 * the new region will not be able to contain it. Therefore, the width
+					 * should be grown instead.
+					 *
+					 * By extension, this check does not have to be performed if growWidth
+					 * is already true.
+					 *
+					 * This check does not have to be performed when wouldGrowEffectiveWidth
+					 * is false because this means that the total width would be less than
+					 * doubled, meaning that the holder width is less than the total width.
+					 *
+					 * A similar check does not have to be performed for the heights due to
+					 * the sprite sorting - taller sprites are always added before shorter
+					 * ones.
+					 */
+					growWidth = holder.width > storageX;
+				}
+			} else {
+				if (wouldGrowEffectiveHeight) {
+					/*
+					 * If the height would be grown but the width would not be, grow the
+					 * width to fill up the unused space on the right.
+					 */
+					growWidth = true;
+				} else {
+					/*
+					 * If neither the width nor height would be grown, grow the dimension
+					 * that is smaller than the other. If both dimensions are already the
+					 * same, grow the width.
+					 */
+					growWidth = effectiveWidth <= effectiveHeight;
+				}
+			}
+		} else {
+			growWidth = canFitWidth;
+		}
+
+		Region region;
+		if (growWidth) {
+			if (storageY == 0) {
+				storageY = holder.height;
+			}
+
+			region = new Region(storageX, 0, holder.width, storageY);
+			storageX += holder.width;
+		} else {
+			region = new Region(0, storageY, storageX, holder.height);
+			storageY += holder.height;
+		}
+
+		region.add(holder);
+		storage.add(region);
+		return true;
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,6 +33,7 @@
     "mixins.iris.fantastic.json",
     "mixins.iris.vertexformat.json",
     "mixins.iris.bettermipmaps.json",
+    "mixins.iris.optimized-stitching.json",
     "mixins.iris.compat.indigo.json",
     "mixins.iris.compat.sodium.json",
     "mixins.iris.compat.indium.json"

--- a/src/main/resources/iris.accesswidener
+++ b/src/main/resources/iris.accesswidener
@@ -1,7 +1,9 @@
 accessWidener v1 named
+
 accessible class com/mojang/blaze3d/platform/GlStateManager$AlphaState
 accessible class com/mojang/blaze3d/platform/GlStateManager$BlendState
 accessible class com/mojang/blaze3d/platform/GlStateManager$FogState
 accessible class com/mojang/blaze3d/platform/GlStateManager$TextureState
+accessible class net/minecraft/client/renderer/texture/Stitcher$Holder
 accessible class net/minecraft/client/renderer/LevelRenderer$RenderChunkInfo
 mutable field net/minecraft/client/renderer/LevelRenderer renderBuffers Lnet/minecraft/client/renderer/RenderBuffers;

--- a/src/main/resources/mixins.iris.optimized-stitching.json
+++ b/src/main/resources/mixins.iris.optimized-stitching.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.coderbot.iris.mixin.optimized_stitching",
+  "compatibilityLevel": "JAVA_8",
+  "client": [
+    "MixinStitcher",
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
`Stitcher#expand` is overwritten to optimize region creation, thus optimizing the size of the atlas. The block atlas (and some others) is halved in size when using default textures as a result of this change (1024x1024 -> 1024x512). Refer to the javadoc and comments for more information.