### PR TITLE
add boolean expression parser to disable programs

### DIFF
--- a/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
@@ -27,6 +27,7 @@ import net.irisshaders.iris.shaderpack.option.ShaderPackOptions;
 import net.irisshaders.iris.shaderpack.option.menu.OptionMenuContainer;
 import net.irisshaders.iris.shaderpack.option.values.MutableOptionValues;
 import net.irisshaders.iris.shaderpack.option.values.OptionValues;
+import net.irisshaders.iris.shaderpack.parsing.BooleanParser;
 import net.irisshaders.iris.shaderpack.preprocessor.JcppProcessor;
 import net.irisshaders.iris.shaderpack.preprocessor.PropertiesPreprocessor;
 import net.irisshaders.iris.shaderpack.programs.ProgramSet;
@@ -228,9 +229,7 @@ public class ShaderPack {
 		this.profile.current.ifPresent(profile -> disabledPrograms.addAll(profile.disabledPrograms));
 		// Add programs that are disabled by shader options
 		shaderProperties.getConditionallyEnabledPrograms().forEach((program, shaderOption) -> {
-			if ("true".equals(shaderOption)) return;
-
-			if ("false".equals(shaderOption) || !this.shaderPackOptions.getOptionValues().getBooleanValueOrDefault(shaderOption)) {
+			if (!BooleanParser.parse(shaderOption, this.shaderPackOptions.getOptionValues())) {
 				disabledPrograms.add(program);
 			}
 		});

--- a/src/main/java/net/irisshaders/iris/shaderpack/parsing/BooleanParser.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/parsing/BooleanParser.java
@@ -1,0 +1,150 @@
+package net.irisshaders.iris.shaderpack.parsing;
+
+import net.irisshaders.iris.Iris;
+import net.irisshaders.iris.shaderpack.option.values.OptionValues;
+
+import java.util.EmptyStackException;
+import java.util.Stack;
+
+public class BooleanParser {
+	private enum OPERATION {
+		AND {
+			@Override
+			boolean compute(boolean value, Stack<Boolean> valueStack) {
+				return value & valueStack.pop();
+			}
+		}, OR {
+			@Override
+			boolean compute(boolean value, Stack<Boolean> valueStack) {
+				return value | valueStack.pop();
+			}
+		}, NOT {
+			@Override
+			boolean compute(boolean value, Stack<Boolean> valueStack) {
+				return !value;
+			}
+		}, OPEN;
+
+		boolean compute(boolean value, Stack<Boolean> valueStack) {
+			return value;
+		}
+	}
+
+	/**
+	 * parses the given expression
+	 * @param expression expression to parse
+	 * @param valueLookup lookup of shadow options
+	 * @return result of the expression, or true if there was an error
+	 */
+	public static boolean parse(String expression, OptionValues valueLookup) {
+		try {
+			String option = "";
+			Stack<OPERATION> operationStack = new Stack<>();
+			Stack<Boolean> valueStack = new Stack<>();
+			for (int i = 0; i < expression.length(); i++) {
+				char c = expression.charAt(i);
+				switch (c) {
+					case '!' -> operationStack.push(OPERATION.NOT);
+					case '&' -> {
+						// add value first, because this checks for preceding NOTs
+						if (!option.isEmpty()) {
+							valueStack.push(processValue(option, valueLookup, operationStack));
+							option = "";
+						}
+						// AND operators have priority, so add a bracket if it's the first AND
+						if (operationStack.isEmpty() || !operationStack.peek().equals(OPERATION.AND)) {
+							operationStack.push(OPERATION.OPEN);
+						}
+						i++;
+						operationStack.push(OPERATION.AND);
+					}
+					case '|' -> {
+						// add value first, because this checks for preceding NOTs
+						if (!option.isEmpty()) {
+							valueStack.push(processValue(option, valueLookup, operationStack));
+							option = "";
+						}
+						// if there was an AND before, that needs to be evaluated because it takes priority
+						if (!operationStack.isEmpty() && operationStack.peek().equals(OPERATION.AND)) {
+							evaluate(operationStack, valueStack, true);
+						}
+						i++;
+						operationStack.push(OPERATION.OR);
+					}
+					case '(' -> operationStack.push(OPERATION.OPEN);
+					case ')' -> {
+						// add value first, because this checks for preceding NOTs
+						if (!option.isEmpty()) {
+							valueStack.push(processValue(option, valueLookup, operationStack));
+							option = "";
+						}
+						// if there was an AND before, that needs to be evaluated because it added its own bracket
+						if (!operationStack.isEmpty() && operationStack.peek().equals(OPERATION.AND)) {
+							evaluate(operationStack, valueStack, true);
+						}
+						evaluate(operationStack, valueStack, true);
+					}
+					case ' ' -> {}
+					default -> option += c;
+				}
+			}
+			if (!option.isEmpty()) {
+				valueStack.push(processValue(option, valueLookup, operationStack));
+			}
+			evaluate(operationStack, valueStack, false);
+			boolean result = valueStack.pop();
+			if (!valueStack.isEmpty() || !operationStack.isEmpty()) {
+				Iris.logger.warn(
+					"Failed to parse the following boolean operation correctly, stacks not empty, defaulting to true!: '{}'",
+					expression);
+				return true;
+			}
+			return result;
+		} catch (EmptyStackException emptyStackException) {
+			Iris.logger.warn(
+				"Failed to parse the following boolean operation correctly, stacks empty when it shouldn't, defaulting to true!: '{}'",
+				expression);
+			return true;
+		}
+	}
+
+	/**
+	 * gets the value for the given string and negates it if there is a NOT in the operationStack
+	 */
+	private static boolean processValue(String value, OptionValues valueLookup, Stack<OPERATION> operationStack) {
+		boolean booleanValue = switch (value) {
+			case "true", "1" -> true;
+			case "false" -> false;
+			default -> valueLookup != null && valueLookup.getBooleanValueOrDefault(value);
+		};
+		if (!operationStack.isEmpty() && operationStack.peek() == OPERATION.NOT) {
+			// if there is a NOT, that needs to be handled immediately
+			operationStack.pop();
+			return !booleanValue;
+		} else {
+			return booleanValue;
+		}
+	}
+
+	/**
+	 * evaluates the operation stack backwards, to the next bracket, or the whole way
+	 * @param operationStack Stack with operations
+	 * @param valueStack Stack with values
+	 * @param currentBracket only evaluates the current bracket
+	 */
+	private static void evaluate(Stack<OPERATION> operationStack, Stack<Boolean> valueStack, boolean currentBracket) {
+		boolean value = valueStack.pop();
+		while (!operationStack.isEmpty() && (!currentBracket || operationStack.peek() != OPERATION.OPEN)) {
+			value = operationStack.pop().compute(value, valueStack);
+		}
+
+		// if there is a bracket check if the whole bracket should be negated
+		if (!operationStack.isEmpty() && operationStack.peek() == OPERATION.OPEN) {
+			operationStack.pop();
+			if (!operationStack.isEmpty() && operationStack.peek() == OPERATION.NOT) {
+				value = operationStack.pop().compute(value, valueStack);
+			}
+		}
+		valueStack.push(value);
+	}
+}


### PR DESCRIPTION
fixes #1026

adds a boolean expression parser. it might not be the best implementation, but it works from my testing.

the parser uses 2 Stacks, one for operations andone for the parsed values.
expressinos are read front to back, and evaluated back to front.
brackets and && chains are evaluated once they close/end