### PR TITLE
Fixed TEXTURE_RECTANGLE

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gl/texture/TextureType.java
+++ b/common/src/main/java/net/irisshaders/iris/gl/texture/TextureType.java
@@ -1,16 +1,16 @@
 package net.irisshaders.iris.gl.texture;
 
 import net.irisshaders.iris.gl.IrisRenderSystem;
-import org.lwjgl.opengl.GL30C;
+import org.lwjgl.opengl.GL32C;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
 public enum TextureType {
-	TEXTURE_1D(GL30C.GL_TEXTURE_1D),
-	TEXTURE_2D(GL30C.GL_TEXTURE_2D),
-	TEXTURE_3D(GL30C.GL_TEXTURE_3D),
-	TEXTURE_RECTANGLE(GL30C.GL_TEXTURE_3D);
+	TEXTURE_1D(GL32C.GL_TEXTURE_1D),
+	TEXTURE_2D(GL32C.GL_TEXTURE_2D),
+	TEXTURE_3D(GL32C.GL_TEXTURE_3D),
+	TEXTURE_RECTANGLE(GL32C.GL_TEXTURE_RECTANGLE);
 
 	private final int glType;
 


### PR DESCRIPTION
It exists in document, so why not make it work, that's it.

Previously when binding raw TEXTURE_RECTANGLE to custom textures or colortexes, it will be nothing as it was acturally bind to TEXTURE_3D type