### PR TITLE
fix frustum culling

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinCamera.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinCamera.java
@@ -1,5 +1,7 @@
 package net.irisshaders.iris.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.shadows.frustum.fallback.NonCullingFrustum;
@@ -8,6 +10,7 @@ import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,16 +20,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Camera.class)
 public class MixinCamera {
-	@Shadow
-	private Vec3 position;
+	@WrapOperation(
+		method = "prepareCullFrustum",
+		at = @At(
+			value = "NEW",
+			target = "Lnet/minecraft/client/renderer/culling/Frustum;"
+		)
+	)
+	private Frustum iris$disableFrustum(Matrix4fc modelViewMatrix, Matrix4f projectionMatrixForCulling, Operation<Frustum> original) {
+		Frustum frustum;
 
-	@Inject(method = "extractRenderState", at = @At("RETURN"), cancellable = true)
-	private void iris$disableFrustum(CameraRenderState cameraState, float partialTicks, CallbackInfo ci) {
 		if (Iris.getPipelineManager().getPipeline().map(WorldRenderingPipeline::shouldDisableFrustumCulling).orElse(false)) {
-			NonCullingFrustum f = new NonCullingFrustum();
-			f.prepare(position.x, position.y, position.z);
-
-			cameraState.cullFrustum = f;
+			frustum = new NonCullingFrustum(modelViewMatrix, projectionMatrixForCulling);
+		} else {
+			frustum = original.call(modelViewMatrix, projectionMatrixForCulling);
 		}
-	}
+		
+		return frustum;
+   }
 }

--- a/common/src/main/java/net/irisshaders/iris/shadows/frustum/fallback/NonCullingFrustum.java
+++ b/common/src/main/java/net/irisshaders/iris/shadows/frustum/fallback/NonCullingFrustum.java
@@ -6,6 +6,7 @@ import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.phys.AABB;
 import org.joml.FrustumIntersection;
+import org.joml.Matrix4fc;
 import org.joml.Matrix4f;
 import org.joml.Vector3d;
 
@@ -16,6 +17,10 @@ public class NonCullingFrustum extends Frustum implements ViewportProvider, net.
 		super(new Matrix4f(), new Matrix4f());
 	}
 
+	public NonCullingFrustum(final Matrix4fc modelViewMatrix, final Matrix4f projectionMatrixForCulling) {
+		super(modelViewMatrix, projectionMatrixForCulling);
+	}
+
 	// For Immersive Portals
 	// NB: The shadow culling in Immersive Portals must be disabled, because when Advanced Shadow Frustum Culling
 	//     is not active, we are at a point where we can make no assumptions how the shader pack uses the shadow
@@ -24,6 +29,7 @@ public class NonCullingFrustum extends Frustum implements ViewportProvider, net.
 		return false;
 	}
 
+	@Override
 	public boolean isVisible(AABB box) {
 		return true;
 	}
@@ -32,6 +38,11 @@ public class NonCullingFrustum extends Frustum implements ViewportProvider, net.
 	public int cubeInFrustum(BoundingBox boundingBox) {
 		return FrustumIntersection.INSIDE;
 	}
+
+	@Override
+	public boolean pointInFrustum(double x, double y, double z) {
+      return true;
+   }
 
 	@Override
 	public double getCamX() {
@@ -50,6 +61,7 @@ public class NonCullingFrustum extends Frustum implements ViewportProvider, net.
 
 	@Override
 	public void prepare(double d, double e, double f) {
+		super.prepare(d, e, f);
 		this.position.set(d, e, f);
 	}
 


### PR DESCRIPTION
setting frustum.culling to false no longer worked and was always true. this changes the frustum to be directly created as a NonCullingFrustum when it's set to false. idk what issues this can cause, but it worked perfectly fine during my testing