### PR TITLE
Fix custom dimension skybox (1.21.11 regression)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/Iris.java
+++ b/common/src/main/java/net/irisshaders/iris/Iris.java
@@ -46,7 +46,7 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.level.dimension.DimensionType;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.opengl.ARBParallelShaderCompile;
@@ -623,19 +623,19 @@ public class Iris {
 				return dimensionId;
 			}
 
-			// Check if the dimension type of the current level has custom effects set (end sky or nether).
-			// This is minecraft:overworld by default, but can also be minecraft:the_nether or minecraft:the_end.
+			// Check if the dimension type of the current level has a custom skybox set (end sky or overworld).
+			// This is OVERWORLD by default, but can also be END or NONE.
 			// The appropriate shader for the dimension should be used by default in order to prevent buggy results.
 			// More information at https://minecraft.wiki/w/Dimension_type
 			// https://github.com/IrisShaders/Iris/issues/2200
-			Identifier effects = level.dimension().identifier();
+			DimensionType.Skybox skybox = level.dimensionType().skybox();
 
-			if (Level.END.identifier().equals(effects)) {
+			if (skybox == DimensionType.Skybox.END) {
 				return DimensionId.END;
 			}
 
-			if (Level.NETHER.identifier().equals(effects)) {
-				return DimensionId.NETHER;
+			if (skybox == DimensionType.Skybox.OVERWORLD) {
+				return DimensionId.OVERWORLD;
 			}
 
 			return dimensionId;


### PR DESCRIPTION
The end shader is no longer used for custom dimensions with the end skybox.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8c6ca0e4-adf9-457a-9d10-eea141da8edc" />

This was caused because of a change in the 1.21.11 upgrade in commit 7f17ac47e027c72326678ae31549c9cc6de9493d in Iris::getCurrentDimension:

```diff
-			ResourceLocation effects = level.dimensionType().effectsLocation();
+			Identifier effects = level.dimension().identifier();
```
This broke the previous patch from PR #2853 

In 1.21.11, the `effectsLocation()` property is now called `skybox()` and now returns a Skybox enum constant. Possible values are: `NONE`, `OVERWORLD` and `END`

This PR updates the dimension overwrite for the `END` and `OVERWORLD` skyboxes. As there is no nether skybox option, the nether overwrite was removed.

Closes #2200 

Updated datapack for testing: [iris_bug_demo.zip](https://github.com/user-attachments/files/24318265/iris_bug_demo.zip)


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/123fa5ca-7662-409e-8d3b-a7e08fd1307c" />
