### PR TITLE
Add compat for item lighting provided through LambDynamicLights

### DIFF
--- a/src/main/java/net/coderbot/iris/compat/lambdynlights/ILambDynLightsCompat.java
+++ b/src/main/java/net/coderbot/iris/compat/lambdynlights/ILambDynLightsCompat.java
@@ -1,0 +1,34 @@
+package net.coderbot.iris.compat.lambdynlights;
+
+import net.minecraft.world.item.ItemStack;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public interface ILambDynLightsCompat {
+	ILambDynLightsCompat INSTANCE = getInstance();
+
+	Optional<Integer> getLuminance(ItemStack stack, boolean submergedInWater);
+
+	static ILambDynLightsCompat getInstance() {
+		ILambDynLightsCompat instance;
+
+		try {
+			Class<?> itemLightSources = Class.forName("dev.lambdaurora.lambdynlights.api.item.ItemLightSources", true, ILambDynLightsCompat.class.getClassLoader());
+			Method method = itemLightSources.getMethod("getLuminance", ItemStack.class, Boolean.class);
+
+			instance = (stack, submergedInWater) -> {
+				try {
+					return Optional.of((int) method.invoke(null, stack, submergedInWater));
+				} catch (IllegalAccessException | InvocationTargetException e) {
+					return Optional.empty();
+				}
+			};
+		} catch (LinkageError | ClassNotFoundException | NoSuchMethodException e) {
+			instance = (stack, submergedInWater) -> Optional.empty();
+		}
+
+		return instance;
+	}
+}

--- a/src/main/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
+++ b/src/main/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
@@ -1,6 +1,7 @@
 package net.irisshaders.iris.api.v0.item;
 
 import com.mojang.math.Vector3f;
+import net.coderbot.iris.compat.lambdynlights.ILambDynLightsCompat;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
@@ -16,7 +17,7 @@ public interface IrisItemLightProvider {
 			return item.getBlock().defaultBlockState().getLightEmission();
 		}
 
-		return 0;
+		return ILambDynLightsCompat.INSTANCE.getLuminance(stack, player.isUnderWater()).orElse(0);
 	}
 
 	default Vector3f getLightColor(Player player, ItemStack stack) {


### PR DESCRIPTION
Adds "free" support for mods which register dynamic item lighting through LambDynamicLights via a compat module