### PR TITLE
Fix #2870 (Shader pack screen is drawn twice and have unnecessary blur)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
@@ -163,12 +163,6 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 
 		if (!this.guiHidden) {
 			super.extractRenderState(guiGraphics, mouseX, mouseY, delta);
-
-			if (optionMenuOpen && this.shaderOptionList != null) {
-				this.shaderOptionList.extractRenderState(guiGraphics, mouseX, mouseY, delta);
-			} else {
-				this.shaderPackList.extractRenderState(guiGraphics, mouseX, mouseY, delta);
-			}
 		} else {
 			this.showHideButton.extractRenderState(guiGraphics, mouseX, mouseY, delta);
 		}

--- a/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
@@ -133,6 +133,14 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 	}
 
 	@Override
+	protected void extractBlurredBackground(final GuiGraphicsExtractor graphics) {
+		float blurRadius = Math.min(this.minecraft.options.getMenuBackgroundBlurriness(), this.blurTransition.getAsFloat());
+		if (blurRadius >= 1.0F) {
+			graphics.blurBeforeThisStratum();
+		}
+	}
+
+	@Override
 	public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float delta) {
 		notifier.onNewFrame();
 		backgroundInit = 1.0f;


### PR DESCRIPTION
Looks like `super.extractRenderState()` in `ShaderPackScreen.extractRenderState()` already extracted all needed objects, and as Iris extracted shader options list or shader pack list again, objects in those 2 lists will be drawn twice. This pr removed the extra extracts for shader options/packs list and everything still looks fine, just a bit brigher as the dark effect of shader screen is also drawn twice before. If Iris want to restore the GUI darkness as before, please change the values in single draw instead of making it draw twice.

This pr also overrides `extractBlurredBackground()` for shader pack screen, so blur radius of shader option menu will be treated as vanilla blur radius, blocking GUI blur passes when blur radius is lower than 1.

Fixes #2870 