### PR TITLE
Rename Uniform Prefixes to iris_ for better future integration with glsl-transformer

### DIFF
--- a/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
@@ -1,5 +1,9 @@
 package net.coderbot.iris.pipeline;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.IntFunction;
+
 import net.coderbot.iris.IrisLogging;
 import net.coderbot.iris.gl.program.ProgramImages;
 import net.coderbot.iris.gl.program.ProgramSamplers;
@@ -11,10 +15,6 @@ import net.coderbot.iris.shaderpack.transform.StringTransformations;
 import net.coderbot.iris.shaderpack.transform.Transformations;
 import net.coderbot.iris.uniforms.CommonUniforms;
 import net.coderbot.iris.uniforms.builtin.BuiltinReplacementUniforms;
-
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.IntFunction;
 
 public class SodiumTerrainPipeline {
 	String terrainVertex;
@@ -107,10 +107,10 @@ public class SodiumTerrainPipeline {
 			"attribute vec2 iris_LightCoord; // The light map texture coordinate of the vertex\n" +
 			"attribute vec3 iris_Normal; // The vertex normal\n" +
 			"uniform mat4 iris_ModelViewMatrix;\n" +
-			"uniform mat4 iris_ModelViewProjectionMatrix;\n" +
+			"uniform mat4 u_ModelViewProjectionMatrix;\n" +
 			"uniform mat4 iris_NormalMatrix;\n" +
-			"uniform vec3 iris_ModelScale;\n" +
-			"uniform vec2 iris_TextureScale;\n" +
+			"uniform vec3 u_ModelScale;\n" +
+			"uniform vec2 u_TextureScale;\n" +
 			"\n" +
 			"// The model translation for this draw call.\n" +
 			"attribute vec4 iris_ModelOffset;\n" +
@@ -119,13 +119,13 @@ public class SodiumTerrainPipeline {
 
 		transformations.injectLine(Transformations.InjectionPoint.BEFORE_CODE, injections);
 
-		transformations.define("gl_Vertex", "vec4((iris_Pos * iris_ModelScale) + iris_ModelOffset.xyz, 1.0)");
+		transformations.define("gl_Vertex", "vec4((iris_Pos * u_ModelScale) + iris_ModelOffset.xyz, 1.0)");
 		// transformations.replaceExact("gl_MultiTexCoord1.xy/255.0", "iris_LightCoord");
-		transformations.define("gl_MultiTexCoord0", "vec4(iris_TexCoord * iris_TextureScale, 0.0, 1.0)");
+		transformations.define("gl_MultiTexCoord0", "vec4(iris_TexCoord * u_TextureScale, 0.0, 1.0)");
 		//transformations.replaceExact("gl_MultiTexCoord1", "vec4(iris_LightCoord * 255.0, 0.0, 1.0)");
 		transformations.define("gl_Color", "iris_Color");
 		transformations.define("gl_ModelViewMatrix", "iris_ModelViewMatrix");
-		transformations.define("gl_ModelViewProjectionMatrix", "iris_ModelViewProjectionMatrix");
+		transformations.define("gl_ModelViewProjectionMatrix", "u_ModelViewProjectionMatrix");
 		transformations.replaceExact("gl_TextureMatrix[0]", "mat4(1.0)");
 		// transformations.replaceExact("gl_TextureMatrix[1]", "mat4(1.0 / 255.0)");
 		transformations.define("gl_NormalMatrix", "mat3(iris_NormalMatrix)");
@@ -148,11 +148,11 @@ public class SodiumTerrainPipeline {
 
 		String injections =
 				"uniform mat4 iris_ModelViewMatrix;\n" +
-				"uniform mat4 iris_ModelViewProjectionMatrix;\n" +
+				"uniform mat4 u_ModelViewProjectionMatrix;\n" +
 				"uniform mat4 iris_NormalMatrix;\n";
 
 		transformations.define("gl_ModelViewMatrix", "iris_ModelViewMatrix");
-		transformations.define("gl_ModelViewProjectionMatrix", "iris_ModelViewProjectionMatrix");
+		transformations.define("gl_ModelViewProjectionMatrix", "u_ModelViewProjectionMatrix");
 		transformations.replaceExact("gl_TextureMatrix[0]", "mat4(1.0)");
 		transformations.define("gl_NormalMatrix", "mat3(iris_NormalMatrix)");
 

--- a/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
@@ -101,39 +101,39 @@ public class SodiumTerrainPipeline {
 	private static String transformVertexShader(String base) {
 		StringTransformations transformations = new StringTransformations(base);
 
-		String injections = "attribute vec3 a_Pos; // The position of the vertex\n" +
-			"attribute vec4 a_Color; // The color of the vertex\n" +
-			"attribute vec2 a_TexCoord; // The block texture coordinate of the vertex\n" +
-			"attribute vec2 a_LightCoord; // The light map texture coordinate of the vertex\n" +
-			"attribute vec3 a_Normal; // The vertex normal\n" +
-			"uniform mat4 u_ModelViewMatrix;\n" +
-			"uniform mat4 u_ModelViewProjectionMatrix;\n" +
-			"uniform mat4 u_NormalMatrix;\n" +
-			"uniform vec3 u_ModelScale;\n" +
-			"uniform vec2 u_TextureScale;\n" +
+		String injections = "attribute vec3 iris_Pos; // The position of the vertex\n" +
+			"attribute vec4 iris_Color; // The color of the vertex\n" +
+			"attribute vec2 iris_TexCoord; // The block texture coordinate of the vertex\n" +
+			"attribute vec2 iris_LightCoord; // The light map texture coordinate of the vertex\n" +
+			"attribute vec3 iris_Normal; // The vertex normal\n" +
+			"uniform mat4 iris_ModelViewMatrix;\n" +
+			"uniform mat4 iris_ModelViewProjectionMatrix;\n" +
+			"uniform mat4 iris_NormalMatrix;\n" +
+			"uniform vec3 iris_ModelScale;\n" +
+			"uniform vec2 iris_TextureScale;\n" +
 			"\n" +
 			"// The model translation for this draw call.\n" +
-			"attribute vec4 d_ModelOffset;\n" +
+			"attribute vec4 iris_ModelOffset;\n" +
 			"\n" +
 			"vec4 ftransform() { return gl_ModelViewProjectionMatrix * gl_Vertex; }";
 
 		transformations.injectLine(Transformations.InjectionPoint.BEFORE_CODE, injections);
 
-		transformations.define("gl_Vertex", "vec4((a_Pos * u_ModelScale) + d_ModelOffset.xyz, 1.0)");
-		// transformations.replaceExact("gl_MultiTexCoord1.xy/255.0", "a_LightCoord");
-		transformations.define("gl_MultiTexCoord0", "vec4(a_TexCoord * u_TextureScale, 0.0, 1.0)");
-		//transformations.replaceExact("gl_MultiTexCoord1", "vec4(a_LightCoord * 255.0, 0.0, 1.0)");
-		transformations.define("gl_Color", "a_Color");
-		transformations.define("gl_ModelViewMatrix", "u_ModelViewMatrix");
-		transformations.define("gl_ModelViewProjectionMatrix", "u_ModelViewProjectionMatrix");
+		transformations.define("gl_Vertex", "vec4((iris_Pos * iris_ModelScale) + iris_ModelOffset.xyz, 1.0)");
+		// transformations.replaceExact("gl_MultiTexCoord1.xy/255.0", "iris_LightCoord");
+		transformations.define("gl_MultiTexCoord0", "vec4(iris_TexCoord * iris_TextureScale, 0.0, 1.0)");
+		//transformations.replaceExact("gl_MultiTexCoord1", "vec4(iris_LightCoord * 255.0, 0.0, 1.0)");
+		transformations.define("gl_Color", "iris_Color");
+		transformations.define("gl_ModelViewMatrix", "iris_ModelViewMatrix");
+		transformations.define("gl_ModelViewProjectionMatrix", "iris_ModelViewProjectionMatrix");
 		transformations.replaceExact("gl_TextureMatrix[0]", "mat4(1.0)");
 		// transformations.replaceExact("gl_TextureMatrix[1]", "mat4(1.0 / 255.0)");
-		transformations.define("gl_NormalMatrix", "mat3(u_NormalMatrix)");
-		transformations.define("gl_Normal", "a_Normal");
+		transformations.define("gl_NormalMatrix", "mat3(iris_NormalMatrix)");
+		transformations.define("gl_Normal", "iris_Normal");
 		// Just being careful
 		transformations.define("ftransform", "iris_ftransform");
 
-		new BuiltinUniformReplacementTransformer("a_LightCoord").apply(transformations);
+		new BuiltinUniformReplacementTransformer("iris_LightCoord").apply(transformations);
 
 		if (IrisLogging.ENABLE_SPAM) {
 			System.out.println("Final patched vertex source:");
@@ -147,14 +147,14 @@ public class SodiumTerrainPipeline {
 		StringTransformations transformations = new StringTransformations(base);
 
 		String injections =
-				"uniform mat4 u_ModelViewMatrix;\n" +
-				"uniform mat4 u_ModelViewProjectionMatrix;\n" +
-				"uniform mat4 u_NormalMatrix;\n";
+				"uniform mat4 iris_ModelViewMatrix;\n" +
+				"uniform mat4 iris_ModelViewProjectionMatrix;\n" +
+				"uniform mat4 iris_NormalMatrix;\n";
 
-		transformations.define("gl_ModelViewMatrix", "u_ModelViewMatrix");
-		transformations.define("gl_ModelViewProjectionMatrix", "u_ModelViewProjectionMatrix");
+		transformations.define("gl_ModelViewMatrix", "iris_ModelViewMatrix");
+		transformations.define("gl_ModelViewProjectionMatrix", "iris_ModelViewProjectionMatrix");
 		transformations.replaceExact("gl_TextureMatrix[0]", "mat4(1.0)");
-		transformations.define("gl_NormalMatrix", "mat3(u_NormalMatrix)");
+		transformations.define("gl_NormalMatrix", "mat3(iris_NormalMatrix)");
 
 		transformations.injectLine(Transformations.InjectionPoint.BEFORE_CODE, injections);
 

--- a/src/main/java/net/coderbot/iris/uniforms/ExternallyManagedUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/ExternallyManagedUniforms.java
@@ -9,30 +9,30 @@ public class ExternallyManagedUniforms {
 	}
 
 	public static void addExternallyManagedUniforms(UniformHolder uniformHolder) {
-		addMat4(uniformHolder, "u_ModelViewMatrix");
-		addMat4(uniformHolder, "u_ModelViewProjectionMatrix");
-		addMat4(uniformHolder, "u_NormalMatrix");
+		addMat4(uniformHolder, "iris_ModelViewMatrix");
+		addMat4(uniformHolder, "iris_ModelViewProjectionMatrix");
+		addMat4(uniformHolder, "iris_NormalMatrix");
 	}
 
 	public static void addExternallyManagedUniforms116(UniformHolder uniformHolder) {
 		addExternallyManagedUniforms(uniformHolder);
 
-		uniformHolder.externallyManagedUniform("u_ModelScale", UniformType.VEC3);
-		uniformHolder.externallyManagedUniform("u_TextureScale", UniformType.VEC2);
+		uniformHolder.externallyManagedUniform("iris_ModelScale", UniformType.VEC3);
+		uniformHolder.externallyManagedUniform("iris_TextureScale", UniformType.VEC2);
 	}
 
 	public static void addExternallyManagedUniforms117(UniformHolder uniformHolder) {
 		addExternallyManagedUniforms(uniformHolder);
 
 		// Sodium
-		addFloat(uniformHolder, "u_FogStart");
-		addFloat(uniformHolder, "u_FogEnd");
-		addVec4(uniformHolder, "u_FogColor");
-		addMat4(uniformHolder, "u_ProjectionMatrix");
-		addFloat(uniformHolder, "u_TextureScale");
-		addFloat(uniformHolder, "u_ModelScale");
-		addFloat(uniformHolder, "u_ModelOffset");
-		uniformHolder.externallyManagedUniform("u_CameraTranslation", UniformType.VEC3);
+		addFloat(uniformHolder, "iris_FogStart");
+		addFloat(uniformHolder, "iris_FogEnd");
+		addVec4(uniformHolder, "iris_FogColor");
+		addMat4(uniformHolder, "iris_ProjectionMatrix");
+		addFloat(uniformHolder, "iris_TextureScale");
+		addFloat(uniformHolder, "iris_ModelScale");
+		addFloat(uniformHolder, "iris_ModelOffset");
+		uniformHolder.externallyManagedUniform("iris_CameraTranslation", UniformType.VEC3);
 
 		// Vanilla
 		uniformHolder.externallyManagedUniform("iris_TextureMat", UniformType.MAT4);

--- a/src/main/java/net/coderbot/iris/uniforms/ExternallyManagedUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/ExternallyManagedUniforms.java
@@ -10,15 +10,15 @@ public class ExternallyManagedUniforms {
 
 	public static void addExternallyManagedUniforms(UniformHolder uniformHolder) {
 		addMat4(uniformHolder, "iris_ModelViewMatrix");
-		addMat4(uniformHolder, "iris_ModelViewProjectionMatrix");
+		addMat4(uniformHolder, "u_ModelViewProjectionMatrix");
 		addMat4(uniformHolder, "iris_NormalMatrix");
 	}
 
 	public static void addExternallyManagedUniforms116(UniformHolder uniformHolder) {
 		addExternallyManagedUniforms(uniformHolder);
 
-		uniformHolder.externallyManagedUniform("iris_ModelScale", UniformType.VEC3);
-		uniformHolder.externallyManagedUniform("iris_TextureScale", UniformType.VEC2);
+		uniformHolder.externallyManagedUniform("u_ModelScale", UniformType.VEC3);
+		uniformHolder.externallyManagedUniform("u_TextureScale", UniformType.VEC2);
 	}
 
 	public static void addExternallyManagedUniforms117(UniformHolder uniformHolder) {
@@ -29,8 +29,8 @@ public class ExternallyManagedUniforms {
 		addFloat(uniformHolder, "iris_FogEnd");
 		addVec4(uniformHolder, "iris_FogColor");
 		addMat4(uniformHolder, "iris_ProjectionMatrix");
-		addFloat(uniformHolder, "iris_TextureScale");
-		addFloat(uniformHolder, "iris_ModelScale");
+		addFloat(uniformHolder, "u_TextureScale");
+		addFloat(uniformHolder, "u_ModelScale");
 		addFloat(uniformHolder, "iris_ModelOffset");
 		uniformHolder.externallyManagedUniform("iris_CameraTranslation", UniformType.VEC3);
 

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgram.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgram.java
@@ -1,7 +1,13 @@
 package net.coderbot.iris.compat.sodium.impl.shader_overrides;
 
+import java.nio.FloatBuffer;
+
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.system.MemoryStack;
+
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
+
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
 import me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkProgram;
 import me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkShaderFogComponent;
@@ -10,10 +16,6 @@ import net.coderbot.iris.gl.program.ProgramImages;
 import net.coderbot.iris.gl.program.ProgramSamplers;
 import net.coderbot.iris.gl.program.ProgramUniforms;
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.Nullable;
-import org.lwjgl.system.MemoryStack;
-
-import java.nio.FloatBuffer;
 
 public class IrisChunkProgram extends ChunkProgram {
 	// Uniform variable binding indexes
@@ -66,7 +68,7 @@ public class IrisChunkProgram extends ChunkProgram {
 
 	@Override
 	public int getUniformLocation(String name) {
-		// NB: We pass through calls involving iris_ModelViewProjectionMatrix, iris_ModelScale, and iris_TextureScale, since
+		// NB: We pass through calls involving u_ModelViewProjectionMatrix, u_ModelScale, and u_TextureScale, since
 		//     currently patched Iris shader programs use those.
 
 		if ("iris_BlockTex".equals(name) || "iris_LightTex".equals(name)) {

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgram.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgram.java
@@ -33,8 +33,8 @@ public class IrisChunkProgram extends ChunkProgram {
 							@Nullable ProgramUniforms irisProgramUniforms, @Nullable ProgramSamplers irisProgramSamplers,
 							@Nullable ProgramImages irisProgramImages) {
 		super(owner, name, handle, ChunkShaderFogComponent.None::new);
-		this.uModelViewMatrix = this.getUniformLocation("u_ModelViewMatrix");
-		this.uNormalMatrix = this.getUniformLocation("u_NormalMatrix");
+		this.uModelViewMatrix = this.getUniformLocation("iris_ModelViewMatrix");
+		this.uNormalMatrix = this.getUniformLocation("iris_NormalMatrix");
 		this.irisProgramUniforms = irisProgramUniforms;
 		this.irisProgramSamplers = irisProgramSamplers;
 		this.irisProgramImages = irisProgramImages;
@@ -66,10 +66,10 @@ public class IrisChunkProgram extends ChunkProgram {
 
 	@Override
 	public int getUniformLocation(String name) {
-		// NB: We pass through calls involving u_ModelViewProjectionMatrix, u_ModelScale, and u_TextureScale, since
+		// NB: We pass through calls involving iris_ModelViewProjectionMatrix, iris_ModelScale, and iris_TextureScale, since
 		//     currently patched Iris shader programs use those.
 
-		if ("u_BlockTex".equals(name) || "u_LightTex".equals(name)) {
+		if ("iris_BlockTex".equals(name) || "iris_LightTex".equals(name)) {
 			// Not relevant for Iris shader programs
 			return -1;
 		}

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgramOverrides.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/shader_overrides/IrisChunkProgramOverrides.java
@@ -130,15 +130,15 @@ public class IrisChunkProgramOverrides {
 
 			return builder.attachShader(vertShader)
 					.attachShader(fragShader)
-					.bindAttribute("a_Pos", ChunkShaderBindingPoints.POSITION)
-					.bindAttribute("a_Color", ChunkShaderBindingPoints.COLOR)
-					.bindAttribute("a_TexCoord", ChunkShaderBindingPoints.TEX_COORD)
-					.bindAttribute("a_LightCoord", ChunkShaderBindingPoints.LIGHT_COORD)
+					.bindAttribute("iris_Pos", ChunkShaderBindingPoints.POSITION)
+					.bindAttribute("iris_Color", ChunkShaderBindingPoints.COLOR)
+					.bindAttribute("iris_TexCoord", ChunkShaderBindingPoints.TEX_COORD)
+					.bindAttribute("iris_LightCoord", ChunkShaderBindingPoints.LIGHT_COORD)
 					.bindAttribute("mc_Entity", IrisChunkShaderBindingPoints.BLOCK_ID)
 					.bindAttribute("mc_midTexCoord", IrisChunkShaderBindingPoints.MID_TEX_COORD)
 					.bindAttribute("at_tangent", IrisChunkShaderBindingPoints.TANGENT)
-					.bindAttribute("a_Normal", IrisChunkShaderBindingPoints.NORMAL)
-					.bindAttribute("d_ModelOffset", ChunkShaderBindingPoints.MODEL_OFFSET)
+					.bindAttribute("iris_Normal", IrisChunkShaderBindingPoints.NORMAL)
+					.bindAttribute("iris_ModelOffset", ChunkShaderBindingPoints.MODEL_OFFSET)
 					.build((program, name) -> {
 						ProgramUniforms uniforms = pipeline.initUniforms(name);
 						ProgramSamplers samplers;


### PR DESCRIPTION
This change only renames the renamable uniforms to use `iris_` instead of `u_`, `d_` or `a_` as a prefix. This PR does not introduce glsl-transformer but it makes it easier to work with it in its own PR.