### PR TITLE
Use version counter to check whether to reload sodium shaders, for compatibility with Immersive Portals

### DIFF
--- a/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -1,8 +1,11 @@
 package net.coderbot.iris.pipeline;
 
 import com.mojang.blaze3d.platform.GlStateManager;
+import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
+import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
+import net.coderbot.iris.compat.sodium.impl.shader_overrides.IrisChunkProgramOverrides;
 import net.coderbot.iris.shaderpack.DimensionId;
 import net.coderbot.iris.uniforms.SystemTimeUniforms;
 import net.minecraft.client.Minecraft;
@@ -57,6 +60,15 @@ public class PipelineManager {
 		return Optional.ofNullable(pipeline);
 	}
 
+	/**
+	 * In {@link IrisChunkProgramOverrides#getProgramOverride(RenderDevice, BlockRenderPass)},
+	 * it uses version counter to check whether to reload sodium shaders.
+	 * This fixes a compat issue with Immersive Portals(#1188).
+	 * Immersive Portals may load multiple client dimensions at the same time,
+	 * and every dimension corresponds to a {@link IrisChunkProgramOverrides} object.
+	 * Multiple dimensions (mod dimensions that fallback to overworld shaders) may use the same pipeline.
+	 * This ensures that the sodium shader for each dimension will get properly reloaded.
+	 */
 	public int getVersionCounterForSodiumShaderReload() {
 		return versionCounterForSodiumShaderReload;
 	}

--- a/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -61,22 +61,6 @@ public class PipelineManager {
 		return versionCounterForSodiumShaderReload;
 	}
 
-	public void setAsInstance() {
-		if (instance != null) {
-			throw new IllegalStateException("Multiple pipeline managers active at one time");
-		} else {
-			instance = this;
-		}
-	}
-
-	public static void resetInstance() {
-		instance = null;
-	}
-
-	public static PipelineManager getInstance() {
-		return instance;
-	}
-
 	/**
 	 * Destroys all the current pipelines.
 	 *

--- a/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -19,7 +19,7 @@ public class PipelineManager {
 	private final Function<DimensionId, WorldRenderingPipeline> pipelineFactory;
 	private final Map<DimensionId, WorldRenderingPipeline> pipelinesPerDimension = new HashMap<>();
 	private WorldRenderingPipeline pipeline = new FixedFunctionWorldRenderingPipeline();
-	private boolean sodiumShaderReloadNeeded;
+	private int versionCounterForSodiumShaderReload = 0;
 
 	public PipelineManager(Function<DimensionId, WorldRenderingPipeline> pipelineFactory) {
 		this.pipelineFactory = pipelineFactory;
@@ -33,7 +33,6 @@ public class PipelineManager {
 			Iris.logger.info("Creating pipeline for dimension {}", currentDimension);
 			pipeline = pipelineFactory.apply(currentDimension);
 			pipelinesPerDimension.put(currentDimension, pipeline);
-			sodiumShaderReloadNeeded = true;
 
 			if (BlockRenderingSettings.INSTANCE.isReloadRequired()) {
 				if (Minecraft.getInstance().levelRenderer != null) {
@@ -58,12 +57,8 @@ public class PipelineManager {
 		return Optional.ofNullable(pipeline);
 	}
 
-	public boolean isSodiumShaderReloadNeeded() {
-		return sodiumShaderReloadNeeded;
-	}
-
-	public void clearSodiumShaderReloadNeeded() {
-		sodiumShaderReloadNeeded = false;
+	public int getVersionCounterForSodiumShaderReload() {
+		return versionCounterForSodiumShaderReload;
 	}
 
 	public void setAsInstance() {
@@ -102,6 +97,7 @@ public class PipelineManager {
 
 		pipelinesPerDimension.clear();
 		pipeline = null;
+		versionCounterForSodiumShaderReload++;
 	}
 
 	private void resetTextureState() {

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgramOverrides.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgramOverrides.java
@@ -28,6 +28,8 @@ public class IrisChunkProgramOverrides {
 
 	private final EnumMap<IrisTerrainPass, ChunkProgram> programs = new EnumMap<>(IrisTerrainPass.class);
 
+	private int versionCounterForSodiumShaderReload = -1;
+
 	private GlShader createVertexShader(RenderDevice device, IrisTerrainPass pass, SodiumTerrainPipeline pipeline) {
 		Optional<String> irisVertexShader;
 
@@ -164,8 +166,6 @@ public class IrisChunkProgramOverrides {
 	}
 
 	public void createShaders(SodiumTerrainPipeline sodiumTerrainPipeline, RenderDevice device) {
-		Iris.getPipelineManager().clearSodiumShaderReloadNeeded();
-
 		if (sodiumTerrainPipeline != null) {
 			for (IrisTerrainPass pass : IrisTerrainPass.values()) {
 				if (pass == IrisTerrainPass.SHADOW && !sodiumTerrainPipeline.hasShadowPass()) {
@@ -189,7 +189,8 @@ public class IrisChunkProgramOverrides {
 			sodiumTerrainPipeline = worldRenderingPipeline.getSodiumTerrainPipeline();
 		}
 
-		if (Iris.getPipelineManager().isSodiumShaderReloadNeeded()) {
+		if (versionCounterForSodiumShaderReload != Iris.getPipelineManager().getVersionCounterForSodiumShaderReload()) {
+			versionCounterForSodiumShaderReload = Iris.getPipelineManager().getVersionCounterForSodiumShaderReload();
 			deleteShaders();
 			createShaders(sodiumTerrainPipeline, device);
 		}


### PR DESCRIPTION
Fix https://github.com/IrisShaders/Iris/issues/1188

Immersive Portals' custom dimension also use the overworld pipeline. However, every dimension have one `LevelRenderer` and one `IrisChunkProgramOverrides`. It only set `sodiumShaderReloadNeeded` when creating a new pipeline, so the shader in custom dimension won't be reloaded. This issue does not manifest without ImmPtl because only one client world is present. This PR fixes this by using version counter to determine whether to reload the sodium shader.

Also removes unused `PipelineManager.getInstance()` (It uses `Iris.getPipelineManager()`).

How to solve merge confilct in 1.18.2 branch: https://github.com/qouteall/Iris/commit/5bc76294e515d21ce768ae508e81dc7162a663f5