### PR TITLE
Fix lightmap clamp

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/fallback/ShaderSynthesizer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/fallback/ShaderSynthesizer.java
@@ -157,7 +157,7 @@ public class ShaderSynthesizer {
 			shader.append("in ivec2 UV2;\n");
 			shader.append("out vec2 lightCoord;\n");
 
-			main.append("    lightCoord = clamp(UV2 / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0));\n");
+			main.append("    lightCoord = clamp(vec2(UV2 + 8) / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0));\n");
 		}
 
 

--- a/common/src/main/java/net/irisshaders/iris/vertices/sodium/terrain/XHFPTerrainVertex.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/sodium/terrain/XHFPTerrainVertex.java
@@ -81,8 +81,8 @@ public class XHFPTerrainVertex implements ChunkVertexEncoder {
 	}
 
 	private static int encodeLight(int light) {
-		int sky = Mth.clamp(light >>> 16 & 255, 8, 248);
-		int block = Mth.clamp(light >>> 0 & 255, 8, 248);
+		int sky = Mth.clamp(light >>> 16 & 255, 0, 240);
+		int block = Mth.clamp(light >>> 0 & 255, 0, 240);
 		return block << 0 | sky << 8;
 	}
 


### PR DESCRIPTION
The texture matrix already adds ``0.03125f`` to the lightmap coords so the lowest possible value was 0.06 instead of the expected 0.03

thanks to cortex for pointing that out