### PR TITLE
Feature: proof of concept custom item lighting

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinItem.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinItem.java
@@ -1,0 +1,9 @@
+package net.coderbot.iris.mixin;
+
+import net.irisshaders.iris.api.v0.item.IrisItemLightProvider;
+import net.minecraft.world.item.Item;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Item.class)
+public class MixinItem implements IrisItemLightProvider {
+}

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -258,12 +258,11 @@ public final class CommonUniforms {
 
 			ItemStack stack = client.player.getItemInHand(hand);
 
-			if (stack == ItemStack.EMPTY || stack == null || !(stack.getItem() instanceof IrisItemLightProvider)) {
+			if (stack == ItemStack.EMPTY || stack == null) {
 				return 0;
 			}
 
-			IrisItemLightProvider item = (IrisItemLightProvider)stack.getItem();
-			return item.getLightEmission(client.player, stack);
+			return ((IrisItemLightProvider)stack.getItem()).getLightEmission(client.player, stack);
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -33,7 +33,6 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.material.FluidState;
@@ -259,22 +258,12 @@ public final class CommonUniforms {
 
 			ItemStack stack = client.player.getItemInHand(hand);
 
-			if (stack == ItemStack.EMPTY || stack == null) {
+			if (stack == ItemStack.EMPTY || stack == null || !(stack.getItem() instanceof IrisItemLightProvider)) {
 				return 0;
 			}
 
-			if (stack.getItem() instanceof BlockItem) {
-				BlockItem item = (BlockItem)stack.getItem();
-
-				return item.getBlock().defaultBlockState().getLightEmission();
-			}
-			else if (stack.getItem() instanceof IrisItemLightProvider) {
-				IrisItemLightProvider item = (IrisItemLightProvider)stack.getItem();
-
-				return item.getLightEmission(client.player, stack);
-			}
-
-			return 0;
+			IrisItemLightProvider item = (IrisItemLightProvider)stack.getItem();
+			return item.getLightEmission(client.player, stack);
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java
@@ -20,6 +20,7 @@ import net.coderbot.iris.vendored.joml.Vector2i;
 import net.coderbot.iris.vendored.joml.Vector3d;
 import net.coderbot.iris.vendored.joml.Vector4f;
 import net.coderbot.iris.vendored.joml.Vector4i;
+import net.irisshaders.iris.api.v0.item.IrisItemLightProvider;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.GameRenderer;
@@ -258,13 +259,22 @@ public final class CommonUniforms {
 
 			ItemStack stack = client.player.getItemInHand(hand);
 
-			if (stack == ItemStack.EMPTY || stack == null || !(stack.getItem() instanceof BlockItem)) {
+			if (stack == ItemStack.EMPTY || stack == null) {
 				return 0;
 			}
 
-			BlockItem item = (BlockItem) stack.getItem();
+			if (stack.getItem() instanceof BlockItem) {
+				BlockItem item = (BlockItem)stack.getItem();
 
-			return item.getBlock().defaultBlockState().getLightEmission();
+				return item.getBlock().defaultBlockState().getLightEmission();
+			}
+			else if (stack.getItem() instanceof IrisItemLightProvider) {
+				IrisItemLightProvider item = (IrisItemLightProvider)stack.getItem();
+
+				return item.getLightEmission(client.player, stack);
+			}
+
+			return 0;
 		}
 	}
 

--- a/src/main/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
+++ b/src/main/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
@@ -1,0 +1,8 @@
+package net.irisshaders.iris.api.v0.item;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public interface IrisItemLightProvider {
+	int getLightEmission(Player player, ItemStack stack);
+}

--- a/src/main/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
+++ b/src/main/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
@@ -1,8 +1,17 @@
 package net.irisshaders.iris.api.v0.item;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 
 public interface IrisItemLightProvider {
-	int getLightEmission(Player player, ItemStack stack);
+	default int getLightEmission(Player player, ItemStack stack) {
+		if (stack.getItem() instanceof BlockItem) {
+			BlockItem item = (BlockItem)stack.getItem();
+
+			return item.getBlock().defaultBlockState().getLightEmission();
+		}
+
+		return 0;
+	}
 }

--- a/src/main/resources/mixins.iris.json
+++ b/src/main/resources/mixins.iris.json
@@ -24,6 +24,7 @@
     "MixinGlStateManager_BlendOverride",
     "MixinGlStateManager_DepthColorOverride",
     "MixinGlStateManager_FramebufferBinding",
+    "MixinItem",
     "MixinItemBlockRenderTypes",
     "MixinItemInHandRenderer",
     "MixinLevelRenderer",


### PR DESCRIPTION
Through the use of an interface that mods can implement, items can provide custom lighting values that vary based on the target player and stack. This augments the existing functionality of stack-based item lighting which was limited to blocks.