### PR TITLE
Enable smooth triangle shading (custom per-vertex normals)

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
+++ b/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
@@ -244,7 +244,8 @@ public abstract class MixinBufferBuilder extends DefaultedVertexConsumer impleme
 		midV /= vertexAmount;
 
 		if (vertexAmount == 3) {
-			NormalHelper.computeFaceNormalTri(normal, polygon);
+      // Removed to enable smooth shaded triangles. Mods rendering triangles with bad normals need to recalculate their normals manually (cross product) or otherwise shading might be inconsistent.
+			// NormalHelper.computeFaceNormalTri(normal, polygon);
 		} else {
 			NormalHelper.computeFaceNormal(normal, polygon);
 		}

--- a/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
+++ b/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
@@ -244,7 +244,7 @@ public abstract class MixinBufferBuilder extends DefaultedVertexConsumer impleme
 		midV /= vertexAmount;
 
 		if (vertexAmount == 3) {
-      // Removed to enable smooth shaded triangles. Mods rendering triangles with bad normals need to recalculate their normals manually (cross product) or otherwise shading might be inconsistent.
+      			// Removed to enable smooth shaded triangles. Mods rendering triangles with bad normals need to recalculate their normals manually or otherwise shading might be inconsistent.
 			// NormalHelper.computeFaceNormalTri(normal, polygon);
 		} else {
 			NormalHelper.computeFaceNormal(normal, polygon);


### PR DESCRIPTION
Previously, every triangle's normals were being recalculated, which results in custom meshes to not shade smooth.
With this PR, only the normal recalculations for triangles have been disabled to enable smooth and flat shading, given by the per-vertex normals. 