### PR TITLE
minecraft:pipeline/item_cutout does not bind Sampler1

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
@@ -33,8 +33,8 @@ public class IrisPipelines {
 		assignToMain(RenderPipelines.ENTITY_CUTOUT_CULL, p -> getCutout(p));
 		assignToMain(RenderPipelines.ENTITY_CUTOUT_DISSOLVE, p -> getCutout(p));
 		assignToMain(RenderPipelines.ENTITY_TRANSLUCENT_CULL, p -> getTranslucent(p));
-		assignToMain(RenderPipelines.ITEM_TRANSLUCENT, p -> getTranslucent(p));
-		assignToMain(RenderPipelines.ITEM_CUTOUT, p -> getCutout(p));
+		assignToMain(RenderPipelines.ITEM_TRANSLUCENT, p -> getItemTranslucent(p));
+		assignToMain(RenderPipelines.ITEM_CUTOUT, p -> getItemCutout(p));
 		assignToMain(RenderPipelines.ENTITY_TRANSLUCENT, p -> getTranslucent(p));
 		assignToMain(RenderPipelines.ENTITY_SHADOW, p -> getTranslucent(p));
 		assignToMain(RenderPipelines.LINES, p -> ShaderKey.LINES);
@@ -218,6 +218,22 @@ public class IrisPipelines {
 			return (ShaderKey.BE_TRANSLUCENT);
 		} else {
 			return (ShaderKey.ENTITIES_TRANSLUCENT);
+		}
+	}
+
+	private static ShaderKey getItemCutout(Object p) {
+		if (HandRenderer.INSTANCE.isActive()) {
+			return (HandRenderer.INSTANCE.isRenderingSolid() ? ShaderKey.HAND_CUTOUT_DIFFUSE : ShaderKey.HAND_WATER_DIFFUSE);
+		} else {
+			return ShaderKey.ITEM_CUTOUT;
+		}
+	}
+
+	private static ShaderKey getItemTranslucent(Object p) {
+		if (HandRenderer.INSTANCE.isActive()) {
+			return (HandRenderer.INSTANCE.isRenderingSolid() ? ShaderKey.HAND_CUTOUT_DIFFUSE : ShaderKey.HAND_WATER_DIFFUSE);
+		} else {
+			return ShaderKey.ITEM_TRANSLUCENT;
 		}
 	}
 

--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderKey.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderKey.java
@@ -41,6 +41,8 @@ public enum ShaderKey {
 	ENTITIES_CUTOUT(ProgramId.Entities, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.LIGHTMAP),
 	ENTITIES_CUTOUT_DIFFUSE(ProgramId.Entities, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.DIFFUSE_LM),
 	ENTITIES_TRANSLUCENT(ProgramId.EntitiesTrans, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.DIFFUSE_LM),
+	ITEM_CUTOUT(ProgramId.Item, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.DIFFUSE_LM),
+	ITEM_TRANSLUCENT(ProgramId.Item, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.DIFFUSE_LM),
 	ENTITIES_EYES(ProgramId.SpiderEyes, AlphaTests.NON_ZERO_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.FULLBRIGHT),
 	ENTITIES_EYES_TRANS(ProgramId.SpiderEyes, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.FULLBRIGHT),
 	HAND_CUTOUT(ProgramId.Hand, AlphaTests.ONE_TENTH_ALPHA, IrisVertexFormats.ENTITY, FogMode.PER_VERTEX, LightingModel.LIGHTMAP),


### PR DESCRIPTION
`minecraft:pipeline/item_cutout` does not bind `Sampler1` which causes the game to crash on 26.1. It is probably wrong to re-use block-entity keys for items, so the right thing to do is probably to have item-specific program mapping.
If a shader pack does not provide gbuffers_item, ProgramId.Item already has fallback behavior