### PR TITLE
Use the camera "eye" position instead of the player "eye" position when possible 

### DIFF
--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -101,6 +101,8 @@ public class IrisExclusiveUniforms {
 	}
 
 	private static Vector3d getEyePosition() {
+		if (Minecraft.getInstance().cameraEntity != null)
+			return new Vector3d(Minecraft.getInstance().cameraEntity.getX(), Minecraft.getInstance().cameraEntity.getEyeY(), Minecraft.getInstance().cameraEntity.getZ());
 		return new Vector3d(Minecraft.getInstance().player.getX(), Minecraft.getInstance().player.getEyeY(), Minecraft.getInstance().player.getZ());
 	}
 }

--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -11,6 +11,7 @@ import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
 
+import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 public class IrisExclusiveUniforms {
@@ -101,8 +102,7 @@ public class IrisExclusiveUniforms {
 	}
 
 	private static Vector3d getEyePosition() {
-		if (Minecraft.getInstance().cameraEntity != null)
-			return new Vector3d(Minecraft.getInstance().cameraEntity.getX(), Minecraft.getInstance().cameraEntity.getEyeY(), Minecraft.getInstance().cameraEntity.getZ());
-		return new Vector3d(Minecraft.getInstance().player.getX(), Minecraft.getInstance().player.getEyeY(), Minecraft.getInstance().player.getZ());
+		Objects.requireNonNull(Minecraft.getInstance().getCameraEntity());
+		return new Vector3d(Minecraft.getInstance().getCameraEntity().getX(), Minecraft.getInstance().getCameraEntity().getEyeY(), Minecraft.getInstance().getCameraEntity().getZ());
 	}
 }


### PR DESCRIPTION
Should improve compatability with mods that overwrite the camera entity