### PR TITLE
add file capitalization check when debug options are enabled

### DIFF
--- a/src/main/java/net/irisshaders/iris/Iris.java
+++ b/src/main/java/net/irisshaders/iris/Iris.java
@@ -313,6 +313,7 @@ public class Iris {
 		} catch (Exception e) {
 			logger.error("Failed to load the shaderpack \"{}\"!", name);
 			logger.error("", e);
+			handleException(e);
 
 			return false;
 		}
@@ -323,6 +324,19 @@ public class Iris {
 		logger.info("Using shaderpack: " + name);
 
 		return true;
+	}
+
+	private static void handleException(Exception e) {
+		if (lastDimension != null && irisConfig.areDebugOptionsEnabled()) {
+			Minecraft.getInstance().setScreen(new DebugLoadFailedGridScreen(Minecraft.getInstance().screen, Component.literal(e instanceof ShaderCompileException ? "Failed to compile shaders" : "Exception"), e));
+		} else {
+			if (Minecraft.getInstance().player != null) {
+				Minecraft.getInstance().player.displayClientMessage(Component.translatable(e instanceof ShaderCompileException ? "iris.load.failure.shader" : "iris.load.failure.generic").append(Component.literal("Copy Info").withStyle(arg -> arg.withUnderlined(true).withColor(
+					ChatFormatting.BLUE).withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, e.getMessage())))), false);
+			} else {
+				storedError = Optional.of(e);
+			}
+		}
 	}
 
 	private static Optional<Path> loadExternalZipShaderpack(Path shaderpackPath) throws IOException {
@@ -577,15 +591,7 @@ public class Iris {
 		try {
 			return new IrisRenderingPipeline(programs);
 		} catch (Exception e) {
-			if (irisConfig.areDebugOptionsEnabled()) {
-				Minecraft.getInstance().setScreen(new DebugLoadFailedGridScreen(Minecraft.getInstance().screen, Component.literal(e instanceof ShaderCompileException ? "Failed to compile shaders" : "Exception"), e));
-			} else {
-				if (Minecraft.getInstance().player != null) {
-					Minecraft.getInstance().player.displayClientMessage(Component.translatable(e instanceof ShaderCompileException ? "iris.load.failure.shader" : "iris.load.failure.generic").append(Component.literal("Copy Info").withStyle(arg -> arg.withUnderlined(true).withColor(ChatFormatting.BLUE).withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, e.getMessage())))), false);
-				} else {
-					storedError = Optional.of(e);
-				}
-			}
+			handleException(e);
 
 			ShaderStorageBufferHolder.forceDeleteBuffers();
 			logger.error("Failed to create shader rendering pipeline, disabling shaders!", e);

--- a/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
@@ -16,6 +16,7 @@ import net.irisshaders.iris.gui.FeatureMissingErrorScreen;
 import net.irisshaders.iris.gui.screen.ShaderPackScreen;
 import net.irisshaders.iris.helpers.StringPair;
 import net.irisshaders.iris.pathways.colorspace.ColorSpace;
+import net.irisshaders.iris.shaderpack.error.RusticError;
 import net.irisshaders.iris.shaderpack.include.AbsolutePackPath;
 import net.irisshaders.iris.shaderpack.include.IncludeGraph;
 import net.irisshaders.iris.shaderpack.include.IncludeProcessor;
@@ -151,11 +152,7 @@ public class ShaderPack {
 		IncludeGraph graph = new IncludeGraph(root, starts.build());
 
 		if (!graph.getFailures().isEmpty()) {
-			graph.getFailures().forEach((path, error) -> {
-				Iris.logger.error("{}", error.toString());
-			});
-
-			throw new IOException("Failed to resolve some #include directives, see previous messages for details");
+			throw new IOException(String.join("\n", graph.getFailures().values().stream().map(RusticError::toString).toArray(String[]::new)));
 		}
 
 		this.languageMap = new LanguageMap(root.resolve("lang"));

--- a/src/main/java/net/irisshaders/iris/shaderpack/include/FileIncludeException.java
+++ b/src/main/java/net/irisshaders/iris/shaderpack/include/FileIncludeException.java
@@ -1,0 +1,9 @@
+package net.irisshaders.iris.shaderpack.include;
+
+import java.nio.file.NoSuchFileException;
+
+public class FileIncludeException extends NoSuchFileException {
+	public FileIncludeException(String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
this adds a check that the include files are capitalized correctly when debug options are enabled.
it also will show file include errors, instead of only printing them to the log.

this is useful when developing on windows, which ignores file capitalizations, but when zipped they are not ignored.

the `lastDimension != null` check in `handleException` was added, because the include resolving runs before the minecraft font is initialized, so it would crash when trying to create the screen on bootup.

![grafik](https://github.com/user-attachments/assets/13b9124e-f4d6-4f89-83d2-e95cb60b1058)
