### PR TITLE
Fix far plane for hand rendering

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pathways/HandRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/pathways/HandRenderer.java
@@ -59,7 +59,7 @@ public class HandRenderer {
 
 		// We need to scale the matrix by 0.125 so the hand doesn't clip through blocks.
 		Matrix4f scaleMatrix = new Matrix4f().scale(1F, 1F, DEPTH);
-		this.projection.setupPerspective(0.05F, 100.0F, camera.hudFov, Minecraft.getInstance().getWindow().getWidth(), Minecraft.getInstance().getWindow().getHeight());
+		this.projection.setupPerspective(0.05F, camera.depthFar, camera.hudFov, Minecraft.getInstance().getWindow().getWidth(), Minecraft.getInstance().getWindow().getHeight());
 		scaleMatrix.mul(this.projection.getMatrix(new Matrix4f()));
 
 		poseStack.pushPose();


### PR DESCRIPTION
Iris was using hardcoded 100.0 as far plane for projection matrix on hand rendering. This is much less than far plane used by camera, and will let hand depth slightly greater than expected. This also make [2].z and [3].z in `gl_ProjectionMatrix` does not match same component in `MC_HAND_DEPTH * gbufferProjection`.

This pr directly use `camera.depthFar` from input params as far plane, and fixes the issue above. There is no change needed for near plane, as currently Minecraft also hardcode near plane as 0.05.