### PR TITLE
Allow sampling of depthtex2 in gbuffers

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/samplers/IrisSamplers.java
+++ b/common/src/main/java/net/irisshaders/iris/samplers/IrisSamplers.java
@@ -204,8 +204,9 @@ public class IrisSamplers {
 
 	public static void addWorldDepthSamplers(SamplerHolder samplers, RenderTargets renderTargets) {
 		samplers.addDynamicSampler(renderTargets::getDepthTexture, "depthtex0");
-		// TODO: Should depthtex2 be made available to gbuffer / shadow programs?
 		samplers.addDynamicSampler(renderTargets.getDepthTextureNoTranslucents()::getTextureId, "depthtex1");
+		samplers.addDynamicSampler(renderTargets.getDepthTextureNoHand()::getTextureId,
+			"depthtex2");
 	}
 
 	public static void addCompositeSamplers(SamplerHolder samplers, RenderTargets renderTargets) {


### PR DESCRIPTION
When rendering the hand, the developer may wish to sample the depth behind the hand.