### PR TITLE
Fix iris website url in LaunchWarn

### DIFF
--- a/src/main/java/net/coderbot/iris/LaunchWarn.java
+++ b/src/main/java/net/coderbot/iris/LaunchWarn.java
@@ -12,7 +12,7 @@ public class LaunchWarn {
 	public static void main(String[] args) {
 		// TODO: make this translatable
 		String message = "This file is the Fabric version of Iris, meant to be installed as a mod. Would you like to get the Iris Installer instead?";
-		String fallback = "This file is the Fabric version of Iris, meant to be installed as a mod. Please download the Iris Installer from https://irisshaders.net.";
+		String fallback = "This file is the Fabric version of Iris, meant to be installed as a mod. Please download the Iris Installer from https://irisshaders.dev.";
 		if (GraphicsEnvironment.isHeadless()) {
 			System.err.println(fallback);
 		} else {
@@ -27,7 +27,7 @@ public class LaunchWarn {
 
 				if (option == JOptionPane.YES_OPTION) {
 					try {
-						Desktop.getDesktop().browse(URI.create("https://irisshaders.net"));
+						Desktop.getDesktop().browse(URI.create("https://irisshaders.dev"));
 					} catch (IOException e) {
 						e.printStackTrace();
 					}


### PR DESCRIPTION
it was pointing to the old .net website.