### PR TITLE
Updating Build action to use java version 21 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
Updating the Java version for non-release builds to Java 21 from 17.
This should fix the currently failing build action for the multiloader for MC 1.21+, which requires the version 21 of JDK:

```
> Failed to setup Minecraft, java.lang.IllegalStateException: Minecraft 1.21 requires Java 21 but Gradle is using 17
``` 
ref: https://github.com/IrisShaders/Iris/actions/runs/9529460139/job/26268233984#step:5:35
 