### PR TITLE
Use addDepthStencilAttachment instead of addDepthAttachment if the framebuffer has stencil.

### DIFF
--- a/src/main/java/net/coderbot/iris/gl/framebuffer/GlFramebuffer.java
+++ b/src/main/java/net/coderbot/iris/gl/framebuffer/GlFramebuffer.java
@@ -5,6 +5,8 @@ import it.unimi.dsi.fastutil.ints.Int2IntArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import net.coderbot.iris.gl.GlResource;
 import net.coderbot.iris.gl.IrisRenderSystem;
+import net.coderbot.iris.gl.texture.DepthBufferFormat;
+import net.coderbot.iris.texture.TextureInfoCache;
 import org.lwjgl.opengl.GL30C;
 
 public class GlFramebuffer extends GlResource {
@@ -23,13 +25,16 @@ public class GlFramebuffer extends GlResource {
 	}
 
 	public void addDepthAttachment(int texture) {
-		bind();
-		GlStateManager._glFramebufferTexture2D(GL30C.GL_FRAMEBUFFER, GL30C.GL_DEPTH_ATTACHMENT, GL30C.GL_TEXTURE_2D, texture, 0);
-	}
+		int internalFormat = TextureInfoCache.INSTANCE.getInfo(texture).getInternalFormat();
+		DepthBufferFormat depthBufferFormat = DepthBufferFormat.fromGlEnumOrDefault(internalFormat);
 
-	public void addDepthStencilAttachment(int texture) {
 		bind();
-		GlStateManager._glFramebufferTexture2D(GL30C.GL_FRAMEBUFFER, GL30C.GL_DEPTH_STENCIL_ATTACHMENT, GL30C.GL_TEXTURE_2D, texture, 0);
+
+		if (depthBufferFormat.isCombinedStencil()) {
+			GlStateManager._glFramebufferTexture2D(GL30C.GL_FRAMEBUFFER, GL30C.GL_DEPTH_STENCIL_ATTACHMENT, GL30C.GL_TEXTURE_2D, texture, 0);
+		} else {
+			GlStateManager._glFramebufferTexture2D(GL30C.GL_FRAMEBUFFER, GL30C.GL_DEPTH_ATTACHMENT, GL30C.GL_TEXTURE_2D, texture, 0);
+		}
 	}
 
 	public void addColorAttachment(int index, int texture) {

--- a/src/main/java/net/coderbot/iris/rendertarget/RenderTargets.java
+++ b/src/main/java/net/coderbot/iris/rendertarget/RenderTargets.java
@@ -137,11 +137,7 @@ public class RenderTargets {
 					continue;
 				}
 
-				if (currentDepthFormat.isCombinedStencil()) {
-					framebuffer.addDepthStencilAttachment(newDepthTextureId);
-				} else {
-					framebuffer.addDepthAttachment(newDepthTextureId);
-				}
+				framebuffer.addDepthAttachment(newDepthTextureId);
 			}
 		}
 

--- a/src/main/java/net/coderbot/iris/rendertarget/RenderTargets.java
+++ b/src/main/java/net/coderbot/iris/rendertarget/RenderTargets.java
@@ -111,6 +111,7 @@ public class RenderTargets {
 		boolean depthFormatChanged = newDepthFormat != currentDepthFormat;
 
 		if (depthFormatChanged) {
+			currentDepthFormat = newDepthFormat;
 			// Might need a new copy strategy
 			copyStrategy = DepthCopyStrategy.fastest(currentDepthFormat.isCombinedStencil());
 		}
@@ -136,7 +137,11 @@ public class RenderTargets {
 					continue;
 				}
 
-				framebuffer.addDepthAttachment(newDepthTextureId);
+				if (currentDepthFormat.isCombinedStencil()) {
+					framebuffer.addDepthStencilAttachment(newDepthTextureId);
+				} else {
+					framebuffer.addDepthAttachment(newDepthTextureId);
+				}
 			}
 		}
 


### PR DESCRIPTION
Without this, stencil buffer cannot really work with shaders on.