### PR TITLE
Fix integer custom image sampler filtering

### DIFF
--- a/src/main/java/net/coderbot/iris/gl/image/GlImage.java
+++ b/src/main/java/net/coderbot/iris/gl/image/GlImage.java
@@ -43,8 +43,9 @@ public class GlImage extends GlResource {
 	}
 
 	protected void setup(int texture, int width, int height, int depth) {
-		IrisRenderSystem.texParameteri(texture, target.getGlType(), GL11C.GL_TEXTURE_MIN_FILTER, GL11C.GL_LINEAR);
-		IrisRenderSystem.texParameteri(texture, target.getGlType(), GL11C.GL_TEXTURE_MAG_FILTER, GL11C.GL_LINEAR);
+		boolean isInteger = internalTextureFormat.getPixelFormat().isInteger();
+		IrisRenderSystem.texParameteri(texture, target.getGlType(), GL11C.GL_TEXTURE_MIN_FILTER, isInteger ? GL11C.GL_NEAREST : GL11C.GL_LINEAR);
+		IrisRenderSystem.texParameteri(texture, target.getGlType(), GL11C.GL_TEXTURE_MAG_FILTER, isInteger ? GL11C.GL_NEAREST : GL11C.GL_LINEAR);
 		IrisRenderSystem.texParameteri(texture, target.getGlType(), GL11C.GL_TEXTURE_WRAP_S, GL13C.GL_CLAMP_TO_EDGE);
 
 		if (height > 0) {


### PR DESCRIPTION
Iris currently always configures linear filtering for custom images regardless of format, but OpenGL requires nearest filtering for integer formats. This sets nearest filtering for integer formats, and uses linear otherwise.

When trying to access integer custom images through the sampler it simply gave 0 on my Steam Deck, but with the corrected filtering it now retrieves the expected data.