### PR TITLE
Fixed solid/transparent detection for hand

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinItemInHandRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinItemInHandRenderer.java
@@ -32,9 +32,7 @@ public abstract class MixinItemInHandRenderer implements ItemInHandInterface {
 	@Inject(method = "renderArmWithItem", at = @At("HEAD"), cancellable = true)
 	private void iris$skipTranslucentHands(AbstractClientPlayer abstractClientPlayer, float f, float g, InteractionHand interactionHand, float h, ItemStack itemStack, float i, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int j, CallbackInfo ci) {
 		if (Iris.isPackInUseQuick()) {
-			if (HandRenderer.INSTANCE.isRenderingSolid() && HandRenderer.INSTANCE.isHandTranslucent(interactionHand)) {
-				ci.cancel();
-			} else if (!HandRenderer.INSTANCE.isRenderingSolid() && !HandRenderer.INSTANCE.isHandTranslucent(interactionHand)) {
+			if (HandRenderer.INSTANCE.isRenderingSolid() == HandRenderer.INSTANCE.isHandTranslucent(itemStack)) {
 				ci.cancel();
 			}
 		}
@@ -62,5 +60,20 @@ public abstract class MixinItemInHandRenderer implements ItemInHandInterface {
 		} else {
 			customRenderer.endRender();
 		}
+	}
+
+	@Shadow
+	private ItemStack mainHandItem;
+	@Shadow
+	private ItemStack offHandItem;
+
+	@Override
+	public boolean iris$isAnyHandTranslucent () {
+		return HandRenderer.INSTANCE.isHandTranslucent(mainHandItem) || HandRenderer.INSTANCE.isHandTranslucent(offHandItem);
+	}
+
+	@Override
+	public boolean iris$isAnyHandSolid () {
+		return !(HandRenderer.INSTANCE.isHandTranslucent(mainHandItem) && HandRenderer.INSTANCE.isHandTranslucent(offHandItem));
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/mixinterface/ItemInHandInterface.java
+++ b/common/src/main/java/net/irisshaders/iris/mixinterface/ItemInHandInterface.java
@@ -10,4 +10,12 @@ public interface ItemInHandInterface {
 	default void iris$renderHandsWithCustomRenderer(HandRenderer handRenderer, float tickDelta, PoseStack poseStack, SubmitNodeStorage submitNodeCollector, @Nullable LocalPlayer player, int packedLightCoords) {
 		throw new AssertionError();
 	}
+
+ 	default boolean iris$isAnyHandTranslucent() {
+		throw new AssertionError();
+	}
+
+	default boolean iris$isAnyHandSolid() {
+		throw new AssertionError();
+	}
 }

--- a/common/src/main/java/net/irisshaders/iris/pathways/HandRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/pathways/HandRenderer.java
@@ -32,6 +32,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fStack;
@@ -81,8 +82,8 @@ public class HandRenderer {
 			|| Minecraft.getInstance().gameMode.getPlayerMode() == GameType.SPECTATOR);
 	}
 
-	public boolean isHandTranslucent(InteractionHand hand) {
-		Item item = Minecraft.getInstance().player.getItemBySlot(hand == InteractionHand.OFF_HAND ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND).getItem();
+	public boolean isHandTranslucent(ItemStack itemStack) {
+		Item item = itemStack.getItem();
 
 		if (item instanceof BlockItem) {
 			return Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(((BlockItem) item).getBlock().defaultBlockState()).hasMaterialFlag(BakedQuad.FLAG_TRANSLUCENT);
@@ -91,12 +92,8 @@ public class HandRenderer {
 		return false;
 	}
 
-	public boolean isAnyHandTranslucent() {
-		return isHandTranslucent(InteractionHand.MAIN_HAND) || isHandTranslucent(InteractionHand.OFF_HAND);
-	}
-
 	public void renderSolid(Matrix4fc modelMatrix, float tickDelta, Camera camera, CameraRenderState cameraState, GameRenderer gameRenderer, WorldRenderingPipeline pipeline) {
-		if (!canRender(camera, gameRenderer) || !Iris.isPackInUseQuick()) {
+		if (!canRender(camera, gameRenderer) || !gameRenderer.itemInHandRenderer.iris$isAnyHandSolid() || !Iris.isPackInUseQuick()) {
 			return;
 		}
 
@@ -134,7 +131,7 @@ public class HandRenderer {
 	}
 
 	public void renderTranslucent(Matrix4fc modelMatrix, float tickDelta, Camera camera, CameraRenderState cameraState, GameRenderer gameRenderer, WorldRenderingPipeline pipeline) {
-		if (!canRender(camera, gameRenderer) || !isAnyHandTranslucent() || !Iris.isPackInUseQuick()) {
+		if (!canRender(camera, gameRenderer) || !gameRenderer.itemInHandRenderer.iris$isAnyHandTranslucent() || !Iris.isPackInUseQuick()) {
 			submitNodeCollector.endFrame();
 			return;
 		}


### PR DESCRIPTION
Iris was calling Minecraft instance for items in player selected slots for held object, which means transparent/solid changes immediately, instead of waiting for animations of held item.

This pull request changes input directly to the `itemStack` provided in `renderArmWithItem()` function, which means it will match in vanilla animation now. `isAnyHandTranslucent()` and the new added `isAnyHandSolid()` is also moved from `HandRenderer.java` to `MixinItemInHandRenderer.java` to use vanilla held item stacks.