### PR TITLE
Unset tab_width on types with indent_style = tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,9 +14,11 @@ indent_size = 4
 
 [brachyurabootstrapconf.txt]
 indent_style = tab
+tab_width = unset
 
 [*.java]
 indent_style = tab
+tab_width = unset
 ij_continuation_indent_size = 4
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999


### PR DESCRIPTION
If tabs are used, the indent width is purely visual and should not be set by the editorconfig and has no effect on the files themselves.