### PR TITLE
define environment defines without a value as boolean macros

### DIFF
--- a/src/main/java/net/irisshaders/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
@@ -35,7 +35,11 @@ public class PropertiesPreprocessor {
 			}
 
 			for (StringPair envDefine : environmentDefines) {
-				pp.addMacro(envDefine.key(), envDefine.value());
+				if (envDefine.value().isEmpty()) {
+					pp.addMacro(envDefine.key());
+				} else {
+					pp.addMacro(envDefine.key(), envDefine.value());
+				}
 			}
 
 			stringValues.forEach((name, value) -> {


### PR DESCRIPTION
defines environment defines as boolean macros for properties preprocessing
this fixes iris stripping out `IS_IRIS` and such from the program enabled like here
```
program.world0/gbuffers_block_translucent.enabled = TRANSLUCENT_ENTITIES && IS_IRIS
```