### PR TITLE
Use appropriate shader for custom dimension types with nether or end effects

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/Iris.java
+++ b/common/src/main/java/net/irisshaders/iris/Iris.java
@@ -45,6 +45,8 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.opengl.ARBParallelShaderCompile;
@@ -611,6 +613,21 @@ public class Iris {
 		ClientLevel level = Minecraft.getInstance().level;
 
 		if (level != null) {
+			// Check if the dimension type of the current level has custom effects set (end sky or nether).
+			// This is minecraft:overworld by default, but can also be minecraft:the_nether or minecraft:the_end.
+			// The appropriate shader for the dimension should be used by default in order to prevent buggy results.
+			// More information at https://minecraft.wiki/w/Dimension_type
+			// https://github.com/IrisShaders/Iris/issues/2200
+			ResourceLocation effects = level.dimensionType().effectsLocation();
+
+			if (Level.END.location().equals(effects)) {
+				return DimensionId.END;
+			}
+
+			if (Level.NETHER.location().equals(effects)) {
+				return DimensionId.NETHER;
+			}
+
 			return new NamespacedId(level.dimension().location().getNamespace(), level.dimension().location().getPath());
 		} else {
 			// This prevents us from reloading the shaderpack unless we need to. Otherwise, if the player is in the

--- a/common/src/main/java/net/irisshaders/iris/Iris.java
+++ b/common/src/main/java/net/irisshaders/iris/Iris.java
@@ -613,6 +613,15 @@ public class Iris {
 		ClientLevel level = Minecraft.getInstance().level;
 
 		if (level != null) {
+			NamespacedId dimensionId = new NamespacedId(level.dimension().location().getNamespace(), level.dimension().location().getPath());
+
+			ShaderPack pack = getCurrentPack().orElse(null);
+
+			// If there is an exact match in dimension.properties, don't override using dimension type effects
+			if (pack != null && pack.getDimensionMap().containsKey(dimensionId)) {
+				return dimensionId;
+			}
+
 			// Check if the dimension type of the current level has custom effects set (end sky or nether).
 			// This is minecraft:overworld by default, but can also be minecraft:the_nether or minecraft:the_end.
 			// The appropriate shader for the dimension should be used by default in order to prevent buggy results.
@@ -628,7 +637,7 @@ public class Iris {
 				return DimensionId.NETHER;
 			}
 
-			return new NamespacedId(level.dimension().location().getNamespace(), level.dimension().location().getPath());
+			return dimensionId;
 		} else {
 			// This prevents us from reloading the shaderpack unless we need to. Otherwise, if the player is in the
 			// nether and quits the game, we might end up reloading the shaders on exit and on entry to the level

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/ShaderPack.java
@@ -624,4 +624,8 @@ public class ShaderPack {
 	public Int2ObjectArrayMap<BuiltShaderStorageInfo> getBufferObjects() {
 		return bufferObjects;
 	}
+
+	public Map<NamespacedId, String> getDimensionMap() {
+		return dimensionMap;
+	}
 }


### PR DESCRIPTION
Closes #2200 

If you enable an Iris shader in a dimension with a custom dimension type using the nether or end effects, you get a buggy result:
![buggy_result](https://github.com/user-attachments/assets/7c4cb5c4-c5f5-4dd1-a6aa-c1436dfb60e1)
The overworld shader is used but the dimension effects are also rendered at the same time, in this case the end sky.
As described in https://github.com/IrisShaders/Iris/issues/2200, this was broken by [this commit](https://github.com/IrisShaders/Iris/commit/26a323686958bebec59bbcd128defa2717f64759#diff-81965af5d12f85cd5aeac5544a827d132d205e26d38e098b3c16013b8a2ef610L640-L646) and was working fine in Iris 1.6.4 and before.

This is how it looks in vanilla (just an empty custom dimension with the end sky):
![no_shader](https://github.com/user-attachments/assets/cae3fc84-f365-410f-91b0-21bf8a837fd7)

This PR reimplements the check for the dimension type effects in `Iris::getCurrentDimension`.
If the end effect is active, use the end dimension shader by assuming we are in the end dimension.
If the nether effect is active, assume we are in the nether dimension.

With the check the result looks as expected:
![fixed](https://github.com/user-attachments/assets/8303e0db-7234-4924-9ab1-bce6d0df062b)

Could  there be any problems with overriding the current dimension id this way?
IMO most of the time the nether / end effect is desired when having a custom dimension with that sky effect.

The fix can be tested by using this datapack, for example:
[iris_bug_demo.zip](https://github.com/user-attachments/files/22139156/iris_bug_demo.zip)

Just install it when creating a new world and teleport to the dimension with this command:
```
/execute in minecraft:iris_bug_demo run tp @p 0 100 0
```