### PR TITLE
Add a property to ignore the installed Sodium version

### DIFF
--- a/src/main/java/net/coderbot/iris/compat/sodium/SodiumVersionCheck.java
+++ b/src/main/java/net/coderbot/iris/compat/sodium/SodiumVersionCheck.java
@@ -28,6 +28,9 @@ public class SodiumVersionCheck {
 	}
 
 	public static boolean isAllowedVersion(String sodiumVersion) {
+		if (Boolean.parseBoolean(System.getProperty("iris.allowAnySodiumVersion")))
+			return true;
+
 		for (AllowedSodiumVersion allowed : ALLOWED_SODIUM_VERSIONS) {
 			if (allowed.matches(sodiumVersion)) {
 				return true;


### PR DESCRIPTION
When building Sodium from source, Iris refuses to load because it does not recognize the Sodium build as compatible, even if it is. I've added a property `-Diris.allowAnySodiumVersion=true` to skip the version check and allow any version of Sodium, for those who know what they're doing.