### PR TITLE
fix: Null check EndFlashState

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/uniforms/CelestialUniforms.java
+++ b/common/src/main/java/net/irisshaders/iris/uniforms/CelestialUniforms.java
@@ -103,6 +103,8 @@ public final class CelestialUniforms {
 
 	private Vector4f getEndFlashPosition() {
 		EndFlashState state = Minecraft.getInstance().level.endFlashState();
+		if (state == null) return ZERO;
+
 		float h = state.getYAngle(); // yaw around Y
 		float g = state.getXAngle(); // this feels silly
 


### PR DESCRIPTION
This is currently causing a lot of crashes on Wynncraft as entering a queue for another world briefly puts you into the end dimension.

It's not the same as the original issue but you can see a few reports in https://github.com/IrisShaders/Iris/issues/3015

Obviously it's up to you but the Wynncraft community would appreciate if this fix could get a 1.21.11 release as that's the main version being used by Wynncraft mods for the foreseeable future and as mentioned it's causing a lot of crashes.

If you want to replicate, just join `lobby.wynncraft.com` and select a server in the compass menu that has a queue.