### PR TITLE
fix cloudTime uniform

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/CloudRendererAccessor.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/CloudRendererAccessor.java
@@ -1,0 +1,12 @@
+package net.irisshaders.iris.mixin;
+
+import net.minecraft.client.renderer.CloudRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(CloudRenderer.class)
+public interface CloudRendererAccessor {
+
+	@Accessor("texture")
+	CloudRenderer.TextureData getTexture();
+}

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
@@ -35,6 +35,7 @@ import net.minecraft.client.CloudStatus;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.CloudRenderer;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LevelTargetBundle;
@@ -85,14 +86,16 @@ public class MixinLevelRenderer {
 	private RenderBuffers renderBuffers;
 
 	@Shadow
-	private int ticks;
-
-	@Shadow
 	@Final
 	private LevelTargetBundle targets;
 	@Shadow
 	@Final
 	private LevelRenderState levelRenderState;
+	@Shadow
+	private @Nullable ClientLevel level;
+	@Shadow
+	@Final
+	private CloudRenderer cloudRenderer;
 	private boolean warned;
 
 	@Unique
@@ -127,7 +130,11 @@ public class MixinLevelRenderer {
 		CapturedRenderingState.INSTANCE.setGbufferProjection(projection);
 		float fakeTickDelta = deltaTracker.getGameTimeDeltaPartialTick(false);
 		CapturedRenderingState.INSTANCE.setTickDelta(fakeTickDelta);
-		CapturedRenderingState.INSTANCE.setCloudTime((ticks + fakeTickDelta) * 0.03F);
+		if (((CloudRendererAccessor) this.cloudRenderer).getTexture() != null) {
+			CapturedRenderingState.INSTANCE.setCloudTime((this.level.getGameTime() % (((CloudRendererAccessor) this.cloudRenderer).getTexture().width() * 400) + fakeTickDelta) * 0.03F);
+		} else {
+			CapturedRenderingState.INSTANCE.setCloudTime(0);
+		}
 
 		pipeline = Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
 

--- a/common/src/main/resources/mixins.iris.json
+++ b/common/src/main/resources/mixins.iris.json
@@ -6,6 +6,7 @@
   "plugin": "net.irisshaders.iris.mixin.IrisMixinPlugin",
   "compatibilityLevel": "JAVA_8",
   "client": [
+    "CloudRendererAccessor",
     "DimensionTypeAccessor",
     "EndFlashAccess",
     "GameRendererAccessor",


### PR DESCRIPTION
1.21.11 changed the cloud time to be based on the levels gameTime instead of overall game ticks.
this changes the `cloudTime` uniform to reflect that new change