### PR TITLE
Fix #2487 (Light level comes with minimum 8 instead of 0)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/vertices/sodium/terrain/XHFPTerrainVertex.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/sodium/terrain/XHFPTerrainVertex.java
@@ -81,8 +81,8 @@ public class XHFPTerrainVertex implements ChunkVertexEncoder {
 	}
 
 	private static int encodeLight(int light) {
-		int sky = Mth.clamp(light >>> 16 & 255, 8, 248);
-		int block = Mth.clamp(light >>> 0 & 255, 8, 248);
+		int sky = light >>> 16 & 255;
+		int block = light >>> 0 & 255;
 		return block << 0 | sky << 8;
 	}
 


### PR DESCRIPTION
Fixed #2487 according to JellySquid3's suggestion in [Sodium#2761](https://github.com/CaffeineMC/sodium/issues/2761)