### PR TITLE
Fix #2979 (Held map uses `gbuffers_entities` instead of `gbuffers_hand` on 1.21.11)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
@@ -141,7 +141,10 @@ public class IrisPipelines {
 	private static ShaderKey getText(Object p) {
 		IrisRenderingPipeline pipeline = (IrisRenderingPipeline) p;
 
-		if (isBlockEntities(pipeline)) {
+		if (HandRenderer.INSTANCE.isActive()) {
+			// In 1.21.11+, held map uses this.
+			return (ShaderKey.HAND_TEXT);
+		} else if (isBlockEntities(pipeline)) {
 			return (ShaderKey.TEXT_BE);
 		} else {
 			return (ShaderKey.TEXT);

--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
@@ -143,7 +143,7 @@ public class IrisPipelines {
 
 		if (HandRenderer.INSTANCE.isActive()) {
 			// In 1.21.11+, held map uses this.
-			return (ShaderKey.HAND_TEXT);
+			return (HandRenderer.INSTANCE.isRenderingSolid() ? ShaderKey.HAND_TEXT : ShaderKey.HAND_TEXT_TRANSLUCENT);
 		} else if (isBlockEntities(pipeline)) {
 			return (ShaderKey.TEXT_BE);
 		} else {

--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderKey.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderKey.java
@@ -47,6 +47,7 @@ public enum ShaderKey {
 	HAND_CUTOUT_BRIGHT(ProgramId.Hand, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.FULLBRIGHT),
 	HAND_CUTOUT_DIFFUSE(ProgramId.Hand, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.DIFFUSE_LM),
 	HAND_TEXT(ProgramId.Hand, AlphaTests.NON_ZERO_ALPHA, IrisVertexFormats.GLYPH, FogMode.PER_VERTEX, LightingModel.LIGHTMAP),
+	HAND_TEXT_TRANSLUCENT(ProgramId.HandWater, AlphaTests.NON_ZERO_ALPHA, IrisVertexFormats.GLYPH, FogMode.PER_VERTEX, LightingModel.LIGHTMAP),
 	HAND_TEXT_INTENSITY(ProgramId.Hand, AlphaTests.NON_ZERO_ALPHA, IrisVertexFormats.GLYPH, FogMode.PER_VERTEX, LightingModel.LIGHTMAP),
 	HAND_TRANSLUCENT(ProgramId.HandWater, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.LIGHTMAP),
 	HAND_WATER_BRIGHT(ProgramId.HandWater, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.FULLBRIGHT),


### PR DESCRIPTION
In 1.21.11+, vanilla uses `rendertype_text` on held map. Iris has the `HAND_TEXT` shader key, but never check hand instance for texts, might because it's never used before. By adding hand instance check for text types, held map should use `gbuffers_hand` correctly now.

Fixes #2979 