### PR TITLE
Calculate per-vertex smoothTangent and keep smooth normals

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
+++ b/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
@@ -259,14 +259,18 @@ public abstract class MixinBufferBuilder extends DefaultedVertexConsumer impleme
 			tangentOffset = 6;
 		}
 
-		int packedNormal = 0;
+		int packedNormal = -1;
+		int tangent = -1;
 		if (vertexAmount == 3) {
 			// Removed to enable smooth shaded triangles. Mods rendering triangles with bad normals need to recalculate their normals manually or otherwise shading might be inconsistent.
 			// NormalHelper.computeFaceNormalTri(normal, polygon);
-			packedNormal = buffer.getInt(nextElementByte - normalOffset);
+			packedNormal = buffer.getInt(nextElementByte - normalOffset - stride * vertex);
+			normal.set(unpackX(packedNormal), unpackY(packedNormal), unpackZ(packedNormal));
+			tangent = NormalHelper.computeTangentSmooth(normal.x, normal.y, normal.z, polygon);
 		} else {
 			NormalHelper.computeFaceNormal(normal, polygon);
-			packedNormal = NormalHelper.packNormal(normal, 0.0f);
+		  packedNormal = NormalHelper.packNormal(normal, 0.0f);
+      tangent = NormalHelper.computeTangent(normal.x, normal.y, normal.z, polygon);
 		}
 
 		int tangent = NormalHelper.computeTangent(normal.x, normal.y, normal.z, polygon);

--- a/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
+++ b/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
@@ -259,27 +259,30 @@ public abstract class MixinBufferBuilder extends DefaultedVertexConsumer impleme
 			tangentOffset = 6;
 		}
 
-		int packedNormal = -1;
-		int tangent = -1;
 		if (vertexAmount == 3) {
-			// Removed to enable smooth shaded triangles. Mods rendering triangles with bad normals need to recalculate their normals manually or otherwise shading might be inconsistent.
-			// NormalHelper.computeFaceNormalTri(normal, polygon);
-			packedNormal = buffer.getInt(nextElementByte - normalOffset - stride * vertex);
-			normal.set(unpackX(packedNormal), unpackY(packedNormal), unpackZ(packedNormal));
-			tangent = NormalHelper.computeTangentSmooth(normal.x, normal.y, normal.z, polygon);
+			// NormalHelper.computeFaceNormalTri(normal, polygon);	// Removed to enable smooth shaded triangles. Mods rendering triangles with bad normals need to recalculate their normals manually or otherwise shading might be inconsistent.
+
+			for (int vertex = 0; vertex < vertexAmount; vertex++) {
+				int packedNormal = buffer.getInt(nextElementByte - normalOffset - stride * vertex); // retrieve per-vertex normal
+				normal.set(unpackX(packedNormal), unpackY(packedNormal), unpackZ(packedNormal));
+
+				int tangent = NormalHelper.computeTangentSmooth(normal.x, normal.y, normal.z, polygon);
+
+				buffer.putFloat(nextElementByte - midUOffset - stride * vertex, midU);
+				buffer.putFloat(nextElementByte - midVOffset - stride * vertex, midV);
+				buffer.putInt(nextElementByte - tangentOffset - stride * vertex, tangent);
+			}
 		} else {
 			NormalHelper.computeFaceNormal(normal, polygon);
-		  packedNormal = NormalHelper.packNormal(normal, 0.0f);
-      tangent = NormalHelper.computeTangent(normal.x, normal.y, normal.z, polygon);
-		}
+			int packedNormal = NormalHelper.packNormal(normal, 0.0f);
+			int tangent = NormalHelper.computeTangent(normal.x, normal.y, normal.z, polygon);
 
-		int tangent = NormalHelper.computeTangent(normal.x, normal.y, normal.z, polygon);
-
-		for (int vertex = 0; vertex < vertexAmount; vertex++) {
-			buffer.putFloat(nextElementByte - midUOffset - stride * vertex, midU);
-			buffer.putFloat(nextElementByte - midVOffset - stride * vertex, midV);
-			buffer.putInt(nextElementByte - normalOffset - stride * vertex, packedNormal);
-			buffer.putInt(nextElementByte - tangentOffset - stride * vertex, tangent);
+			for (int vertex = 0; vertex < vertexAmount; vertex++) {
+				buffer.putFloat(nextElementByte - midUOffset - stride * vertex, midU);
+				buffer.putFloat(nextElementByte - midVOffset - stride * vertex, midV);
+				buffer.putInt(nextElementByte - normalOffset - stride * vertex, packedNormal);
+				buffer.putInt(nextElementByte - tangentOffset - stride * vertex, tangent);
+			}
 		}
 	}
 

--- a/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
+++ b/src/main/java/net/coderbot/iris/mixin/vertices/MixinBufferBuilder.java
@@ -264,7 +264,7 @@ public abstract class MixinBufferBuilder extends DefaultedVertexConsumer impleme
 
 			for (int vertex = 0; vertex < vertexAmount; vertex++) {
 				int packedNormal = buffer.getInt(nextElementByte - normalOffset - stride * vertex); // retrieve per-vertex normal
-				normal.set(unpackX(packedNormal), unpackY(packedNormal), unpackZ(packedNormal));
+				normal.set(NormalHelper.unpackX(packedNormal), NormalHelper.unpackY(packedNormal), NormalHelper.unpackZ(packedNormal));
 
 				int tangent = NormalHelper.computeTangentSmooth(normal.x, normal.y, normal.z, polygon);
 

--- a/src/main/java/net/coderbot/iris/vertices/NormalHelper.java
+++ b/src/main/java/net/coderbot/iris/vertices/NormalHelper.java
@@ -56,6 +56,18 @@ public abstract class NormalHelper {
 		return packNormal(normal.x, normal.y, normal.z, w);
 	}
 
+  public static float unpackX(int norm) {
+        return (float)((byte)(norm & 255)) * 0.007874016F;
+    }
+
+    public static float unpackY(int norm) {
+        return (float)((byte)(norm >> 8 & 255)) * 0.007874016F;
+    }
+
+    public static float unpackZ(int norm) {
+        return (float)((byte)(norm >> 16 & 255)) * 0.007874016F;
+    }
+
 	/**
 	 * Retrieves values packed by {@link #packNormal(float, float, float, float)}.
 	 *

--- a/src/main/java/net/coderbot/iris/vertices/NormalHelper.java
+++ b/src/main/java/net/coderbot/iris/vertices/NormalHelper.java
@@ -164,6 +164,116 @@ public abstract class NormalHelper {
 		saveTo.set(normX, normY, normZ);
 	}
 
+	public static int computeTangentSmooth(float normalX, float normalY, float normalZ, TriView t) {
+    // Capture all of the relevant vertex positions
+		float x0 = t.x(0);
+		float y0 = t.y(0);
+		float z0 = t.z(0);
+
+		float x1 = t.x(1);
+		float y1 = t.y(1);
+		float z1 = t.z(1);
+
+		float x2 = t.x(2);
+		float y2 = t.y(2);
+		float z2 = t.z(2);
+
+    // Project all vertices onto normal plane (for smooth normal support). Optionally skip this step for flat shading.
+    // Procedure:
+    // project v onto normal
+    // offset v by the projection to get the point on the plane
+    // project x0, y0, z0 onto normal
+    float d0 = x0 * normalX + y0 * normalY + z0 * normalZ;
+    float d1 = x1 * normalX + y1 * normalY + z1 * normalZ;
+    float d2 = x2 * normalX + y2 * normalY + z2 * normalZ;
+
+    // offset x, y, z by the projection to get the projected point on the normal plane
+    x0 -= d0 * normalX;
+    y0 -= d0 * normalY;
+    z0 -= d0 * normalZ;
+
+    x1 -= d1 * normalX;
+    y1 -= d1 * normalY;
+    z1 -= d1 * normalZ;
+
+    x2 -= d2 * normalX;
+    y2 -= d2 * normalY;
+    z2 -= d2 * normalZ;
+
+
+		float edge1x = x1 - x0;
+		float edge1y = y1 - y0;
+		float edge1z = z1 - z0;
+
+		float edge2x = x2 - x0;
+		float edge2y = y2 - y0;
+		float edge2z = z2 - z0;
+
+		float u0 = t.u(0);
+		float v0 = t.v(0);
+
+		float u1 = t.u(1);
+		float v1 = t.v(1);
+
+		float u2 = t.u(2);
+		float v2 = t.v(2);
+
+		float deltaU1 = u1 - u0;
+		float deltaV1 = v1 - v0;
+		float deltaU2 = u2 - u0;
+		float deltaV2 = v2 - v0;
+
+		float fdenom = deltaU1 * deltaV2 - deltaU2 * deltaV1;
+		float f;
+
+		if (fdenom == 0.0) {
+			f = 1.0f;
+		} else {
+			f = 1.0f / fdenom;
+		}
+
+		float tangentx = f * (deltaV2 * edge1x - deltaV1 * edge2x);
+		float tangenty = f * (deltaV2 * edge1y - deltaV1 * edge2y);
+		float tangentz = f * (deltaV2 * edge1z - deltaV1 * edge2z);
+		float tcoeff = rsqrt(tangentx * tangentx + tangenty * tangenty + tangentz * tangentz);
+		tangentx *= tcoeff;
+		tangenty *= tcoeff;
+		tangentz *= tcoeff;
+
+		float bitangentx = f * (-deltaU2 * edge1x + deltaU1 * edge2x);
+		float bitangenty = f * (-deltaU2 * edge1y + deltaU1 * edge2y);
+		float bitangentz = f * (-deltaU2 * edge1z + deltaU1 * edge2z);
+		float bitcoeff = rsqrt(bitangentx * bitangentx + bitangenty * bitangenty + bitangentz * bitangentz);
+		bitangentx *= bitcoeff;
+		bitangenty *= bitcoeff;
+		bitangentz *= bitcoeff;
+
+		// predicted bitangent = tangent × normal
+		// Compute the determinant of the following matrix to get the cross product
+		//  i  j  k
+		// tx ty tz
+		// nx ny nz
+
+		// Be very careful when writing out complex multi-step calculations
+		// such as vector cross products! The calculation for pbitangentz
+		// used to be broken because it multiplied values in the wrong order.
+
+		float pbitangentx = tangenty * normalZ - tangentz * normalY;
+		float pbitangenty = tangentz * normalX - tangentx * normalZ;
+		float pbitangentz = tangentx * normalY - tangenty * normalX;
+
+		float dot = (bitangentx * pbitangentx) + (bitangenty * pbitangenty) + (bitangentz * pbitangentz);
+		float tangentW;
+
+		if (dot < 0) {
+			tangentW = -1.0F;
+		} else {
+			tangentW = 1.0F;
+		}
+
+		return packNormal(tangentx, tangenty, tangentz, tangentW);
+  }
+
 	public static int computeTangent(float normalX, float normalY, float normalZ, TriView t) {
 		// Capture all of the relevant vertex positions
 		float x0 = t.x(0);


### PR DESCRIPTION
The `calculateSmoothTangent` previously built the tangent space transformation matrix based upon the geometry plane only. With smooth shaded meshes, each triangle has a per-vertex normal in contrast to a per-face normal. Each normal not necessarily matches with the geometric face normal, which allows shaders to lerp between normals to create an artificial smoothness of the rendered mesh with the same amount of polygons.

With this PR, the built T and B now lie within the per-vertex smooth normal and not within the geometric normal.
![image](https://github.com/IrisShaders/Iris/assets/43215895/f6d87808-d2a9-4099-8d10-ca2d3c295f17)
(The black arrow represents the geometry normal)
This is achieved by projecting the geometry points (P0, P1, P2) onto the plane of the smooth per-vertex normal plane (green) for the tangent space calculation.

The tangent space was previously also calculated per-face, not per-vertex. This hindered shaders to interpolate between tangent-spaces per-vertex (like it lerps per-vertex normals).

Also, this PR includes the retrieval of the per-vertex normals, needed for the `calculateSmoothTangent` method and smooth shading in general.