### PR TITLE
Uniforms: add relativeEyePosition

### DIFF
--- a/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
+++ b/src/main/java/net/coderbot/iris/uniforms/IrisExclusiveUniforms.java
@@ -34,6 +34,9 @@ public class IrisExclusiveUniforms {
 		uniforms.uniform1b(UniformUpdateFrequency.PER_FRAME, "firstPersonCamera", IrisExclusiveUniforms::isFirstPersonCamera);
 		uniforms.uniform1b(UniformUpdateFrequency.PER_TICK, "isSpectator", IrisExclusiveUniforms::isSpectator);
 		uniforms.uniform3d(UniformUpdateFrequency.PER_FRAME, "eyePosition", IrisExclusiveUniforms::getEyePosition);
+		uniforms.uniform3d(UniformUpdateFrequency.PER_FRAME, "relativeEyePosition", () -> {
+			return CameraUniforms.getUnshiftedCameraPosition().sub(getEyePosition());
+		});
 		Vector4f zero = new Vector4f(0, 0, 0, 0);
 		uniforms.uniform4f(UniformUpdateFrequency.PER_TICK, "lightningBoltPosition", () -> {
 			if (Minecraft.getInstance().level != null) {


### PR DESCRIPTION
cameraPosition is bounded to -30000, 30000 and eyePosition is not. If a shader wants to use the relative eyePosition across this border (i.e. cameraPosition - eyePosition) then this calculation will break. We provide a uniform which uses the unshifted positions for this purpose.