### PR TITLE
Fixed held brightness for lights

### DIFF
--- a/common/src/api/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
@@ -1,8 +1,11 @@
 package net.irisshaders.iris.api.v0.item;
 
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.BlockItemStateProperties;
+import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3f;
 
 public interface IrisItemLightProvider {
@@ -11,7 +14,12 @@ public interface IrisItemLightProvider {
 
 	default int getLightEmission(Player player, ItemStack stack) {
 		if (stack.getItem() instanceof BlockItem item) {
-			return item.getBlock().defaultBlockState().getLightEmission();
+			BlockState blockState = item.getBlock().defaultBlockState();
+			BlockItemStateProperties itemBlockState = stack.getComponents().get(DataComponents.BLOCK_STATE);
+			if (itemBlockState != null) {
+				blockState = itemBlockState.apply(blockState);
+			}
+			return blockState.getLightEmission();
 		}
 
 		return 0;


### PR DESCRIPTION
By applying block states stored in item stack componets, now lights can have correct `heldBlockLightValue`. Previously, as Iris just uses `defaultBlockState()` on them, lights with different light level will all have 15 held light level.