### PR TITLE
Make render layers in block.properties working in 26.1

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/compat/sodium/mixin/MixinAbstractBlockRenderContext.java
+++ b/common/src/main/java/net/irisshaders/iris/compat/sodium/mixin/MixinAbstractBlockRenderContext.java
@@ -1,7 +1,5 @@
 package net.irisshaders.iris.compat.sodium.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
 import net.caffeinemc.mods.sodium.client.render.model.AbstractBlockRenderContext;
@@ -15,10 +13,12 @@ import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.caffeinemc.mods.sodium.client.render.model.MutableQuadViewImpl;
 
@@ -46,35 +46,32 @@ public class MixinAbstractBlockRenderContext {
 		}
 	}
 
-	@WrapOperation(
+	@ModifyArg(
 		method = "bufferDefaultModel",
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/caffeinemc/mods/sodium/client/render/model/MutableQuadViewImpl;setRenderType(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayer;)Lnet/caffeinemc/mods/sodium/client/render/model/MutableQuadViewImpl;"
 		)
 	)
-	private MutableQuadViewImpl handleShaderPackTransparency(
-		MutableQuadViewImpl instance,
-		ChunkSectionLayer renderLayer,
-		Operation<MutableQuadViewImpl> original
+	private @Nullable ChunkSectionLayer handleShaderPackTransparency(
+		@Nullable ChunkSectionLayer renderLayer
 	) {
-		if ((Object)this instanceof BlockRenderer && WorldRenderingSettings.INSTANCE.getBlockTypeIds() != null) {
-			BlockState state = this.state;
-			if (state == null) {
-				return original.call(instance, renderLayer);
-			}
-			BlockRenderType blockRenderType = WorldRenderingSettings.INSTANCE.getBlockTypeIds().get(state.getBlock());
-			if (blockRenderType == null) {
-				return original.call(instance, renderLayer);
-			}
-			ChunkSectionLayer layer = switch (blockRenderType) {
-				case SOLID -> ChunkSectionLayer.SOLID;
-				case CUTOUT,CUTOUT_MIPPED -> ChunkSectionLayer.CUTOUT;
-				case TRANSLUCENT -> ChunkSectionLayer.TRANSLUCENT;
-			};
-			return original.call(instance, layer);
+		if (!((Object) this instanceof BlockRenderer) || WorldRenderingSettings.INSTANCE.getBlockTypeIds() == null) {
+			return renderLayer;
 		}
-		return original.call(instance, renderLayer);
+		BlockState state = this.state;
+		if (state == null) {
+			return renderLayer;
+		}
+		BlockRenderType blockRenderType = WorldRenderingSettings.INSTANCE.getBlockTypeIds().get(state.getBlock());
+		if (blockRenderType == null) {
+			return renderLayer;
+		}
+		return switch (blockRenderType) {
+			case SOLID -> ChunkSectionLayer.SOLID;
+			case CUTOUT, CUTOUT_MIPPED -> ChunkSectionLayer.CUTOUT;
+			case TRANSLUCENT -> ChunkSectionLayer.TRANSLUCENT;
+		};
 	}
 
 	@Inject(method = "bufferDefaultModel", at = @At(value = "TAIL"))

--- a/common/src/main/java/net/irisshaders/iris/compat/sodium/mixin/MixinAbstractBlockRenderContext.java
+++ b/common/src/main/java/net/irisshaders/iris/compat/sodium/mixin/MixinAbstractBlockRenderContext.java
@@ -1,19 +1,20 @@
 package net.irisshaders.iris.compat.sodium.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
 import net.caffeinemc.mods.sodium.client.render.model.AbstractBlockRenderContext;
 import net.irisshaders.iris.compat.general.IrisModSupport;
-import net.irisshaders.iris.platform.IrisPlatformHelpers;
+import net.irisshaders.iris.shaderpack.materialmap.BlockRenderType;
 import net.irisshaders.iris.shaderpack.materialmap.WorldRenderingSettings;
-import net.irisshaders.iris.vertices.BlockSensitiveBufferBuilder;
 import net.irisshaders.iris.vertices.sodium.terrain.VertexEncoderInterface;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockState;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -43,6 +44,37 @@ public class MixinAbstractBlockRenderContext {
 				((VertexEncoderInterface) r).overrideBlock(WorldRenderingSettings.INSTANCE.getBlockStateIds().getInt(override));
 			}
 		}
+	}
+
+	@WrapOperation(
+		method = "bufferDefaultModel",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/caffeinemc/mods/sodium/client/render/model/MutableQuadViewImpl;setRenderType(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayer;)Lnet/caffeinemc/mods/sodium/client/render/model/MutableQuadViewImpl;"
+		)
+	)
+	private MutableQuadViewImpl handleShaderPackTransparency(
+		MutableQuadViewImpl instance,
+		ChunkSectionLayer renderLayer,
+		Operation<MutableQuadViewImpl> original
+	) {
+		if ((Object)this instanceof BlockRenderer && WorldRenderingSettings.INSTANCE.getBlockTypeIds() != null) {
+			BlockState state = this.state;
+			if (state == null) {
+				return original.call(instance, renderLayer);
+			}
+			BlockRenderType blockRenderType = WorldRenderingSettings.INSTANCE.getBlockTypeIds().get(state.getBlock());
+			if (blockRenderType == null) {
+				return original.call(instance, renderLayer);
+			}
+			ChunkSectionLayer layer = switch (blockRenderType) {
+				case SOLID -> ChunkSectionLayer.SOLID;
+				case CUTOUT,CUTOUT_MIPPED -> ChunkSectionLayer.CUTOUT;
+				case TRANSLUCENT -> ChunkSectionLayer.TRANSLUCENT;
+			};
+			return original.call(instance, layer);
+		}
+		return original.call(instance, renderLayer);
 	}
 
 	@Inject(method = "bufferDefaultModel", at = @At(value = "TAIL"))


### PR DESCRIPTION
Grab a `BlockState` from `AbstractBlockRenderContext` to fetch an render layer override in `WorldRenderingSettings.INSTANCE.getBlockTypeIds()`.
Tested with Sundial Alpha Build 2026-03-27.

Before:
<img width="2560" height="1351" alt="image" src="https://github.com/user-attachments/assets/ffecaa41-f892-4973-bad7-42d6b07c10be" />
After:
<img width="2560" height="1351" alt="image" src="https://github.com/user-attachments/assets/bd34224e-0886-4232-a030-1084f2d69a74" />
