### PR TITLE
Optimizes and Fix for DH fog toggle when shaders are disabled.

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/compat/dh/LodRendererEvents.java
+++ b/common/src/main/java/net/irisshaders/iris/compat/dh/LodRendererEvents.java
@@ -37,6 +37,7 @@ import org.lwjgl.opengl.GL46C;
 public class LodRendererEvents {
 	private static boolean eventHandlersBound = false;
 
+	private static boolean previousFramePackInUse;
 	private static boolean atTranslucent = false;
 	private static int textureWidth;
 	private static int textureHeight;
@@ -85,9 +86,19 @@ public class LodRendererEvents {
 			// canceling it will prevent DH from rendering for that frame
 			@Override
 			public void beforeRender(DhApiCancelableEventParam<DhApiRenderParam> event) {
+				// Check if the Shader Pack enabled status has changed between frames.
+				boolean isPackInUse = Iris.isPackInUseQuick();
 
-				DhApi.Delayed.renderProxy.setDeferTransparentRendering(Iris.isPackInUseQuick() && getInstance().shouldOverride);
-				DhApi.Delayed.configs.graphics().fog().drawMode().setValue(getInstance().shouldOverride ? EDhApiFogDrawMode.FOG_DISABLED : EDhApiFogDrawMode.FOG_ENABLED);
+				if (isPackInUse != previousFramePackInUse) {
+					// Shader Pack enabled status has changed between frames; adapt the DH fog settings.
+					DhApi.Delayed.renderProxy.setDeferTransparentRendering(isPackInUse && getInstance().shouldOverride);
+					if (isPackInUse) {
+						DhApi.Delayed.configs.graphics().fog().drawMode().setValue(getInstance().shouldOverride ? EDhApiFogDrawMode.FOG_DISABLED : EDhApiFogDrawMode.FOG_ENABLED);
+					} else {
+						DhApi.Delayed.configs.graphics().fog().drawMode().clearValue();
+					}
+					previousFramePackInUse = isPackInUse;
+				}
 			}
 		};
 


### PR DESCRIPTION
Makes DH fog settings only update if shader packs enabled/disabled state has changed since the prior frame and the DH Fog Enabled setting can be changed when no shader packs are enabled.

Note: Works with DH 2.2.1 without issues but bugged for the upcoming DH 2.3.0 due to a bug with DH 2.3.0s' API with ClearValue(...)