### PR TITLE
DH shadow viewport fix

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/compat/dh/LodRendererEvents.java
+++ b/common/src/main/java/net/irisshaders/iris/compat/dh/LodRendererEvents.java
@@ -1,5 +1,7 @@
 package net.irisshaders.iris.compat.dh;
 
+import com.mojang.blaze3d.opengl.GlStateManager;
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.seibel.distanthorizons.api.DhApi;
 import com.seibel.distanthorizons.api.enums.rendering.EDhApiFogDrawMode;
 import com.seibel.distanthorizons.api.enums.rendering.EDhApiRenderPass;
@@ -29,6 +31,7 @@ import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.shadows.ShadowRenderer;
 import net.irisshaders.iris.shadows.ShadowRenderingState;
 import net.irisshaders.iris.uniforms.CapturedRenderingState;
+import net.minecraft.client.Minecraft;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.lwjgl.opengl.GL43C;
@@ -179,6 +182,8 @@ public class LodRendererEvents {
 				if (getInstance().shouldOverride) {
 					if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
 						getInstance().getShadowShader().unbind();
+						RenderTarget mainRenderTarget = Minecraft.getInstance().getMainRenderTarget();
+						GlStateManager._viewport(0, 0, mainRenderTarget.width, mainRenderTarget.height);
 					} else {
 						getInstance().getSolidShader().unbind();
 					}
@@ -254,6 +259,12 @@ public class LodRendererEvents {
 						OverrideInjector.INSTANCE.bind(IDhApiFramebuffer.class, instance.getSolidFBWrapper());
 					}
 				}
+
+				// DH changes viewport using raw LWJGL calls
+				// https://gitlab.com/distant-horizons-team/distant-horizons-core/-/blob/main/core/src/main/java/com/seibel/distanthorizons/core/render/renderer/LodRenderer.java#L577
+				// We need to resynchronize with Iris's framebuffer binding optimization in MixinGlStateManager_FramebufferBinding
+				RenderTarget mainRenderTarget = Minecraft.getInstance().getMainRenderTarget();
+				GlStateManager._viewport(0, 0, mainRenderTarget.width, mainRenderTarget.height);
 			}
 		};
 		DhApi.events.bind(DhApiBeforeRenderSetupEvent.class, beforeRenderPassEvent);
@@ -285,6 +296,7 @@ public class LodRendererEvents {
 					if (instance.shouldOverride) {
 						if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
 							instance.getShadowShader().bind();
+							Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::setupShadowViewport);
 						} else {
 							instance.getSolidShader().bind();
 						}
@@ -329,6 +341,7 @@ public class LodRendererEvents {
 					if (instance.shouldOverrideShadow && ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
 						instance.getShadowShader().bind();
 						instance.getShadowFB().bind();
+						Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::setupShadowViewport);
 						atTranslucent = true;
 
 						return;

--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisRenderingPipeline.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisRenderingPipeline.java
@@ -1026,6 +1026,13 @@ public class IrisRenderingPipeline implements WorldRenderingPipeline, ShaderRend
 	}
 
 	@Override
+	public void setupShadowViewport() {
+		if (shadowRenderer != null) {
+			this.shadowRenderer.setupShadowViewport();
+		}
+	}
+
+	@Override
 	public void addDebugText(List<String> messages) {
 		if (this.shadowRenderer != null) {
 			messages.add("");

--- a/common/src/main/java/net/irisshaders/iris/pipeline/VanillaRenderingPipeline.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/VanillaRenderingPipeline.java
@@ -45,6 +45,11 @@ public class VanillaRenderingPipeline implements WorldRenderingPipeline {
 	}
 
 	@Override
+	public void setupShadowViewport() {
+		// stub: nothing to do here
+	}
+
+	@Override
 	public void addDebugText(List<String> messages) {
 		// stub: nothing to do here
 	}

--- a/common/src/main/java/net/irisshaders/iris/pipeline/WorldRenderingPipeline.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/WorldRenderingPipeline.java
@@ -21,6 +21,8 @@ public interface WorldRenderingPipeline {
 
 	void renderShadows(LevelRendererAccessor worldRenderer, Camera camera);
 
+	void setupShadowViewport();
+
 	void addDebugText(List<String> messages);
 
 	OptionalInt getForcedShadowRenderDistanceChunksForDisplay();


### PR DESCRIPTION
Fixed #2707

This still won't fix DH shadow on Fabric because DH uses `WorldRenderEvents.AFTER_SETUP` instead of hooking to `renderSectionLayer`. But now, DH shadow should at least work on neoforge.

![7e928a0a6521c4d52a85075d8444e0e1](https://github.com/user-attachments/assets/7a007b5d-20f5-42bf-a7ff-c3e29edefd61)
