### PR TITLE
Add key press cooldown

### DIFF
--- a/src/main/java/net/irisshaders/iris/Iris.java
+++ b/src/main/java/net/irisshaders/iris/Iris.java
@@ -14,6 +14,7 @@ import net.irisshaders.iris.gl.shader.ShaderCompileException;
 import net.irisshaders.iris.gl.shader.StandardMacros;
 import net.irisshaders.iris.gui.debug.DebugLoadFailedGridScreen;
 import net.irisshaders.iris.gui.screen.ShaderPackScreen;
+import net.irisshaders.iris.helpers.CooldownKeyMapping;
 import net.irisshaders.iris.helpers.OptionalBoolean;
 import net.irisshaders.iris.pipeline.IrisRenderingPipeline;
 import net.irisshaders.iris.pipeline.PipelineManager;
@@ -710,11 +711,6 @@ public class Iris {
 
 		updateChecker = new UpdateChecker(IRIS_VERSION);
 
-		reloadKeybind = KeyBindingHelper.registerKeyBinding(new KeyMapping("iris.keybind.reload", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_R, "iris.keybinds"));
-		toggleShadersKeybind = KeyBindingHelper.registerKeyBinding(new KeyMapping("iris.keybind.toggleShaders", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_K, "iris.keybinds"));
-		shaderpackScreenKeybind = KeyBindingHelper.registerKeyBinding(new KeyMapping("iris.keybind.shaderPackSelection", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_O, "iris.keybinds"));
-		wireframeKeybind = KeyBindingHelper.registerKeyBinding(new KeyMapping("iris.keybind.wireframe", InputConstants.Type.KEYSYM, InputConstants.UNKNOWN.getValue(), "iris.keybinds"));
-
 		DHCompat.run();
 
 		try {
@@ -734,6 +730,11 @@ public class Iris {
 			logger.error("Failed to initialize Iris configuration, default values will be used instead");
 			logger.error("", e);
 		}
+
+		reloadKeybind = KeyBindingHelper.registerKeyBinding(new CooldownKeyMapping("iris.keybind.reload", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_R, "iris.keybinds"));
+		toggleShadersKeybind = KeyBindingHelper.registerKeyBinding(new CooldownKeyMapping("iris.keybind.toggleShaders", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_K, "iris.keybinds"));
+		shaderpackScreenKeybind = KeyBindingHelper.registerKeyBinding(new CooldownKeyMapping("iris.keybind.shaderPackSelection", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_O, "iris.keybinds"));
+		wireframeKeybind = KeyBindingHelper.registerKeyBinding(new CooldownKeyMapping("iris.keybind.wireframe", InputConstants.Type.KEYSYM, InputConstants.UNKNOWN.getValue(), "iris.keybinds"));
 
 		updateChecker.checkForUpdates(irisConfig);
 

--- a/src/main/java/net/irisshaders/iris/config/IrisConfig.java
+++ b/src/main/java/net/irisshaders/iris/config/IrisConfig.java
@@ -35,12 +35,17 @@ public class IrisConfig {
 	 * If the update notification should be disabled or not.
 	 */
 	private boolean disableUpdateMessage;
+	/**
+	 * The cooldown amount (in ticks) after a key press to prevent spamming.
+	 */
+	private int keyPressCooldown;
 
 	public IrisConfig(Path propertiesPath) {
 		shaderPackName = null;
 		enableShaders = true;
 		enableDebugOptions = false;
 		disableUpdateMessage = false;
+		keyPressCooldown = 20;
 		this.propertiesPath = propertiesPath;
 	}
 
@@ -102,6 +107,13 @@ public class IrisConfig {
 		return disableUpdateMessage;
 	}
 
+	/**
+	 * Returns the cooldown amount (in ticks) after a key press to prevent spamming.
+	 */
+	public int getKeyPressCooldown() {
+		return keyPressCooldown;
+	}
+
 	public void setDebugEnabled(boolean enabled) {
 		enableDebugOptions = enabled;
 	}
@@ -134,6 +146,14 @@ public class IrisConfig {
 		enableDebugOptions = "true".equals(properties.getProperty("enableDebugOptions"));
 		disableUpdateMessage = "true".equals(properties.getProperty("disableUpdateMessage"));
 		try {
+			keyPressCooldown = Integer.parseInt(properties.getProperty("keyPressCooldown", "20"));
+		} catch (NumberFormatException e) {
+			Iris.logger.error("Key press cooldown setting reset; value is invalid.");
+			keyPressCooldown = 20;
+			save();
+		}
+
+		try {
 			IrisVideoSettings.shadowDistance = Integer.parseInt(properties.getProperty("maxShadowRenderDistance", "32"));
 			IrisVideoSettings.colorSpace = ColorSpace.valueOf(properties.getProperty("colorSpace", "SRGB"));
 		} catch (IllegalArgumentException e) {
@@ -161,6 +181,7 @@ public class IrisConfig {
 		properties.setProperty("enableShaders", enableShaders ? "true" : "false");
 		properties.setProperty("enableDebugOptions", enableDebugOptions ? "true" : "false");
 		properties.setProperty("disableUpdateMessage", disableUpdateMessage ? "true" : "false");
+		properties.setProperty("keyPressCooldown", String.valueOf(keyPressCooldown));
 		properties.setProperty("maxShadowRenderDistance", String.valueOf(IrisVideoSettings.shadowDistance));
 		properties.setProperty("colorSpace", IrisVideoSettings.colorSpace.name());
 		// NB: This uses ISO-8859-1 with unicode escapes as the encoding

--- a/src/main/java/net/irisshaders/iris/helpers/CooldownKeyMapping.java
+++ b/src/main/java/net/irisshaders/iris/helpers/CooldownKeyMapping.java
@@ -1,0 +1,38 @@
+package net.irisshaders.iris.helpers;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.irisshaders.iris.Iris;
+import net.minecraft.client.KeyMapping;
+
+public class CooldownKeyMapping extends KeyMapping {
+
+	private int currentCooldown = 0;
+
+	public CooldownKeyMapping(String string, int i, String string2) {
+		super(string, i, string2);
+	}
+
+	public CooldownKeyMapping(String string, InputConstants.Type type, int i, String string2) {
+		super(string, type, i, string2);
+	}
+
+	public boolean consumeClick() {
+		// If the config value is 0 or lower, we don't need to worry about cooldowns
+		if (Iris.getIrisConfig().getKeyPressCooldown() <= 0)
+			return super.consumeClick();
+
+		// Decrement the cooldown if it's active
+		currentCooldown--;
+
+		// Return if the key was not pressed
+		if (!super.consumeClick()) return false;
+
+		// Check if the key is on cooldown
+		if (currentCooldown > 0)
+			return false;
+
+		// Cooldown is not active, so we process the click and add a cooldown
+		currentCooldown = Iris.getIrisConfig().getKeyPressCooldown();
+		return true;
+	}
+}


### PR DESCRIPTION
## What does this do?
This PR adds a (configurable) cooldown to key presses, which defaults to 20 ticks.

## Why?
During a playthrough with some friends, I accidentally held the wrong key, which kept spam toggling my shaders, making my game crash in the end. **Basically just a minor annoyance :p**

## Before & After
Before fix:
https://github.com/IrisShaders/Iris/assets/21986809/a43e1e20-a2e6-43fa-82ec-3eb028365183

After fix:
https://github.com/IrisShaders/Iris/assets/21986809/2b4b25b7-5c58-4662-a1bd-2bdf7b447cd7