### PR TITLE
Fix transparent detection for block entities

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/layer/OuterWrappedRenderType.java
+++ b/common/src/main/java/net/irisshaders/iris/layer/OuterWrappedRenderType.java
@@ -38,6 +38,11 @@ public class OuterWrappedRenderType extends RenderType {
 	}
 
 	@Override
+	public boolean hasBlending() {
+		return wrapped.hasBlending();
+	}
+
+	@Override
 	public Optional<RenderType> outline() {
 		return this.wrapped.outline();
 	}


### PR DESCRIPTION
Vanilla uses `RenderType.hasBlending()` to determine if some object will be ordered as transparent or cutout for most objects in 26.1. Iris implemented `OuterWrappedRenderType` to add block entity check for entities, however, the `FAKE_SETUP` is hardcoded to be `GUI_TEXTURED`, which has blend, and leading to all block entities considered as transparent.

This pr overrides `hasBlending` for this class, using the `hasBlending` result from really used wrapped RenderType, to get correct transparent detection for block entities.