### PR TITLE
Cursor Based Tooltip Positioning

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
@@ -176,8 +176,10 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 			if (this.isDisplayingComment()) {
 				// Determine panel height and position
 				int panelHeight = Math.max(50, 18 + (this.hoveredElementCommentBody.size() * 10));
-				int x = (int) (0.5 * this.width) - 157;
-				int y = this.height - (panelHeight + 4);
+				int x = mouseX + 5;
+				if (x + 314 >= (this.width - 4)) x = this.width - (318);
+				int y = mouseY + 8;
+				if (y + panelHeight >= (this.height - 4)) y = this.height - (panelHeight + 4);
 				// Draw panel
 				GuiUtil.drawPanel(guiGraphics, x, y, COMMENT_PANEL_WIDTH, panelHeight);
 				// Draw text


### PR DESCRIPTION
This adjusts the tooltips in the shader settings screen to follow the mouse cursor(with a bound for the screen limits) as opposed to always rendering them at the bottom middle of the screen.