### PR TITLE
Hunger, health, and air uniforms

### DIFF
--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -49,7 +49,7 @@ public class IrisExclusiveUniforms {
 			return -1;
 		}
 
-		return Minecraft.getInstance().player.getAirSupply() / Minecraft.getInstance().player.getMaxAirSupply();
+		return (float) Minecraft.getInstance().player.getAirSupply() / (float) Minecraft.getInstance().player.getMaxAirSupply();
 	}
 
 	private static float getMaxAir() {

--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -11,6 +11,11 @@ public class IrisExclusiveUniforms {
 	public static void addIrisExclusiveUniforms(UniformHolder uniforms) {
 		//All Iris-exclusive uniforms (uniforms which do not exist in either OptiFine or ShadersMod) should be registered here.
 		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "thunderStrength", IrisExclusiveUniforms::getThunderStrength);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "currentPlayerHealth", IrisExclusiveUniforms::getCurrentHealth);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "maxPlayerHealth", IrisExclusiveUniforms::getMaxHealth);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "currentPlayerHunger", IrisExclusiveUniforms::getCurrentHunger);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "currentPlayerAir", IrisExclusiveUniforms::getCurrentAir);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "maxPlayerAir", IrisExclusiveUniforms::getMaxAir);
 		uniforms.uniform1b(UniformUpdateFrequency.PER_FRAME, "firstPersonCamera", IrisExclusiveUniforms::isFirstPersonCamera);
 		uniforms.uniform1b(UniformUpdateFrequency.PER_TICK, "isSpectator", IrisExclusiveUniforms::isSpectator);
 		uniforms.uniform3d(UniformUpdateFrequency.PER_FRAME, "eyePosition", IrisExclusiveUniforms::getEyePosition);
@@ -20,6 +25,46 @@ public class IrisExclusiveUniforms {
 		// Note: Ensure this is in the range of 0 to 1 - some custom servers send out of range values.
 		return Math.clamp(0.0F, 1.0F,
 			Minecraft.getInstance().level.getThunderLevel(CapturedRenderingState.INSTANCE.getTickDelta()));
+	}
+
+	private static float getCurrentHealth() {
+		if (Minecraft.getInstance().player == null || !Minecraft.getInstance().gameMode.getPlayerMode().isSurvival()) {
+			return -1;
+		}
+
+		return Minecraft.getInstance().player.getHealth();
+	}
+
+	private static float getCurrentHunger() {
+		if (Minecraft.getInstance().player == null || !Minecraft.getInstance().gameMode.getPlayerMode().isSurvival()) {
+			return -1;
+		}
+
+		return Minecraft.getInstance().player.getFoodData().getFoodLevel();
+	}
+
+	private static float getCurrentAir() {
+		if (Minecraft.getInstance().player == null || !Minecraft.getInstance().gameMode.getPlayerMode().isSurvival()) {
+			return -1;
+		}
+
+		return Minecraft.getInstance().player.getAirSupply();
+	}
+
+	private static float getMaxAir() {
+		if (Minecraft.getInstance().player == null || !Minecraft.getInstance().gameMode.getPlayerMode().isSurvival()) {
+			return -1;
+		}
+
+		return Minecraft.getInstance().player.getMaxAirSupply();
+	}
+
+	private static float getMaxHealth() {
+		if (Minecraft.getInstance().player == null || !Minecraft.getInstance().gameMode.getPlayerMode().isSurvival()) {
+			return -1;
+		}
+
+		return Minecraft.getInstance().player.getMaxHealth();
 	}
 
 	private static boolean isFirstPersonCamera() {

--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -11,11 +11,12 @@ public class IrisExclusiveUniforms {
 	public static void addIrisExclusiveUniforms(UniformHolder uniforms) {
 		//All Iris-exclusive uniforms (uniforms which do not exist in either OptiFine or ShadersMod) should be registered here.
 		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "thunderStrength", IrisExclusiveUniforms::getThunderStrength);
-		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "currentPlayerHealth", IrisExclusiveUniforms::getCurrentHealth);
-		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "maxPlayerHealth", IrisExclusiveUniforms::getMaxHealth);
-		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "currentPlayerHunger", IrisExclusiveUniforms::getCurrentHunger);
-		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "currentPlayerAir", IrisExclusiveUniforms::getCurrentAir);
-		uniforms.uniform1f(UniformUpdateFrequency.PER_FRAME, "maxPlayerAir", IrisExclusiveUniforms::getMaxAir);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_TICK, "currentPlayerHealth", IrisExclusiveUniforms::getCurrentHealth);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_TICK, "maxPlayerHealth", IrisExclusiveUniforms::getMaxHealth);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_TICK, "currentPlayerHunger", IrisExclusiveUniforms::getCurrentHunger);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_TICK, "maxPlayerHunger", () -> 20);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_TICK, "currentPlayerAir", IrisExclusiveUniforms::getCurrentAir);
+		uniforms.uniform1f(UniformUpdateFrequency.PER_TICK, "maxPlayerAir", IrisExclusiveUniforms::getMaxAir);
 		uniforms.uniform1b(UniformUpdateFrequency.PER_FRAME, "firstPersonCamera", IrisExclusiveUniforms::isFirstPersonCamera);
 		uniforms.uniform1b(UniformUpdateFrequency.PER_TICK, "isSpectator", IrisExclusiveUniforms::isSpectator);
 		uniforms.uniform3d(UniformUpdateFrequency.PER_FRAME, "eyePosition", IrisExclusiveUniforms::getEyePosition);
@@ -32,7 +33,7 @@ public class IrisExclusiveUniforms {
 			return -1;
 		}
 
-		return Minecraft.getInstance().player.getHealth();
+		return Minecraft.getInstance().player.getHealth() / Minecraft.getInstance().player.getMaxHealth();
 	}
 
 	private static float getCurrentHunger() {
@@ -40,7 +41,7 @@ public class IrisExclusiveUniforms {
 			return -1;
 		}
 
-		return Minecraft.getInstance().player.getFoodData().getFoodLevel();
+		return Minecraft.getInstance().player.getFoodData().getFoodLevel() / 20f;
 	}
 
 	private static float getCurrentAir() {
@@ -48,7 +49,7 @@ public class IrisExclusiveUniforms {
 			return -1;
 		}
 
-		return Minecraft.getInstance().player.getAirSupply();
+		return Minecraft.getInstance().player.getAirSupply() / Minecraft.getInstance().player.getMaxAirSupply();
 	}
 
 	private static float getMaxAir() {


### PR DESCRIPTION
`currentPlayerHealth` 0-1, -1 if in creative or spectator. Multiply by `maxPlayerHealth` to get the amount in real units.
`maxPlayerHealth` The limit for the current player, default 20. Mods or datapacks can raise the limit.
`currentPlayerAir` 0-1, -1 if in creative or spectator. Multiply by `maxPlayerAir` to get the amount in real units.
`maxPlayerAir` The limit for the current player, default 300.
`currentPlayerHunger` 0-1, -1 if in creative or spectator. Multiply by `maxPlayerHunger` to get the amount in real units.
`maxPlayerHunger` The limit for the current player, default 20.
