### PR TITLE
Fix #3088 (write mask may leak into composite programs)

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/CompositeRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/CompositeRenderer.java
@@ -278,6 +278,7 @@ public class CompositeRenderer {
 		VertexFormat.IndexType type = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS).type();
 
 		FullScreenQuadRenderer.INSTANCE.bind();
+		GlStateManager._colorMask(15);
 
 		for (int i = 0, passesSize = passes.size(); i < passesSize; i++) {
 			Pass compositePass = passes.get(i);


### PR DESCRIPTION
Fix the possibility of write mask leaks to composite programs if something with write mask disabled is rendered last before composite programs, by force enable write mask before composite groups.

We cannot wait vanilla to enable it as vanilla looks only change it when starts rendering something.

Fixes #3088 