### PR TITLE
fix capitalization check for zipped shaders

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/Iris.java
+++ b/common/src/main/java/net/irisshaders/iris/Iris.java
@@ -254,6 +254,7 @@ public class Iris {
 		}
 
 		Path shaderPackPath;
+		boolean isZip = false;
 
 		if (!Files.isDirectory(shaderPackRoot) && shaderPackRoot.toString().endsWith(".zip")) {
 			Optional<Path> optionalPath;
@@ -281,6 +282,7 @@ public class Iris {
 				logger.error("Could not load the shaderpack \"{}\" because it appears to lack a \"shaders\" directory", name);
 				return false;
 			}
+			isZip = true;
 		} else {
 			if (!Files.exists(shaderPackRoot)) {
 				logger.error("Failed to load the shaderpack \"{}\" because it does not exist!", name);
@@ -309,7 +311,7 @@ public class Iris {
 		resetShaderPackOptions = false;
 
 		try {
-			currentPack = new ShaderPack(shaderPackPath, changedConfigs, StandardMacros.createStandardEnvironmentDefines());
+			currentPack = new ShaderPack(shaderPackPath, changedConfigs, StandardMacros.createStandardEnvironmentDefines(), isZip);
 
 			MutableOptionValues changedConfigsValues = currentPack.getShaderPackOptions().getOptionValues().mutableCopy();
 

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
@@ -87,8 +87,8 @@ public class ShaderPack {
 	private final List<String> dimensionIds;
 	private Map<NamespacedId, String> dimensionMap;
 
-	public ShaderPack(Path root, ImmutableList<StringPair> environmentDefines) throws IOException, IllegalStateException {
-		this(root, Collections.emptyMap(), environmentDefines);
+	public ShaderPack(Path root, ImmutableList<StringPair> environmentDefines, boolean isZip) throws IOException, IllegalStateException {
+		this(root, Collections.emptyMap(), environmentDefines, isZip);
 	}
 
 	/**
@@ -99,7 +99,7 @@ public class ShaderPack {
 	 *             have completed, and there is no need to hold on to the path for that reason.
 	 * @throws IOException if there are any IO errors during shader pack loading.
 	 */
-	public ShaderPack(Path root, Map<String, String> changedConfigs, ImmutableList<StringPair> environmentDefines) throws IOException, IllegalStateException {
+	public ShaderPack(Path root, Map<String, String> changedConfigs, ImmutableList<StringPair> environmentDefines, boolean isZip) throws IOException, IllegalStateException {
 		// A null path is not allowed.
 		Objects.requireNonNull(root);
 
@@ -149,7 +149,7 @@ public class ShaderPack {
 		}
 
 		// Read all files and included files recursively
-		IncludeGraph graph = new IncludeGraph(root, starts.build());
+		IncludeGraph graph = new IncludeGraph(root, starts.build(), isZip);
 
 		if (!graph.getFailures().isEmpty()) {
 			throw new IOException(String.join("\n", graph.getFailures().values().stream().map(RusticError::toString).toArray(String[]::new)));

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/include/IncludeGraph.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/include/IncludeGraph.java
@@ -64,7 +64,7 @@ public class IncludeGraph {
 		this.failures = failures;
 	}
 
-	public IncludeGraph(Path root, ImmutableList<AbsolutePackPath> startingPaths) {
+	public IncludeGraph(Path root, ImmutableList<AbsolutePackPath> startingPaths, boolean isZip) {
 		Map<AbsolutePackPath, AbsolutePackPath> cameFrom = new HashMap<>();
 		Map<AbsolutePackPath, Integer> lineNumberInclude = new HashMap<>();
 
@@ -81,9 +81,15 @@ public class IncludeGraph {
 
 			try {
 				Path p = next.resolved(root);
-				if (Iris.getIrisConfig().areDebugOptionsEnabled() && root.isAbsolute() && !p.toAbsolutePath().toString().equals(p.toFile().getCanonicalPath())) {
-					throw new FileIncludeException("'" + next.getPathString() + "' doesn't exist, did you mean '" +
-						root.relativize(p.toFile().getCanonicalFile().toPath()).toString().replace("\\", "/") + "'?");
+				if (Iris.getIrisConfig().areDebugOptionsEnabled() && !isZip) {
+					String absolute = p.toAbsolutePath().toString().replace("\\", "/");
+					absolute = absolute.substring(absolute.lastIndexOf("shaders/") + 8);
+
+					String canonical = p.toFile().getCanonicalPath().replace("\\", "/");
+					canonical = canonical.substring(canonical.lastIndexOf("shaders/") + 8);
+					if (!absolute.equals(canonical)) {
+						throw new FileIncludeException("'" + next.getPathString() + "' doesn't exist, did you mean '" + canonical + "'?");
+					}
 				}
 				source = readFile(p);
 			} catch (IOException e) {


### PR DESCRIPTION
adds a `isZip` parameter to ShaderPack and `IncludeGraph` to skip the file capitalization check, since it cause an exception for zips