### PR TITLE
Update Gradle wrapper and Fabric Loom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
-
 plugins {
     id("java")
-    id("fabric-loom") version("1.7.3") apply(false)
+    id("fabric-loom") apply(false)
 }
 
 val MINECRAFT_VERSION by extra { "1.21.1" }
@@ -24,19 +23,12 @@ allprojects {
     apply(plugin = "maven-publish")
 }
 
-tasks.withType<JavaCompile> {
-    options.encoding = "UTF-8"
-}
-
 tasks.jar {
     enabled = false
 }
 
 subprojects {
     apply(plugin = "maven-publish")
-
-    java.toolchain.languageVersion = JavaLanguageVersion.of(21)
-
 
     fun createVersionString(): String {
         val builder = StringBuilder()

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("idea")
-    id("fabric-loom") version "1.7.3"
+    id("fabric-loom")
     id("com.github.gmazzo.buildconfig") version "5.3.5"
 }
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("idea")
-    id("fabric-loom") version ("1.7.3")
+    id("fabric-loom")
 }
 
 val MINECRAFT_VERSION: String by rootProject.extra

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs = -Xmx4G
 org.gradle.caching=true
 org.gradle.parallel=true
+
+# Gradle plugins
+fabric_loom_version=1.9.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -125,5 +125,3 @@ dependencies {
     includeAdditional("io.github.douira:glsl-transformer:2.0.1")
     includeAdditional("org.anarres:jcpp:1.4.14")
 }
-
-java.toolchain.languageVersion = JavaLanguageVersion.of(21)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,11 @@ pluginManagement {
         maven { url = uri("https://maven.neoforged.net/releases/") }
         gradlePluginPortal()
     }
+
+    val fabric_loom_version: String by settings
+    plugins {
+        id("fabric-loom") version(fabric_loom_version) apply(false)
+    }
 }
 
 include("common", "fabric", "neoforge")


### PR DESCRIPTION
- Updated Gradle wrapper to `v8.11.1`
- Updated Fabric Loom to `v1.9.2`

Also moved the Fabric Loom version declaration into `gradle.properties`, using `settings.gradle`.
I also removed `java.toolchain.languageVersion = JavaLanguageVersion.of(21)`, that should be redundant with:
```java
    tasks.withType<JavaCompile> {
        options.encoding = "UTF-8"
        options.release.set(21)
    }
```
which is already present in the `subprojects` block of `build.gradle.kts`.