### PR TITLE
Update BaseOptionElementWidget.java to debug rmb click

### DIFF
--- a/src/main/java/net/irisshaders/iris/gui/element/widget/BaseOptionElementWidget.java
+++ b/src/main/java/net/irisshaders/iris/gui/element/widget/BaseOptionElementWidget.java
@@ -18,6 +18,8 @@ import net.minecraft.network.chat.TextColor;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
+import net.irisshaders.iris.Iris;
+
 import java.util.Optional;
 
 public abstract class BaseOptionElementWidget<T extends OptionMenuElement> extends CommentedElementWidget<T> {
@@ -165,6 +167,7 @@ public abstract class BaseOptionElementWidget<T extends OptionMenuElement> exten
 
 	@Override
 	public boolean mouseClicked(double mx, double my, int button) {
+		Iris.logger.info("Button" + String.valueOf(button));
 		if (button == GLFW.GLFW_MOUSE_BUTTON_1 || button == GLFW.GLFW_MOUSE_BUTTON_2) {
 			boolean refresh = false;
 


### PR DESCRIPTION
I added some logging to log which button on the mouse is clicked so that we can see if we have the right if statement. I would recommend creating a refractor-mouse-debug branch for this so that we can merge and remove the debug with ease. This pr does not change very much, only adding debug, to the mouse click, printing the int of mouse.