### PR TITLE
Fixed normal and tangent vectors encoding

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
@@ -138,7 +138,7 @@ public class SodiumTransformer {
 			"const uint MATERIAL_USE_MIP_OFFSET = 0u;",
 			"""
 vec3 oct_to_vec3(vec2 e) {
-	vec2 f = vec2(e.x * 2.0f - 1.0f, e.y * 2.0f - 1.0f);
+	vec2 f = vec2(e.x, e.y);
 	vec3 n = vec3(f.x, f.y, 1.0f - abs(f.x) - abs(f.y));
 	float t = clamp(-n.z, 0.0f, 1.0f);
 	n.x += n.x >= 0.0f ? -t : t;
@@ -149,9 +149,9 @@ vec3 oct_to_vec3(vec2 e) {
 			"""
 vec4 tangent_decode(vec2 e) {
 	vec2 oct_compressed = e;
-	oct_compressed.y = oct_compressed.y * 2 - 1;
-	float r_sign = oct_compressed.y >= 0.0f ? 1.0f : -1.0f;
-	oct_compressed.y = abs(oct_compressed.y);
+	oct_compressed.y *= 127.0f / 64.0f;
+	float r_sign = abs(oct_compressed.y) >= 1.0f ? -1.0f : 1.0f;
+	oct_compressed.y = fract(oct_compressed.y) * (64.0f / 63.0f);
 	vec3 res = oct_to_vec3(oct_compressed.xy);
 	return vec4(res, r_sign);
 }

--- a/common/src/main/java/net/irisshaders/iris/vertices/NormalHelper.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/NormalHelper.java
@@ -61,32 +61,27 @@ public abstract class NormalHelper {
 			oY = (1.0f - absNX) * (nY >= 0.0f ? 1.0f : -1.0f);
 		}
 
-		oX = oX * 0.5f + 0.5f;
-		oY = oY * 0.5f + 0.5f;
-
 		output.set(oX, oY);
 	}
 
-	private static final float BIAS = 1.0f / 32767.0f;
-
 	public static void tangentEncode(Vector2f output, Vector4f tangent) {
 		octahedronEncode(output, tangent.x, tangent.y, tangent.z);
-		output.y = Math.max(output.y, BIAS);
-		output.y = output.y * 0.5f + 0.5f;
-		output.y = tangent.w >= 0.0f ? output.y : 1 - output.y;
+		float y_sign = output.y >= 0.0f ? 64.0f / 127.0f : -64.0f / 127.0f;
+		output.y *= 63.0f / 127.0f;
+		output.y = tangent.w >= 0.0f ? output.y : output.y + y_sign;
 	}
 
 	static Vector4f octahedron_tangent_decode(Vector2f p_oct) {
 		Vector2f oct_compressed = new Vector2f(p_oct);
-		oct_compressed.y = oct_compressed.y * 2 - 1;
-		float r_sign = oct_compressed.y >= 0.0f ? 1.0f : -1.0f;
-		oct_compressed.y = Math.abs(oct_compressed.y);
+		oct_compressed.y = oct_compressed.y * 127.0f / 64.0f;
+		float r_sign = Math.abs(oct_compressed.y) >= 1.0f ? -1.0f : 1.0f;
+		oct_compressed.y = oct_compressed.y % 1.0f;
 		Vector3f res = octahedron_decode(oct_compressed.x, oct_compressed.y);
 		return new Vector4f(res.x, res.y, res.z, r_sign);
 	}
 
 	private static Vector3f octahedron_decode(float inX, float inY) {
-		Vector2f f = new Vector2f(inX * 2.0f - 1.0f, inY * 2.0f - 1.0f);
+		Vector2f f = new Vector2f(inX, inY);
 		Vector3f n = new Vector3f(f.x, f.y, 1.0f - Math.abs(f.x) - Math.abs(f.y));
 		float t = Mth.clamp(-n.z, 0.0f, 1.0f);
 		n.x += n.x >= 0 ? -t : t;


### PR DESCRIPTION
This change adresses following issues:
https://github.com/IrisShaders/Iris/issues/2798
https://github.com/IrisShaders/Iris/issues/2709
https://github.com/IrisShaders/Iris/issues/2554

This change 
Removes incorrect edge case of handedness encoding.
Doubles precision of normal and tangent attributes.
Adds explicit zero and one values, allowing stored vectors to be aligned with world grid.