### PR TITLE
Change the hover time to take half as long for better UX

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
@@ -676,7 +676,7 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 	}
 
 	public boolean isDisplayingComment() {
-		return this.hoveredElementCommentTimer > 20 &&
+		return this.hoveredElementCommentTimer > 10 &&
 			this.hoveredElementCommentTitle.isPresent() &&
 			!this.hoveredElementCommentBody.isEmpty();
 	}


### PR DESCRIPTION
The current hover time for descriptions to appear is too long. Most users don't wait this long and then never see the description, which often contains the exact answer when they come asking questions in support channels. 