### PR TITLE
1.21.4: Bump mod version back to 1.8.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ val SODIUM_DEPENDENCY_NEO by extra { "maven.modrinth:sodium:GUEd3mz0"}
 val PARCHMENT_VERSION by extra { null }
 
 // https://semver.org/
-val MOD_VERSION by extra { "1.8.7" }
+val MOD_VERSION by extra { "1.8.8" }
 
 allprojects {
     apply(plugin = "java")


### PR DESCRIPTION
Bytecode examination of `iris-fabric-1.8.8+mc1.21.4.jar` and `iris-neoforge-1.8.8+mc1.21.4.jar` from Modrinth suggests that the 1.21.4 branch indeed contains the source code for version 1.8.8, but it would be nice to get confirmation.