### PR TITLE
fix const float parsing

### DIFF
--- a/src/main/java/net/irisshaders/iris/shaderpack/parsing/ParsedString.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/parsing/ParsedString.java
@@ -104,8 +104,15 @@ public class ParsedString {
 				if (!Character.isDigit(text.charAt(position)) && !Character.isDigit(text.charAt(position + 1))) {
 					break;
 				}
+			} else if (!Character.isDigit(text.charAt(position))) {
+				break;
 			}
 
+			position++;
+		}
+
+		// take any f float suffixes, if we have a number
+		if (position > 0 && position + 1 < text.length() && (text.charAt(position) == 'f' || text.charAt(position) == 'F')) {
 			position++;
 		}
 


### PR DESCRIPTION
fixes the const float parser failing for stuff with the `f` suffix, or no characters after the semicolon, like
```
const float ambientOcclusionLevel = 1.0f;   //[0.0f 0.1f 0.2f 0.3f 0.4f 0.5f 0.6f 0.7f 0.8f 0.9f 1.0f]
```
or
```
const float ambientOcclusionLevel = 0.5;
```