### PR TITLE
Fix #2980 (sunAngle and shadow matrices mismatch during sunset and sunrise)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/uniforms/CelestialUniforms.java
+++ b/common/src/main/java/net/irisshaders/iris/uniforms/CelestialUniforms.java
@@ -64,11 +64,9 @@ public final class CelestialUniforms {
 	}
 
 	public static boolean isDay() {
-		// Determine whether it is day or night based on the sky angle.
-		//
-		// World#isDay appears to do some nontrivial calculations that appear to not entirely work for us here.
-		int timeOfDay = Math.toIntExact((Minecraft.getInstance().level.getDayTime() % 24000));
-		return timeOfDay < 12751 || timeOfDay > 23219; // TODO
+		// Use same function as `sunAngle` uniform, no longer use hardcoded time values.
+		float sunAngle = CelestialUniforms.getSunAngle(true);
+		return sunAngle < 180;
 	}
 
 	private static ClientLevel getWorld() {


### PR DESCRIPTION
By using the same function to get `uniform float sunAngle;` to determine if it's day or night for shadow matrices, it will fix the mismatch between `sunAngle` and shadow matrices. And as it removes the hardcoded time value to determine day or night by using vanilla sun angle, it will fit future vanilla change automanticly if there is such change in future.

Fixes #2980 