### PR TITLE
(In 1.18.2) For compatibility with Immersive Portals: Use version number to track whether the color buffer and depth buffer should refresh.

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinRenderTarget.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinRenderTarget.java
@@ -17,32 +17,22 @@ public class MixinRenderTarget implements Blaze3dRenderTargetExt {
 	@Shadow
 	private int depthBufferId;
 
-	private boolean iris$depthDirty = false;
-	private boolean iris$colorDirty = false;
+	private int iris$depthBufferVersion;
+	private int iris$colorBufferVersion;
 
 	@Inject(method = "destroyBuffers()V", at = @At("HEAD"))
 	private void iris$onDestroyBuffers(CallbackInfo ci) {
-		iris$depthDirty = true;
-		iris$colorDirty = true;
+		iris$depthBufferVersion++;
+		iris$colorBufferVersion++;
 	}
 
 	@Override
-	public boolean iris$isDepthBufferDirty() {
-		return iris$depthDirty;
+	public int iris$getDepthBufferVersion() {
+		return iris$depthBufferVersion;
 	}
 
 	@Override
-	public void iris$clearDepthBufferDirtyFlag() {
-		iris$depthDirty = false;
-	}
-
-	@Override
-	public boolean iris$isColorBufferDirty() {
-		return iris$colorDirty;
-	}
-
-	@Override
-	public void iris$clearColorBufferDirtyFlag() {
-		iris$colorDirty = false;
+	public int iris$getColorBufferVersion() {
+		return iris$colorBufferVersion;
 	}
 }

--- a/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -2,6 +2,7 @@ package net.coderbot.iris.pipeline;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.mojang.blaze3d.pipeline.MainTarget;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -153,6 +154,7 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		DepthBufferFormat depthBufferFormat = DepthBufferFormat.fromGlEnumOrDefault(internalFormat);
 
 		this.renderTargets = new RenderTargets(mainTarget.width, mainTarget.height, depthTextureId,
+			((Blaze3dRenderTargetExt) mainTarget).iris$getDepthBufferVersion(),
 			depthBufferFormat, programs.getPackDirectives().getRenderTargetDirectives().getRenderTargetSettings());
 
 		this.sunPathRotation = programs.getPackDirectives().getSunPathRotation();
@@ -809,10 +811,8 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 		int internalFormat = TextureInfoCache.INSTANCE.getInfo(depthTextureId).getInternalFormat();
 		DepthBufferFormat depthBufferFormat = DepthBufferFormat.fromGlEnumOrDefault(internalFormat);
 
-		renderTargets.resizeIfNeeded(mainExt.iris$isDepthBufferDirty(), depthTextureId, main.width,
+		renderTargets.resizeIfNeeded(mainExt.iris$getDepthBufferVersion(), depthTextureId, main.width,
 			main.height, depthBufferFormat);
-
-		mainExt.iris$clearDepthBufferDirtyFlag();
 
 		final ImmutableList<ClearPass> passes;
 

--- a/src/main/java/net/coderbot/iris/pipeline/newshader/NewWorldRenderingPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/newshader/NewWorldRenderingPipeline.java
@@ -2,6 +2,7 @@ package net.coderbot.iris.pipeline.newshader;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.mojang.blaze3d.pipeline.MainTarget;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -155,7 +156,9 @@ public class NewWorldRenderingPipeline implements WorldRenderingPipeline, CoreWo
 		int internalFormat = TextureInfoCache.INSTANCE.getInfo(depthTextureId).getInternalFormat();
 		DepthBufferFormat depthBufferFormat = DepthBufferFormat.fromGlEnumOrDefault(internalFormat);
 
-		this.renderTargets = new RenderTargets(main.width, main.height, depthTextureId, depthBufferFormat, programSet.getPackDirectives().getRenderTargetDirectives().getRenderTargetSettings());
+		this.renderTargets = new RenderTargets(main.width, main.height, depthTextureId,
+			((Blaze3dRenderTargetExt) main).iris$getDepthBufferVersion(),
+			depthBufferFormat, programSet.getPackDirectives().getRenderTargetDirectives().getRenderTargetSettings());
 		this.sunPathRotation = programSet.getPackDirectives().getSunPathRotation();
 
 		PackShadowDirectives shadowDirectives = programSet.getPackDirectives().getShadowDirectives();
@@ -551,8 +554,7 @@ public class NewWorldRenderingPipeline implements WorldRenderingPipeline, CoreWo
 		int internalFormat = TextureInfoCache.INSTANCE.getInfo(depthTextureId).getInternalFormat();
 		DepthBufferFormat depthBufferFormat = DepthBufferFormat.fromGlEnumOrDefault(internalFormat);
 
-		renderTargets.resizeIfNeeded(((Blaze3dRenderTargetExt) main).iris$isDepthBufferDirty(), depthTextureId, main.width, main.height, depthBufferFormat);
-		((Blaze3dRenderTargetExt) main).iris$clearDepthBufferDirtyFlag();
+		renderTargets.resizeIfNeeded(((Blaze3dRenderTargetExt) main).iris$getDepthBufferVersion(), depthTextureId, main.width, main.height, depthBufferFormat);
 
 		final ImmutableList<ClearPass> passes;
 

--- a/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
+++ b/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
@@ -2,6 +2,7 @@ package net.coderbot.iris.postprocess;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.mojang.blaze3d.pipeline.MainTarget;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -57,6 +58,7 @@ public class FinalPassRenderer {
 	private final GlFramebuffer baseline;
 	private final GlFramebuffer colorHolder;
 	private int lastColorTextureId;
+	private int lastColorTextureVersion;
 	private final IntSupplier noiseTexture;
 	private final FrameUpdateNotifier updateNotifier;
 	private final CenterDepthSampler centerDepthSampler;
@@ -99,6 +101,7 @@ public class FinalPassRenderer {
 		this.baseline = renderTargets.createGbufferFramebuffer(flippedBuffers, new int[] {0});
 		this.colorHolder = new GlFramebuffer();
 		this.lastColorTextureId = Minecraft.getInstance().getMainRenderTarget().getColorTextureId();
+		this.lastColorTextureVersion = ((Blaze3dRenderTargetExt) Minecraft.getInstance().getMainRenderTarget()).iris$getColorBufferVersion();
 		this.colorHolder.addColorAttachment(0, lastColorTextureId);
 
 		// TODO: We don't actually fully swap the content, we merely copy it from alt to main
@@ -163,8 +166,8 @@ public class FinalPassRenderer {
 		//
 		// This is not a concern for depthtex1 / depthtex2 since the copy call extracts the depth values, and the
 		// shader pack only ever uses them to read the depth values.
-		if (((Blaze3dRenderTargetExt) main).iris$isColorBufferDirty() || main.getColorTextureId() != lastColorTextureId) {
-			((Blaze3dRenderTargetExt) main).iris$clearColorBufferDirtyFlag();
+		if (((Blaze3dRenderTargetExt) main).iris$getColorBufferVersion() != lastColorTextureVersion || main.getColorTextureId() != lastColorTextureId) {
+			lastColorTextureVersion = ((Blaze3dRenderTargetExt) main).iris$getColorBufferVersion();
 			this.lastColorTextureId = main.getColorTextureId();
 			colorHolder.addColorAttachment(0, lastColorTextureId);
 		}

--- a/src/main/java/net/coderbot/iris/rendertarget/Blaze3dRenderTargetExt.java
+++ b/src/main/java/net/coderbot/iris/rendertarget/Blaze3dRenderTargetExt.java
@@ -1,9 +1,7 @@
 package net.coderbot.iris.rendertarget;
 
 public interface Blaze3dRenderTargetExt {
-	boolean iris$isDepthBufferDirty();
-	void iris$clearDepthBufferDirtyFlag();
+	int iris$getDepthBufferVersion();
 
-	boolean iris$isColorBufferDirty();
-	void iris$clearColorBufferDirtyFlag();
+	int iris$getColorBufferVersion();
 }

--- a/src/main/java/net/coderbot/iris/rendertarget/RenderTargets.java
+++ b/src/main/java/net/coderbot/iris/rendertarget/RenderTargets.java
@@ -30,7 +30,9 @@ public class RenderTargets {
 
 	private boolean destroyed;
 
-	public RenderTargets(int width, int height, int depthTexture, DepthBufferFormat depthFormat, Map<Integer, PackRenderTargetDirectives.RenderTargetSettings> renderTargets) {
+	private int cachedDepthBufferVersion;
+
+	public RenderTargets(int width, int height, int depthTexture, int depthBufferVersion, DepthBufferFormat depthFormat, Map<Integer, PackRenderTargetDirectives.RenderTargetSettings> renderTargets) {
 		targets = new RenderTarget[renderTargets.size()];
 
 		renderTargets.forEach((index, settings) -> {
@@ -49,6 +51,7 @@ public class RenderTargets {
 
 		this.cachedWidth = width;
 		this.cachedHeight = height;
+		this.cachedDepthBufferVersion = depthBufferVersion;
 
 		this.ownedFramebuffers = new ArrayList<>();
 
@@ -108,10 +111,12 @@ public class RenderTargets {
 		return noHand;
 	}
 
-	public void resizeIfNeeded(boolean recreateDepth, int newDepthTextureId, int newWidth, int newHeight, DepthBufferFormat newDepthFormat) {
-		if (newDepthTextureId != currentDepthTexture) {
+	public void resizeIfNeeded(int newDepthBufferVersion, int newDepthTextureId, int newWidth, int newHeight, DepthBufferFormat newDepthFormat) {
+		boolean recreateDepth = false;
+		if (cachedDepthBufferVersion != newDepthBufferVersion) {
 			recreateDepth = true;
 			currentDepthTexture = newDepthTextureId;
+			cachedDepthBufferVersion = newDepthBufferVersion;
 		}
 
 		boolean sizeChanged = newWidth != cachedWidth || newHeight != cachedHeight;


### PR DESCRIPTION
I roughly tested it and the window resizing works both with and without immptl.