### PR TITLE
Add (uncomment) clamping for end flash angle

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinEndFlash.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinEndFlash.java
@@ -22,14 +22,13 @@ public class MixinEndFlash {
 	@Shadow
 	private long flashSeed;
 
-	private static final float ABOVE_HORIZON_EPS = 1.0F; // degrees above horizon
+	private static final float ABOVE_HORIZON_EPS = 10.0F; // degrees above horizon
 
-	// Working on it...
-	//@Inject(method = "calculateFlashParameters", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;randomBetween(Lnet/minecraft/util/RandomSource;FF)F", ordinal = 0), cancellable = true)
+	@Inject(method = "calculateFlashParameters", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;randomBetween(Lnet/minecraft/util/RandomSource;FF)F", ordinal = 0), cancellable = true)
 	private void iris$calculateNewAngles(long l, CallbackInfo ci, @Local(ordinal = 1) long m, @Local RandomSource randomSource) {
 		if (Iris.getCurrentPack().isPresent()) {
 			ci.cancel();
-			this.xAngle = -Mth.randomBetween(randomSource, ABOVE_HORIZON_EPS, 60.0F); // [-60, -1]
+			this.xAngle = -Mth.randomBetween(randomSource, ABOVE_HORIZON_EPS, 60.0F); // [-60, -10]
 			this.yAngle = Mth.randomBetween(randomSource, -180.0F, 180.0F);
 			this.flashSeed = m;
 		}

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinEndFlash.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinEndFlash.java
@@ -22,13 +22,13 @@ public class MixinEndFlash {
 	@Shadow
 	private long flashSeed;
 
-	private static final float ABOVE_HORIZON_EPS = 10.0F; // degrees above horizon
+	private static final float ABOVE_HORIZON_EPS = 5.0F; // degrees above horizon
 
 	@Inject(method = "calculateFlashParameters", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;randomBetween(Lnet/minecraft/util/RandomSource;FF)F", ordinal = 0), cancellable = true)
 	private void iris$calculateNewAngles(long l, CallbackInfo ci, @Local(ordinal = 1) long m, @Local RandomSource randomSource) {
 		if (Iris.getCurrentPack().isPresent()) {
 			ci.cancel();
-			this.xAngle = -Mth.randomBetween(randomSource, ABOVE_HORIZON_EPS, 60.0F); // [-60, -10]
+			this.xAngle = -Mth.randomBetween(randomSource, ABOVE_HORIZON_EPS, 60.0F); // [-60, -5]
 			this.yAngle = Mth.randomBetween(randomSource, -180.0F, 180.0F);
 			this.flashSeed = m;
 		}


### PR DESCRIPTION
A 1 degree clamp is inadequate as shadows are basically parallel to the horizon. 10 degrees produce much more stable results.

Image of the issue this PR fixes:
<img width="2560" height="1440" alt="2026-04-10_19 41 45" src="https://github.com/user-attachments/assets/3277dfaa-aa2b-49fe-8bbe-d2cc8e2a4173" />
