### PR TITLE
Update glsl-transformer to 2.0.0-pre11 and refactor to use new APIs

### DIFF
--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -91,7 +91,7 @@ public class Buildscript extends SimpleFabricProject {
 		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.anarres:jcpp:1.4.14"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 		jij(d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-key-binding-api-v1", "1.0.12+54e5b2ec60"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 
-		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:2.0.0-pre10"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
+		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:2.0.0-pre11"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.11.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 
 		if (SODIUM) {

--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -91,7 +91,7 @@ public class Buildscript extends SimpleFabricProject {
 		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.anarres:jcpp:1.4.14"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 		jij(d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", "fabric-key-binding-api-v1", "1.0.12+54e5b2ec60"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 
-		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:2.0.0-pre9"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
+		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("io.github.douira:glsl-transformer:2.0.0-pre10"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 		jij(d.addMaven(Maven.MAVEN_CENTRAL, new MavenId("org.antlr:antlr4-runtime:4.11.1"), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
 
 		if (SODIUM) {

--- a/src/main/java/net/coderbot/iris/pipeline/transform/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/TransformPatcher.java
@@ -17,9 +17,6 @@ import io.github.douira.glsl_transformer.ast.node.VersionStatement;
 import io.github.douira.glsl_transformer.ast.print.PrintType;
 import io.github.douira.glsl_transformer.ast.query.Root;
 import io.github.douira.glsl_transformer.ast.query.RootSupplier;
-import io.github.douira.glsl_transformer.ast.query.index.ExternalDeclarationIndex;
-import io.github.douira.glsl_transformer.ast.query.index.NodeIndex;
-import io.github.douira.glsl_transformer.ast.query.index.PrefixIdentifierIndex;
 import io.github.douira.glsl_transformer.ast.transform.EnumASTTransformer;
 import io.github.douira.glsl_transformer.token_filter.ChannelFilter;
 import io.github.douira.glsl_transformer.token_filter.TokenChannel;
@@ -157,15 +154,10 @@ public class TransformPatcher {
 
 	private static final List<String> internalPrefixes = List.of("iris_", "irisMain", "moj_import");
 
-	private static final RootSupplier PREFIX_UNORDERED_ED_EXACT = new RootSupplier(
-			NodeIndex::withUnordered,
-			PrefixIdentifierIndex::withPrefix,
-			ExternalDeclarationIndex::withOnlyExact);
-
 	static {
 		transformer = new EnumASTTransformer<Parameters, PatchShaderType>(PatchShaderType.class) {
 			{
-				setRootSupplier(PREFIX_UNORDERED_ED_EXACT);
+				setRootSupplier(RootSupplier.PREFIX_UNORDERED_ED_EXACT);
 			}
 
 			@Override
@@ -207,7 +199,7 @@ public class TransformPatcher {
 											+ id.getName() + ". See debugging.md for more information.");
 						});
 
-				Root.indexBuildSession(root, () -> {
+				root.indexBuildSession(() -> {
 					VersionStatement versionStatement = tree.getVersionStatement();
 					if (versionStatement == null) {
 						throw new IllegalStateException("Missing the version statement!");

--- a/src/main/java/net/coderbot/iris/pipeline/transform/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/TransformPatcher.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.coderbot.iris.Iris;
-import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Token;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,6 +16,9 @@ import io.github.douira.glsl_transformer.ast.node.Version;
 import io.github.douira.glsl_transformer.ast.node.VersionStatement;
 import io.github.douira.glsl_transformer.ast.print.PrintType;
 import io.github.douira.glsl_transformer.ast.query.Root;
+import io.github.douira.glsl_transformer.ast.query.RootSupplier;
+import io.github.douira.glsl_transformer.ast.query.index.ExternalDeclarationIndex;
+import io.github.douira.glsl_transformer.ast.query.index.NodeIndex;
 import io.github.douira.glsl_transformer.ast.query.index.PrefixIdentifierIndex;
 import io.github.douira.glsl_transformer.ast.transform.EnumASTTransformer;
 import io.github.douira.glsl_transformer.token_filter.ChannelFilter;
@@ -156,11 +157,19 @@ public class TransformPatcher {
 
 	private static final List<String> internalPrefixes = List.of("iris_", "irisMain", "moj_import");
 
+	private static final RootSupplier PREFIX_UNORDERED_ED_EXACT = new RootSupplier(
+			NodeIndex::withUnordered,
+			PrefixIdentifierIndex::withPrefix,
+			ExternalDeclarationIndex::withOnlyExact);
+
 	static {
-		Root.identifierIndexFactory = PrefixIdentifierIndex::withPrefix;
 		transformer = new EnumASTTransformer<Parameters, PatchShaderType>(PatchShaderType.class) {
+			{
+				setRootSupplier(PREFIX_UNORDERED_ED_EXACT);
+			}
+
 			@Override
-			public TranslationUnit parseTranslationUnit(String input) throws RecognitionException {
+			public TranslationUnit parseTranslationUnit(Root rootInstance, String input) {
 				// parse #version directive using an efficient regex before parsing so that the
 				// parser can be set to the correct version
 				Matcher matcher = versionPattern.matcher(input);
@@ -174,7 +183,7 @@ public class TransformPatcher {
 				}
 				transformer.getLexer().version = version;
 
-				return super.parseTranslationUnit(input);
+				return super.parseTranslationUnit(rootInstance, input);
 			}
 		};
 		transformer.setTransformation((trees, parameters) -> {
@@ -198,7 +207,7 @@ public class TransformPatcher {
 											+ id.getName() + ". See debugging.md for more information.");
 						});
 
-				Root.indexBuildSession(tree, () -> {
+				Root.indexBuildSession(root, () -> {
 					VersionStatement versionStatement = tree.getVersionStatement();
 					if (versionStatement == null) {
 						throw new IllegalStateException("Missing the version statement!");
@@ -353,8 +362,8 @@ public class TransformPatcher {
 			float positionScale, float positionOffset, float textureScale,
 			Object2ObjectMap<Tri<String, TextureType, TextureStage>, String> textureMap) {
 		return transform(vertex, geometry, fragment,
-			new SodiumParameters(Patch.SODIUM, textureMap, alpha, inputs, positionScale, positionOffset,
-				textureScale));
+				new SodiumParameters(Patch.SODIUM, textureMap, alpha, inputs, positionScale, positionOffset,
+						textureScale));
 	}
 
 	public static Map<PatchShaderType, String> patchComposite(

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/AttributeTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/AttributeTransformer.java
@@ -8,9 +8,9 @@ import io.github.douira.glsl_transformer.ast.node.abstract_node.ASTNode;
 import io.github.douira.glsl_transformer.ast.node.external_declaration.ExternalDeclaration;
 import io.github.douira.glsl_transformer.ast.query.Root;
 import io.github.douira.glsl_transformer.ast.query.match.AutoHintedMatcher;
-import io.github.douira.glsl_transformer.ast.query.match.Matcher;
 import io.github.douira.glsl_transformer.ast.transform.ASTInjectionPoint;
 import io.github.douira.glsl_transformer.ast.transform.ASTParser;
+import io.github.douira.glsl_transformer.parser.ParseShape;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.pipeline.transform.PatchShaderType;
 import net.coderbot.iris.pipeline.transform.parameter.AttributeParameters;
@@ -123,7 +123,7 @@ public class AttributeTransformer {
 	}
 
 	private static final AutoHintedMatcher<ExternalDeclaration> uniformVec4EntityColor = new AutoHintedMatcher<>(
-			"uniform vec4 entityColor;", Matcher.externalDeclarationPattern);
+			"uniform vec4 entityColor;", ParseShape.EXTERNAL_DECLARATION);
 
 	// Add entity color -> overlay color attribute support.
 	public static void patchOverlayColor(

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CommonTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CommonTransformer.java
@@ -28,6 +28,7 @@ import io.github.douira.glsl_transformer.ast.query.match.Matcher;
 import io.github.douira.glsl_transformer.ast.transform.ASTInjectionPoint;
 import io.github.douira.glsl_transformer.ast.transform.ASTParser;
 import io.github.douira.glsl_transformer.ast.transform.Template;
+import io.github.douira.glsl_transformer.parser.ParseShape;
 import io.github.douira.glsl_transformer.util.Type;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.blending.AlphaTest;
@@ -36,11 +37,11 @@ import net.coderbot.iris.pipeline.transform.parameter.Parameters;
 
 public class CommonTransformer {
 	public static final AutoHintedMatcher<Expression> glTextureMatrix0 = new AutoHintedMatcher<>(
-			"gl_TextureMatrix[0]", Matcher.expressionPattern);
+			"gl_TextureMatrix[0]", ParseShape.EXPRESSION);
 	public static final AutoHintedMatcher<Expression> glTextureMatrix1 = new AutoHintedMatcher<>(
-			"gl_TextureMatrix[1]", Matcher.expressionPattern);
+			"gl_TextureMatrix[1]", ParseShape.EXPRESSION);
 	public static final Matcher<ExternalDeclaration> sampler = new Matcher<>(
-			"uniform Type name;", Matcher.externalDeclarationPattern) {
+			"uniform Type name;", ParseShape.EXTERNAL_DECLARATION) {
 		{
 			markClassedPredicateWildcard("type",
 					pattern.getRoot().identifierIndex.getUnique("Type").getAncestor(TypeSpecifier.class),
@@ -52,7 +53,7 @@ public class CommonTransformer {
 	};
 
 	private static final AutoHintedMatcher<Expression> glFragDataI = new AutoHintedMatcher<>(
-			"gl_FragData[index]", Matcher.expressionPattern) {
+			"gl_FragData[index]", ParseShape.EXPRESSION) {
 		{
 			markClassedPredicateWildcard("index",
 					pattern.getRoot().identifierIndex.getUnique("index").getAncestor(ReferenceExpression.class),
@@ -83,7 +84,7 @@ public class CommonTransformer {
 				id -> {
 					FunctionCallExpression functionCall = (FunctionCallExpression) id.getParent();
 					functionCall.getFunctionName().setName(innerName);
-					FunctionCallExpression wrapper = (FunctionCallExpression) t.parseExpression(id, "vec4()");
+					FunctionCallExpression wrapper = (FunctionCallExpression) t.parseExpression(root, "vec4()");
 					functionCall.replaceBy(wrapper);
 					wrapper.getParameters().add(functionCall);
 				});
@@ -146,7 +147,7 @@ public class CommonTransformer {
 			}
 			for (long index : replaceIndexesSet) {
 				tree.injectNode(ASTInjectionPoint.BEFORE_DECLARATIONS,
-						fragDataDeclaration.getInstanceFor(tree,
+						fragDataDeclaration.getInstanceFor(root,
 								new LiteralExpression(Type.INT32, index),
 								new Identifier("iris_FragData" + index)));
 			}

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
@@ -308,7 +308,7 @@ public class CompatibilityTransformer {
 				new Identifier(name),
 				type.isScalar()
 						? LiteralExpression.getDefaultValue(type)
-						: Root.indexNodes(root, () -> new FunctionCallExpression(
+						: root.indexNodes(() -> new FunctionCallExpression(
 								new Identifier(type.getMostCompactName()),
 								Stream.of(LiteralExpression.getDefaultValue(type)))));
 	}

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompatibilityTransformer.java
@@ -44,6 +44,7 @@ import io.github.douira.glsl_transformer.ast.query.match.Matcher;
 import io.github.douira.glsl_transformer.ast.transform.ASTInjectionPoint;
 import io.github.douira.glsl_transformer.ast.transform.ASTParser;
 import io.github.douira.glsl_transformer.ast.transform.Template;
+import io.github.douira.glsl_transformer.parser.ParseShape;
 import io.github.douira.glsl_transformer.util.Type;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.shader.ShaderType;
@@ -55,7 +56,7 @@ public class CompatibilityTransformer {
 	static Logger LOGGER = LogManager.getLogger(CompatibilityTransformer.class);
 
 	private static final AutoHintedMatcher<Expression> sildursWaterFract = new AutoHintedMatcher<>(
-			"fract(worldpos.y + 0.001)", Matcher.expressionPattern);
+			"fract(worldpos.y + 0.001)", ParseShape.EXPRESSION);
 
 	private static StorageQualifier getConstQualifier(TypeQualifier qualifier) {
 		if (qualifier == null) {
@@ -234,7 +235,7 @@ public class CompatibilityTransformer {
 		private final StorageType storageType;
 
 		public DeclarationMatcher(StorageType storageType) {
-			super("out float name;", Matcher.externalDeclarationPattern);
+			super("out float name;", ParseShape.EXTERNAL_DECLARATION);
 			this.storageType = storageType;
 		}
 
@@ -591,7 +592,7 @@ public class CompatibilityTransformer {
 
 	private static final Matcher<ExternalDeclaration> nonLayoutOutDeclarationMatcher = new Matcher<ExternalDeclaration>(
 			"out float name;",
-			Matcher.externalDeclarationPattern) {
+			ParseShape.EXTERNAL_DECLARATION) {
 		{
 			markClassWildcard("qualifier", pattern.getRoot().nodeIndex.getUnique(TypeQualifier.class));
 			markClassWildcard("type", pattern.getRoot().nodeIndex.getUnique(BuiltinNumericTypeSpecifier.class));

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompositeDepthTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompositeDepthTransformer.java
@@ -7,13 +7,13 @@ import io.github.douira.glsl_transformer.ast.node.external_declaration.Declarati
 import io.github.douira.glsl_transformer.ast.node.external_declaration.ExternalDeclaration;
 import io.github.douira.glsl_transformer.ast.query.Root;
 import io.github.douira.glsl_transformer.ast.query.match.HintedMatcher;
-import io.github.douira.glsl_transformer.ast.query.match.Matcher;
 import io.github.douira.glsl_transformer.ast.transform.ASTInjectionPoint;
 import io.github.douira.glsl_transformer.ast.transform.ASTParser;
+import io.github.douira.glsl_transformer.parser.ParseShape;
 
 class CompositeDepthTransformer {
 	private static final HintedMatcher<ExternalDeclaration> uniformFloatCenterDepthSmooth = new HintedMatcher<>(
-			"uniform float name;", Matcher.externalDeclarationPattern, "centerDepthSmooth") {
+			"uniform float name;", ParseShape.EXTERNAL_DECLARATION, "centerDepthSmooth") {
 		{
 			markClassWildcard("name*",
 					pattern.getRoot().identifierIndex.getUnique("name").getAncestor(DeclarationMember.class));

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompositeTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/CompositeTransformer.java
@@ -6,15 +6,15 @@ import io.github.douira.glsl_transformer.ast.node.expression.LiteralExpression;
 import io.github.douira.glsl_transformer.ast.node.expression.ReferenceExpression;
 import io.github.douira.glsl_transformer.ast.query.Root;
 import io.github.douira.glsl_transformer.ast.query.match.AutoHintedMatcher;
-import io.github.douira.glsl_transformer.ast.query.match.Matcher;
 import io.github.douira.glsl_transformer.ast.transform.ASTInjectionPoint;
 import io.github.douira.glsl_transformer.ast.transform.ASTParser;
+import io.github.douira.glsl_transformer.parser.ParseShape;
 import net.coderbot.iris.gl.shader.ShaderType;
 import net.coderbot.iris.pipeline.transform.parameter.Parameters;
 
 public class CompositeTransformer {
 	private static final AutoHintedMatcher<Expression> glTextureMatrix0To7 = new AutoHintedMatcher<Expression>(
-			"gl_TextureMatrix[index]", Matcher.expressionPattern) {
+			"gl_TextureMatrix[index]", ParseShape.EXPRESSION) {
 		{
 			markClassedPredicateWildcard("index",
 					pattern.getRoot().identifierIndex.getOne("index").getAncestor(ReferenceExpression.class),


### PR DESCRIPTION
Updates the library version and refactors the relevant uses of the updated APIs. Merging this into 1.19.x may require also applying these changes to code exclusive to that branch. Let me know if I should do that.

This glsl-transformer release contains some bug fixes to critical issues, a possible performance improvement and generally improves the API. It also includes a way to query external declarations by their name through the use of the new external declaration index, which I've also enabled on the AST transformer.