### PR TITLE
Fix many resource leaks

### DIFF
--- a/src/main/java/net/coderbot/iris/Iris.java
+++ b/src/main/java/net/coderbot/iris/Iris.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
@@ -48,6 +49,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.stream.Stream;
 import java.util.zip.ZipError;
 import java.util.zip.ZipException;
 
@@ -409,10 +411,12 @@ public class Iris {
 		// For example Sildurs-Vibrant-Shaders.zip/shaders
 		// While other packs have Trippy-Shaderpack-master.zip/Trippy-Shaderpack-master/shaders
 		// This makes it hard to determine what is the actual shaders dir
-		return Files.walk(root)
-				.filter(Files::isDirectory)
-				.filter(path -> path.endsWith("shaders"))
-				.findFirst();
+		try (Stream<Path> stream = Files.walk(root)) {
+			return stream
+					.filter(Files::isDirectory)
+					.filter(path -> path.endsWith("shaders"))
+					.findFirst();
+		}
 	}
 
 	private static void setShadersDisabled() {
@@ -452,10 +456,10 @@ public class Iris {
 		Properties properties = new Properties();
 
 		if (Files.exists(path)) {
-			try {
+			try (InputStream is = Files.newInputStream(path)) {
 				// NB: config properties are specified to be encoded with ISO-8859-1 by OptiFine,
 				//     so we don't need to do the UTF-8 workaround here.
-				properties.load(Files.newInputStream(path));
+				properties.load(is);
 			} catch (IOException e) {
 				// TODO: Better error handling
 				return Optional.empty();
@@ -493,8 +497,8 @@ public class Iris {
 			if (pack.equals(getShaderpacksDirectory())) {
 				return false;
 			}
-			try {
-				return Files.walk(pack)
+			try (Stream<Path> stream = Files.walk(pack)) {
+				return stream
 						.filter(Files::isDirectory)
 						// Prevent a pack simply named "shaders" from being
 						// identified as a valid pack
@@ -508,9 +512,11 @@ public class Iris {
 		if (pack.toString().endsWith(".zip")) {
 			try (FileSystem zipSystem = FileSystems.newFileSystem(pack, Iris.class.getClassLoader())) {
 				Path root = zipSystem.getRootDirectories().iterator().next();
-				return Files.walk(root)
-						.filter(Files::isDirectory)
-						.anyMatch(path -> path.endsWith("shaders"));
+				try (Stream<Path> stream = Files.walk(root)) {
+					return stream
+							.filter(Files::isDirectory)
+							.anyMatch(path -> path.endsWith("shaders"));
+				}
 			} catch (ZipError zipError) {
 				// Java 8 seems to throw a ZipError instead of a subclass of IOException
 				Iris.logger.warn("The ZIP at " + pack + " is corrupt");

--- a/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -4,6 +4,8 @@ import net.coderbot.iris.Iris;
 import net.coderbot.iris.gui.option.IrisVideoSettings;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -128,7 +130,9 @@ public class IrisConfig {
 
 		Properties properties = new Properties();
 		// NB: This uses ISO-8859-1 with unicode escapes as the encoding
-		properties.load(Files.newInputStream(propertiesPath));
+		try (InputStream is = Files.newInputStream(propertiesPath)) {
+			properties.load(is);
+		}
 		shaderPackName = properties.getProperty("shaderPack");
 		enableShaders = !"false".equals(properties.getProperty("enableShaders"));
 		enableDebugOptions = "true".equals(properties.getProperty("enableDebugOptions"));
@@ -161,6 +165,8 @@ public class IrisConfig {
 		properties.setProperty("disableUpdateMessage", disableUpdateMessage ? "true" : "false");
 		properties.setProperty("maxShadowRenderDistance", String.valueOf(IrisVideoSettings.shadowDistance));
 		// NB: This uses ISO-8859-1 with unicode escapes as the encoding
-		properties.store(Files.newOutputStream(propertiesPath), COMMENT);
+		try (OutputStream os = Files.newOutputStream(propertiesPath)) {
+			properties.store(os, COMMENT);
+		}
 	}
 }

--- a/src/main/java/net/coderbot/iris/pipeline/PatchedShaderPrinter.java
+++ b/src/main/java/net/coderbot/iris/pipeline/PatchedShaderPrinter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import net.coderbot.iris.Iris;
 import net.fabricmc.loader.api.FabricLoader;
@@ -28,13 +29,15 @@ public class PatchedShaderPrinter {
 			if (!outputLocationCleared) {
 				try {
 					if (Files.exists(debugOutDir)) {
-						Files.list(debugOutDir).forEach(path -> {
-							try {
-								Files.delete(path);
-							} catch (IOException e) {
-								throw new RuntimeException(e);
-							}
-						});
+						try (Stream<Path> stream = Files.list(debugOutDir)) {
+							stream.forEach(path -> {
+								try {
+									Files.delete(path);
+								} catch (IOException e) {
+									throw new RuntimeException(e);
+								}
+							});
+						}
 					}
 
 					Files.createDirectories(debugOutDir);

--- a/src/main/java/net/coderbot/iris/shaderpack/LanguageMap.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/LanguageMap.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class LanguageMap {
 	private final Map<String, Map<String, String>> translationMaps;
@@ -29,35 +30,37 @@ public class LanguageMap {
 		// we also want to avoid any directories while filtering
 		// Basically, we want the immediate files nested in the path for the langFolder
 		// There is also Files.list which can be used for similar behavior
-		Files.list(root).filter(path -> !Files.isDirectory(path)).forEach(path -> {
-			// Shader packs use legacy file name coding which is different than modern minecraft's.
-			// An example of this is using "en_US.lang" compared to "en_us.json"
-			// Also note that OptiFine uses a property scheme for loading language entries to keep parity with other
-			// OptiFine features
-			String currentFileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
+		try (Stream<Path> stream = Files.list(root)) {
+			stream.filter(path -> !Files.isDirectory(path)).forEach(path -> {
+				// Shader packs use legacy file name coding which is different than modern minecraft's.
+				// An example of this is using "en_US.lang" compared to "en_us.json"
+				// Also note that OptiFine uses a property scheme for loading language entries to keep parity with other
+				// OptiFine features
+				String currentFileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
 
-			if (!currentFileName.endsWith(".lang")) {
-				// This file lacks a .lang file extension and should be ignored.
-				return;
-			}
+				if (!currentFileName.endsWith(".lang")) {
+					// This file lacks a .lang file extension and should be ignored.
+					return;
+				}
 
-			String currentLangCode = currentFileName.substring(0, currentFileName.lastIndexOf("."));
-			Properties properties = new Properties();
+				String currentLangCode = currentFileName.substring(0, currentFileName.lastIndexOf("."));
+				Properties properties = new Properties();
 
-			try {
 				// Use InputStreamReader to avoid the default charset of ISO-8859-1.
 				// This is needed since shader language files are specified to be in UTF-8.
-				properties.load(new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8));
-			} catch (IOException e) {
-				Iris.logger.error("Failed to parse shader pack language file " + path, e);
-			}
+				try (InputStreamReader isr = new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8)) {
+					properties.load(isr);
+				} catch (IOException e) {
+					Iris.logger.error("Failed to parse shader pack language file " + path, e);
+				}
 
-			ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+				ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-			properties.forEach((key, value) -> builder.put(key.toString(), value.toString()));
+				properties.forEach((key, value) -> builder.put(key.toString(), value.toString()));
 
-			translationMaps.put(currentLangCode, builder.build());
-		});
+				translationMaps.put(currentLangCode, builder.build());
+			});
+		}
 	}
 
 	public Set<String> getLanguages() {

--- a/src/main/java/net/coderbot/iris/shaderpack/ShaderPack.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/ShaderPack.java
@@ -328,11 +328,10 @@ public class ShaderPack {
 	}
 
 	private JsonObject loadMcMeta(Path mcMetaPath) throws IOException, JsonParseException {
-		BufferedReader reader =
-				new BufferedReader(new InputStreamReader(Files.newInputStream(mcMetaPath), StandardCharsets.UTF_8));
-
-		JsonReader jsonReader = new JsonReader(reader);
-		return GSON.getAdapter(JsonObject.class).read(jsonReader);
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(mcMetaPath), StandardCharsets.UTF_8))) {
+			JsonReader jsonReader = new JsonReader(reader);
+			return GSON.getAdapter(JsonObject.class).read(jsonReader);
+		}
 	}
 
 	private static String readProperties(Path shaderPath, String name) {

--- a/src/main/java/net/coderbot/iris/shaderpack/discovery/ShaderpackDirectoryManager.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/discovery/ShaderpackDirectoryManager.java
@@ -32,21 +32,25 @@ public class ShaderpackDirectoryManager {
 			// which requires additional handling when used in a lambda
 
 			// Copy all sub folders, collected as a list in order to prevent issues with non-ordered sets
-			for (Path p : Files.walk(source).filter(Files::isDirectory).collect(Collectors.toList())) {
-				Path folder = source.relativize(p);
+			try (Stream<Path> stream = Files.walk(source)) {
+				for (Path p : stream.filter(Files::isDirectory).collect(Collectors.toList())) {
+					Path folder = source.relativize(p);
 
-				if (Files.exists(folder)) {
-					continue;
+					if (Files.exists(folder)) {
+						continue;
+					}
+
+					Files.createDirectory(target.resolve(folder));
 				}
-
-				Files.createDirectory(target.resolve(folder));
 			}
 
 			// Copy all non-folder files
-			for (Path p : Files.walk(source).filter(p -> !Files.isDirectory(p)).collect(Collectors.toSet())) {
-				Path file = source.relativize(p);
+			try (Stream<Path> stream = Files.walk(source)) {
+				for (Path p : stream.filter(p -> !Files.isDirectory(p)).collect(Collectors.toSet())) {
+					Path file = source.relativize(p);
 
-				Files.copy(p, target.resolve(file));
+					Files.copy(p, target.resolve(file));
+				}
 			}
 		}
 	}

--- a/src/main/java/net/coderbot/iris/shaderpack/include/ShaderPackSourceNames.java
+++ b/src/main/java/net/coderbot/iris/shaderpack/include/ShaderPackSourceNames.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Enumerates the possible program source file names to
@@ -26,9 +27,12 @@ public class ShaderPackSourceNames {
 
 		boolean anyFound = false;
 
-		Set<String> found = Files.list(directoryPath)
-				.map(path -> path.getFileName().toString())
-				.collect(Collectors.toSet());
+		Set<String> found;
+		try (Stream<Path> stream = Files.list(directoryPath)) {
+			found = stream
+					.map(path -> path.getFileName().toString())
+					.collect(Collectors.toSet());
+		}
 
 		for (String candidate : candidates) {
 			if (found.contains(candidate)) {


### PR DESCRIPTION
This pull request fixes _many_ resource (not memory) leaks in the Iris codebase. Most common ones are not closing the streams from `Files.walk` and `Files.list`, needed because `Stream`s don't run their closing operations when you run their terminal operation. Fun thing is there were some handled correctly around.

There were also some Input/OutputStreams that were never closed and are now. I've looked at the whole codebase and tried to fix all of the resource leaks (that I know) related to the `Files` class usage.

After this (if I tested it right), you can delete shaderpacks files without having to stop the game.