### PR TITLE
Drop of CF

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -80,9 +80,9 @@ Make sure to check the [**Compatibility with other Fabric mods**](#compatibility
 7. You should get the following prompt:  
    ![fabricsuccess](guide-resources/fabricsuccess.png)  
    Click OK and close the installer.
-8. Download Iris and Sodium from your website of choice:
-    - Iris Shaders: [Curseforge](https://www.curseforge.com/minecraft/mc-mods/irisshaders), [Modrinth](https://modrinth.com/mod/iris)  
-    - Sodium: [Curseforge](https://www.curseforge.com/minecraft/mc-mods/sodium), [Modrinth](https://modrinth.com/mod/sodium)  
+8. Download Iris and Sodium from the following website:
+    - Iris Shaders: [Modrinth](https://modrinth.com/mod/iris)  
+    - Sodium: [Modrinth](https://modrinth.com/mod/sodium)  
    
    The following table shows which version of Sodium you need based on your Minecraft version:
    
@@ -178,7 +178,7 @@ If you are using **ANY** of the following mods:
 
 ... and many others which could possibly utilize the Fabric Rendering API, **you will experience issues when playing the game**.
 
-**Solution**: Download **Indium** ([Curseforge](https://www.curseforge.com/minecraft/mc-mods/indium), [Modrinth](https://modrinth.com/mod/indium)) and add it to your mods folder.  
+**Solution**: Download **Indium** ([Modrinth](https://modrinth.com/mod/indium)) and add it to your mods folder.  
 
 Make sure to download the version that supports your current version of Sodium:
 


### PR DESCRIPTION
Iris and Sodium are no longer available on CurseForge