### PR TITLE
Fix #2952 (override buffer blend leads unexpected blend in later program)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gl/blending/BlendModeStorage.java
+++ b/common/src/main/java/net/irisshaders/iris/gl/blending/BlendModeStorage.java
@@ -55,9 +55,9 @@ public class BlendModeStorage {
 		} else {
 			IrisRenderSystem.enableBufferBlend(index);
 			IrisRenderSystem.blendFuncSeparatei(index, override.srcRgb(), override.dstRgb(), override.srcAlpha(), override.dstAlpha());
-			blendUnknown = true;
 		}
 
+		blendUnknown = true;
 		blendLocked = true;
 	}
 

--- a/common/src/main/java/net/irisshaders/iris/gl/blending/BlendModeStorage.java
+++ b/common/src/main/java/net/irisshaders/iris/gl/blending/BlendModeStorage.java
@@ -9,9 +9,14 @@ public class BlendModeStorage {
 	private static boolean originalBlendEnable;
 	private static BlendMode originalBlend;
 	private static boolean blendLocked;
+	private static boolean blendUnknown;
 
 	public static boolean isBlendLocked() {
 		return blendLocked;
+	}
+
+	public static boolean isBlendUnknown() {
+		return blendUnknown;
 	}
 
 	public static void overrideBlend(BlendMode override) {
@@ -30,6 +35,7 @@ public class BlendModeStorage {
 		} else {
 			GlStateManager._enableBlend();
 			GlStateManager._blendFuncSeparate(override.srcRgb(), override.dstRgb(), override.srcAlpha(), override.dstAlpha());
+			blendUnknown = false;
 		}
 
 		blendLocked = true;
@@ -49,6 +55,7 @@ public class BlendModeStorage {
 		} else {
 			IrisRenderSystem.enableBufferBlend(index);
 			IrisRenderSystem.blendFuncSeparatei(index, override.srcRgb(), override.dstRgb(), override.srcAlpha(), override.dstAlpha());
+			blendUnknown = true;
 		}
 
 		blendLocked = true;
@@ -63,7 +70,7 @@ public class BlendModeStorage {
 	}
 
 	public static void restoreBlend() {
-		if (!blendLocked) {
+		if (!blendLocked && !blendUnknown) {
 			return;
 		}
 
@@ -77,5 +84,6 @@ public class BlendModeStorage {
 
 		GlStateManager._blendFuncSeparate(originalBlend.srcRgb(), originalBlend.dstRgb(),
 			originalBlend.srcAlpha(), originalBlend.dstAlpha());
+		blendUnknown = false;
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinGlStateManager_BlendOverride.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinGlStateManager_BlendOverride.java
@@ -2,7 +2,9 @@ package net.irisshaders.iris.mixin;
 
 import com.mojang.blaze3d.opengl.GlStateManager;
 import net.irisshaders.iris.gl.blending.BlendModeStorage;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -25,10 +27,21 @@ public class MixinGlStateManager_BlendOverride {
 		}
 	}
 
+	@Shadow
+	@Final
+	private static GlStateManager.BlendState BLEND;
+
 	@Inject(method = "_blendFuncSeparate", at = @At("HEAD"), cancellable = true)
 	private static void iris$blendFuncSeparateLock(int srcRgb, int dstRgb, int srcAlpha, int dstAlpha, CallbackInfo ci) {
 		if (BlendModeStorage.isBlendLocked()) {
 			BlendModeStorage.deferBlendFunc(srcRgb, dstRgb, srcAlpha, dstAlpha);
+			ci.cancel();
+		} else if (BlendModeStorage.isBlendUnknown()) {
+			BLEND.srcRgb = srcRgb;
+			BLEND.dstRgb = dstRgb;
+			BLEND.srcAlpha = srcAlpha;
+			BLEND.dstAlpha = dstAlpha;
+			GlStateManager.glBlendFuncSeparate(srcRgb, dstRgb, srcAlpha, dstAlpha);
 			ci.cancel();
 		}
 	}


### PR DESCRIPTION
When Iris override buffer blend through `BlendModeStorage.overrideBufferBlend()`, it will not notify `GlStateManager` about the blend change. In later program, if there is no buffer blend, just global blend, Iris will just call `GlStateManager` for blend change, which leads to the buffer blend will not change to global blend when globle blend does not change in later programs.

This fix acts like the blend on/off fix in 2a652bc, consider blend state unknown when overriding buffer blend, and set unknown to false when overrding or restoring globle blend.

Fixes #2952 