### PR TITLE
Use Item Model instead of raw Item ids for uniform lookup.

### DIFF
--- a/common/src/api/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
@@ -11,7 +11,6 @@ public interface IrisItemLightProvider {
 
 	default int getLightEmission(Player player, ItemStack stack) {
 		if (stack.getItem() instanceof BlockItem item) {
-
 			return item.getBlock().defaultBlockState().getLightEmission();
 		}
 

--- a/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/ItemStackStateLayerMixin.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/ItemStackStateLayerMixin.java
@@ -34,7 +34,7 @@ public class ItemStackStateLayerMixin {
 	@Inject(method = "render", at = @At("HEAD"))
 	private void onRender(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, int j, CallbackInfo ci, @Share("lastBState") LocalIntRef ref) {
 		ref.set(CapturedRenderingState.INSTANCE.getCurrentRenderedBlockEntity());
-		iris$setupId(((ItemContextState) parentState).getDisplayItem());
+		iris$setupId(((ItemContextState) parentState).getDisplayItem(), ((ItemContextState) parentState).getDisplayItemModel());
 	}
 
 	@Inject(method = "render", at = @At("TAIL"))
@@ -44,7 +44,7 @@ public class ItemStackStateLayerMixin {
 	}
 
 	@Unique
-	private void iris$setupId(Item item) {
+	private void iris$setupId(Item item, ResourceLocation modelId) {
 		if (WorldRenderingSettings.INSTANCE.getItemIds() == null) return;
 
 		if (item instanceof BlockItem blockItem && !(item instanceof SolidBucketItem)) {
@@ -55,7 +55,7 @@ public class ItemStackStateLayerMixin {
 			//System.out.println(WorldRenderingSettings.INSTANCE.getBlockStateIds().getInt(blockItem.getBlock().defaultBlockState()));
 			CapturedRenderingState.INSTANCE.setCurrentRenderedItem(WorldRenderingSettings.INSTANCE.getBlockStateIds().getOrDefault(blockItem.getBlock().defaultBlockState(), 0));
 		} else {
-			ResourceLocation location = BuiltInRegistries.ITEM.getKey(item);
+			ResourceLocation location = modelId != null ? modelId : BuiltInRegistries.ITEM.getKey(item);
 
 			CapturedRenderingState.INSTANCE.setCurrentRenderedItem(WorldRenderingSettings.INSTANCE.getItemIds().applyAsInt(new NamespacedId(location.getNamespace(), location.getPath())));
 		}

--- a/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/ItemStackStateMixin.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/ItemStackStateMixin.java
@@ -2,8 +2,8 @@ package net.irisshaders.iris.mixin.entity_render_context;
 
 import net.irisshaders.iris.mixinterface.ItemContextState;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,19 +14,26 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ItemStackStateMixin implements ItemContextState {
 	@Unique
 	private Item iris_displayStack;
+	@Unique
+	private ResourceLocation iris_displayModelId;
 
 	@Override
-	public void setDisplayItem(Item itemStack) {
+	public void setDisplayItem(Item itemStack, ResourceLocation modelId) {
 		this.iris_displayStack = itemStack;
+		this.iris_displayModelId = modelId;
 	}
 
 	@Override
 	public Item getDisplayItem() {
 		return iris_displayStack;
 	}
+	public ResourceLocation getDisplayItemModel() {
+		return iris_displayModelId;
+	}
 
 	@Inject(method = "clear", at = @At("HEAD"))
 	private void clearDisplayStack(CallbackInfo ci) {
 		this.iris_displayStack = null;
+		this.iris_displayModelId = null;
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinEquipmentLayerRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinEquipmentLayerRenderer.java
@@ -36,7 +36,10 @@ public abstract class MixinEquipmentLayerRenderer {
 	private void changeId(CallbackInfo ci, @Local(argsOnly = true) ItemStack itemStack) {
 		if (WorldRenderingSettings.INSTANCE.getItemIds() == null) return;
 
-		ResourceLocation location = BuiltInRegistries.ITEM.getKey(itemStack.getItem());
+		ResourceLocation location = itemStack.get(DataComponents.ITEM_MODEL);
+		if (location == null)
+			location = BuiltInRegistries.ITEM.getKey(itemStack.getItem());
+
 
 		CapturedRenderingState.INSTANCE.setCurrentRenderedItem(WorldRenderingSettings.INSTANCE.getItemIds().applyAsInt(new NamespacedId(location.getNamespace(), location.getPath())));
 	}

--- a/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinHorseArmorLayer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinHorseArmorLayer.java
@@ -7,9 +7,9 @@ import net.irisshaders.iris.uniforms.CapturedRenderingState;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.HorseArmorLayer;
 import net.minecraft.client.renderer.entity.state.HorseRenderState;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.item.AnimalArmorItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,7 +23,10 @@ public class MixinHorseArmorLayer {
 		if (WorldRenderingSettings.INSTANCE.getItemIds() == null || !(horseRenderState.bodyArmorItem.getItem() instanceof AnimalArmorItem))
 			return;
 
-		ResourceLocation location = BuiltInRegistries.ITEM.getKey((horseRenderState.bodyArmorItem.getItem()));
+		ResourceLocation location = horseRenderState.bodyArmorItem.get(DataComponents.ITEM_MODEL);
+		if (location == null)
+			location = BuiltInRegistries.ITEM.getKey((horseRenderState.bodyArmorItem.getItem()));
+
 		CapturedRenderingState.INSTANCE.setCurrentRenderedItem(WorldRenderingSettings.INSTANCE.getItemIds().applyAsInt(new NamespacedId(location.getNamespace(), location.getPath())));
 	}
 

--- a/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinItemRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinItemRenderer.java
@@ -3,6 +3,7 @@ package net.irisshaders.iris.mixin.entity_render_context;
 import net.irisshaders.iris.mixinterface.ItemContextState;
 import net.minecraft.client.renderer.item.ItemModelResolver;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
@@ -20,6 +21,10 @@ public abstract class MixinItemRenderer {
 
 	@Inject(method = "appendItemLayers", at = @At(value = "HEAD"))
 	private void changeId(ItemStackRenderState itemStackRenderState, ItemStack itemStack, ItemDisplayContext itemDisplayContext, Level level, LivingEntity livingEntity, int i, CallbackInfo ci) {
-		((ItemContextState) itemStackRenderState).setDisplayItem(itemStack != null ? itemStack.getItem() : null);
+		if (itemStack != null) {
+			((ItemContextState) itemStackRenderState).setDisplayItem(itemStack.getItem(), itemStack.get(DataComponents.ITEM_MODEL));
+		} else {
+			((ItemContextState) itemStackRenderState).setDisplayItem(null, null);
+		}
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/mixinterface/ItemContextState.java
+++ b/common/src/main/java/net/irisshaders/iris/mixinterface/ItemContextState.java
@@ -1,10 +1,12 @@
 package net.irisshaders.iris.mixinterface;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 public interface ItemContextState {
-	void setDisplayItem(Item itemStack);
+	void setDisplayItem(Item itemStack, ResourceLocation location);
 
 	Item getDisplayItem();
+	ResourceLocation getDisplayItemModel();
 }

--- a/common/src/main/java/net/irisshaders/iris/uniforms/IdMapUniforms.java
+++ b/common/src/main/java/net/irisshaders/iris/uniforms/IdMapUniforms.java
@@ -8,6 +8,7 @@ import net.irisshaders.iris.shaderpack.IdMap;
 import net.irisshaders.iris.shaderpack.materialmap.NamespacedId;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
@@ -85,7 +86,10 @@ public final class IdMapUniforms {
 				return;
 			}
 
-			ResourceLocation heldItemId = BuiltInRegistries.ITEM.getKey(heldItem);
+			ResourceLocation heldItemId = heldStack.get(DataComponents.ITEM_MODEL);
+			if (heldItemId == null) {
+				heldItemId = BuiltInRegistries.ITEM.getKey(heldItem);
+			}
 			intID = itemIdMap.applyAsInt(new NamespacedId(heldItemId.getNamespace(), heldItemId.getPath()));
 
 			IrisItemLightProvider lightProvider = (IrisItemLightProvider) heldItem;


### PR DESCRIPTION
Just like title. This change shouldn't change anything if modded (and vanilla items) didn't override item_model component (aka it matches registry id, which is currently the default).

If player gets an item with custom item_model, the uniform will depend purely on that. It should solve issues with some unintended effects caused by servers using base items that get some shader related effects.

This change doesn't apply to Block Items as to not change the logic, through in my opinion it should, as some blocks use different block and item models, which might make them look wrong.