### PR TITLE
Fix: `iris$beforeNext` only supporting quads and triangles

### DIFF
--- a/src/main/java/net/irisshaders/iris/mixin/vertices/MixinBufferBuilder.java
+++ b/src/main/java/net/irisshaders/iris/mixin/vertices/MixinBufferBuilder.java
@@ -169,6 +169,10 @@ public abstract class MixinBufferBuilder implements VertexConsumer, BlockSensiti
 			return;
 		}
 
+		if (mode != VertexFormat.Mode.QUADS && mode != VertexFormat.Mode.TRIANGLES) {
+			return;
+		}
+
 		vertexPointers[iris$vertexCount] = vertexPointer;
 
 		iris$vertexCount++;


### PR DESCRIPTION
Currently `this.vertexPointers[this.iris$vertexCount] = this.vertexPointer;` will increment for each `endLastVertex` call.
However if you are using a vertex mode which isn't `QUADS` or `TRIANGLES` than you get `ArrayIndexOutOfBoundsException: Index 4 out of bounds for length 4`
Since `vertexPointers` is `new long[4]`

Basically it doesn't account for `TRIANGLE_STRIP` currently. We should just skip them, since you aren't using them for the extended data.
It's possible to get this by using `TRIANGLE_STRIP` on a player layer.