### PR TITLE
Log warns for missing backslashes in .properties file

### DIFF
--- a/src/main/java/net/irisshaders/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/IdMap.java
@@ -315,7 +315,7 @@ public class IdMap {
 	}
 
 	private static void warnMissingBackslashInPropertiesFile(String processedSource, String propertiesFileName) {
-		if (propertiesFileName.equals("shader.properties")) {
+		if (propertiesFileName.equals("shaders.properties")) {
 			return;
 		}
 		String[] fileNameSections = propertiesFileName.split("\\.");

--- a/src/main/java/net/irisshaders/iris/shaderpack/IdMap.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/IdMap.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Matcher;
 
 /**
  * A utility class for parsing entries in item.properties, block.properties, and entities.properties files in shaderpacks
@@ -104,8 +105,8 @@ public class IdMap {
 
 		// TODO: This is the worst code I have ever made. Do not do this.
 		String processed = PropertiesPreprocessor.preprocessSource(fileContents, shaderPackOptions, environmentDefines).replaceAll("\\\\\\n\\s*\\n", " ").replaceAll("\\S\s*block\\.", "\nblock.");
-
 		StringReader propertiesReader = new StringReader(processed);
+		warnMissingBackslashInPropertiesFile(processed, name);
 
 		// Note: ordering of properties is significant
 		// See https://github.com/IrisShaders/Iris/issues/1327 and the relevant putIfAbsent calls in
@@ -311,6 +312,28 @@ public class IdMap {
 		});
 
 		return overrides;
+	}
+
+	private static void warnMissingBackslashInPropertiesFile(String processedSource, String propertiesFileName) {
+		if (propertiesFileName.equals("shader.properties")) {
+			return;
+		}
+		String[] fileNameSections = propertiesFileName.split("\\.");
+		String entryName = "entry";
+		if (fileNameSections.length >= 2) {
+			entryName = fileNameSections[0] + " entry";
+		}
+		Matcher matcher = PropertiesPreprocessor.BACKSLASH_MATCHER.matcher(processedSource);
+		while (matcher.find()) {
+			Iris.logger.warn("Found missing \"\\\" in file \"{}\" in {}: \"{}\"", propertiesFileName, entryName, matcher.group(0));
+			for (int i = 1; i <= matcher.groupCount(); i++) {
+				String match = matcher.group(i);
+				if (match == null) {
+					continue;
+				}
+				Iris.logger.warn("At ID: \"{}\"", match);
+			}
+		}
 	}
 
 	public Int2ObjectLinkedOpenHashMap<List<BlockEntry>> getBlockProperties() {

--- a/src/main/java/net/irisshaders/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
@@ -17,9 +17,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class PropertiesPreprocessor {
+
+	public static final Pattern BACKSLASH_MATCHER = Pattern.compile("(?<!\\\\\\n)^(?![ \\t]*(#|block\\.\\d*|layer\\.\\d*|item\\.\\d*|entity\\.\\d*|dimension\\.\\d*)).+", Pattern.MULTILINE);
+
 	// Derived from ShaderProcessor.glslPreprocessSource, which is derived from GlShader from Canvas, licenced under LGPL
 	public static String preprocessSource(String source, ShaderPackOptions shaderPackOptions, Iterable<StringPair> environmentDefines) {
 		if (source.contains(PropertyCollectingListener.PROPERTY_MARKER) || source.contains("IRIS_PASSTHROUGHBACKSLASH")) {


### PR DESCRIPTION
Credits to [Balint](https://github.com/BalintCsala) for the regex pattern. This regex has been tested and has no false positives. Feel free to suggest or implement any changes. The `shaders.properties` file is excluded by these warnings.
