### PR TITLE
Update glsl-transformer and rename reserved words (texture)

### DIFF
--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -91,7 +91,7 @@ public class Buildscript extends SimpleFabricProject {
 		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.anarres:jcpp:1.4.14"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 		jij(d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-key-binding-api-v1", "1.0.12+54e5b2ec60"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 
-		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:2.0.0-pre7"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
+		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:2.0.0-pre8"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.11.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 
 		if (SODIUM) {

--- a/src/main/java/net/coderbot/iris/pipeline/transform/parameter/Parameters.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/parameter/Parameters.java
@@ -1,6 +1,6 @@
 package net.coderbot.iris.pipeline.transform.parameter;
 
-import io.github.douira.glsl_transformer.basic.JobParameters;
+import io.github.douira.glsl_transformer.ast.transform.JobParameters;
 import net.coderbot.iris.gl.blending.AlphaTest;
 import net.coderbot.iris.pipeline.transform.Patch;
 import net.coderbot.iris.pipeline.transform.PatchShaderType;

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/AttributeTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/AttributeTransformer.java
@@ -4,7 +4,7 @@ import java.util.stream.Stream;
 
 import io.github.douira.glsl_transformer.ast.node.Identifier;
 import io.github.douira.glsl_transformer.ast.node.TranslationUnit;
-import io.github.douira.glsl_transformer.ast.node.basic.ASTNode;
+import io.github.douira.glsl_transformer.ast.node.abstract_node.ASTNode;
 import io.github.douira.glsl_transformer.ast.node.external_declaration.ExternalDeclaration;
 import io.github.douira.glsl_transformer.ast.query.Root;
 import io.github.douira.glsl_transformer.ast.query.match.AutoHintedMatcher;
@@ -148,7 +148,7 @@ public class AttributeTransformer {
 			// Create our own main function to wrap the existing main function, so that we
 			// can pass through the overlay color at the end to the geometry or fragment
 			// stage.
-			tree.prependMain(t,
+			tree.prependMainFunctionBody(t,
 					"vec4 overlayColor = texelFetch(iris_overlay, iris_UV1, 0);",
 					"entityColor = vec4(overlayColor.rgb, 1.0 - overlayColor.a);",
 					"iris_vertexColor = iris_Color;",
@@ -167,7 +167,7 @@ public class AttributeTransformer {
 					"in vec4 entityColor[];",
 					"out vec4 iris_vertexColorGS;",
 					"in vec4 iris_vertexColor[];");
-			tree.prependMain(t,
+			tree.prependMainFunctionBody(t,
 					"entityColorGS = entityColor[0];",
 					"iris_vertexColorGS = iris_vertexColor[0];");
 		} else if (parameters.type.glShaderType == ShaderType.FRAGMENT) {

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CommonTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CommonTransformer.java
@@ -158,7 +158,7 @@ public class CommonTransformer {
 			// insert alpha test for iris_FragData0 in the fragment shader
 			if (parameters.getAlphaTest() != AlphaTest.ALWAYS && replaceIndexesSet.contains(0L)) {
 				tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS, "uniform float iris_currentAlphaTest;");
-				tree.appendMain(t, parameters.getAlphaTest().toExpression("iris_FragData0.a", "iris_currentAlphaTest", "	"));
+				tree.appendMainFunctionBody(t, parameters.getAlphaTest().toExpression("iris_FragData0.a", "iris_currentAlphaTest", "	"));
 			}
 		}
 

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
@@ -217,8 +217,7 @@ public class CompatibilityTransformer {
 			String newName = "iris_renamed_" + reservedWord;
 			if (root.process(root.identifierIndex.getStream(reservedWord).filter(
 					id -> !(id.getParent() instanceof FunctionCallExpression)
-							&& id.getBranchAncestor(
-									FunctionDefinition.class, FunctionDefinition::getFunctionPrototype) == null),
+							&& !(id.getParent() instanceof FunctionPrototype)),
 					id -> id.setName(newName))) {
 				LOGGER.warn("Renamed reserved word \"" + reservedWord + "\" to \"" + newName + "\".");
 			}

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
@@ -70,6 +70,8 @@ public class CompatibilityTransformer {
 		return null;
 	}
 
+	private static List<String> reservedWords = List.of("texture");
+
 	public static void transformEach(ASTParser t, TranslationUnit tree, Root root, Parameters parameters) {
 		if (parameters.type == PatchShaderType.VERTEX) {
 			if (root.replaceExpressionMatches(t, sildursWaterFract, "fract(worldpos.y + 0.01)")) {
@@ -208,6 +210,18 @@ public class CompatibilityTransformer {
 		if (emptyDeclarationHit) {
 			LOGGER.warn(
 					"Removed empty external declarations (\";\").");
+		}
+
+		// rename reserved words within files
+		for (String reservedWord : reservedWords) {
+			String newName = "iris_renamed_" + reservedWord;
+			if (root.process(root.identifierIndex.getStream(reservedWord).filter(
+					id -> !(id.getParent() instanceof FunctionCallExpression)
+							&& id.getBranchAncestor(
+									FunctionDefinition.class, FunctionDefinition::getFunctionPrototype) == null),
+					id -> id.setName(newName))) {
+				LOGGER.warn("Renamed reserved word \"" + reservedWord + "\" to \"" + newName + "\".");
+			}
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.douira.glsl_transformer.ast.node.Identifier;
 import io.github.douira.glsl_transformer.ast.node.TranslationUnit;
-import io.github.douira.glsl_transformer.ast.node.basic.ASTNode;
+import io.github.douira.glsl_transformer.ast.node.abstract_node.ASTNode;
 import io.github.douira.glsl_transformer.ast.node.declaration.DeclarationMember;
 import io.github.douira.glsl_transformer.ast.node.declaration.FunctionParameter;
 import io.github.douira.glsl_transformer.ast.node.declaration.TypeAndInitDeclaration;
@@ -441,7 +441,7 @@ public class CompatibilityTransformer {
 									new Identifier(name)));
 
 							// add the initializer to the main function
-							prevTree.prependMain(getInitializer(prevRoot, name, inType));
+							prevTree.prependMainFunctionBody(getInitializer(prevRoot, name, inType));
 
 							// update out declarations to prevent duplicates
 							outDeclarations.put(name, null);
@@ -475,7 +475,7 @@ public class CompatibilityTransformer {
 								}
 
 								// add an initialization statement for this declaration
-								prevTree.prependMain(getInitializer(prevRoot, name, inType));
+								prevTree.prependMainFunctionBody(getInitializer(prevRoot, name, inType));
 								outDeclarations.put(name, null);
 								continue;
 							}
@@ -535,7 +535,7 @@ public class CompatibilityTransformer {
 
 							// insert a statement at the end of the main function that sets the value of the
 							// out declaration to the value of the global variable and does a type cast
-							prevTree.appendMain(
+							prevTree.appendMainFunctionBody(
 									(isVector && outType.getDimensions()[0] < inType.getDimensions()[0] ? statementTemplateVector
 											: statementTemplate).getInstanceFor(prevRoot,
 													new Identifier(name),

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/SodiumTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/SodiumTransformer.java
@@ -117,7 +117,7 @@ public class SodiumTransformer {
 					"uniform vec3 u_RegionOffset;",
 					// _draw_translation replaced with Chunks[_draw_id].offset.xyz
 					"vec4 getVertexPosition() { return vec4(u_RegionOffset + Chunks[_draw_id].offset.xyz + _vert_position, 1.0); }");
-			tree.prependMain(t, "_vert_init();");
+			tree.prependMainFunctionBody(t, "_vert_init();");
 			root.replaceReferenceExpressions(t, "gl_Vertex", "getVertexPosition()");
 		} else {
 			tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_DECLARATIONS,


### PR DESCRIPTION
excludes function calls and function definitions. This might break if somebody defines a type called `texture` and uses it as a function prototype but that would be very weird (and probably not even valid glsl).