### PR TITLE
preserve gui render state when vignette is disabled

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/gui/MixinGui.java
+++ b/src/main/java/net/coderbot/iris/mixin/gui/MixinGui.java
@@ -1,5 +1,6 @@
 package net.coderbot.iris.mixin.gui;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gui.screen.HudHideable;
@@ -65,6 +66,10 @@ public class MixinGui {
 		WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipelineNullable();
 
 		if (pipeline != null && !pipeline.shouldRenderVignette()) {
+			// we need to set up the GUI render state ourselves if we cancel the vignette
+			RenderSystem.enableDepthTest();
+			RenderSystem.defaultBlendFunc();
+
 			ci.cancel();
 		}
 	}


### PR DESCRIPTION
Just a small change to vignette disabling to correctly set up the render state for the GUI
This was causing a bug in MCXR where the hotbar was being drawn incorrectly

This better matches how vanilla does it:
```
if (Minecraft.useFancyGraphics()) {
    this.renderVignette(this.minecraft.getCameraEntity());
} else {
    RenderSystem.enableDepthTest();
    RenderSystem.defaultBlendFunc();
 }
```