### PR TITLE
Fix line transform

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java
@@ -340,18 +340,9 @@ public class VanillaTransformer {
 		root.replaceReferenceExpressions(t, "gl_ModelViewProjectionMatrix",
 			"(gl_ProjectionMatrix * gl_ModelViewMatrix)");
 
-		if (parameters.hasChunkOffset) {
-			boolean doInjection = root.replaceReferenceExpressionsReport(t, "gl_ModelViewMatrix",
-				"(iris_transforms.ModelViewMat * _iris_internal_translate(iris_transforms.ModelOffset))");
-			if (doInjection) {
-				tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_FUNCTIONS,
-					"mat4 _iris_internal_translate(vec3 offset) {" +
-						"return mat4(1.0, 0.0, 0.0, 0.0," +
-						"0.0, 1.0, 0.0, 0.0," +
-						"0.0, 0.0, 1.0, 0.0," +
-						"offset.x, offset.y, offset.z, 1.0); }");
-			}
-		} else if (parameters.inputs.isNewLines()) {
+		StringBuilder transform = new StringBuilder("(");
+		// `hasChunkOffset` is always true currently. We need move this branch out to get correct line scale.
+		if (parameters.inputs.isNewLines()) {
 			tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
 				"const float iris_VIEW_SHRINK = 1.0 - (1.0 / 256.0);",
 				"const mat4 iris_VIEW_SCALE = mat4(" +
@@ -359,11 +350,20 @@ public class VanillaTransformer {
 					"0.0, iris_VIEW_SHRINK, 0.0, 0.0," +
 					"0.0, 0.0, iris_VIEW_SHRINK, 0.0," +
 					"0.0, 0.0, 0.0, 1.0);");
-			root.replaceReferenceExpressions(t, "gl_ModelViewMatrix",
-				"(iris_VIEW_SCALE * iris_transforms.ModelViewMat)");
-		} else {
-			root.rename("gl_ModelViewMatrix", "iris_transforms.ModelViewMat");
+			transform.append("iris_VIEW_SCALE * ");
 		}
+		transform.append("iris_transforms.ModelViewMat");
+		if (parameters.hasChunkOffset) {
+			tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_FUNCTIONS,
+				"mat4 _iris_internal_translate(vec3 offset) {" +
+					"return mat4(1.0, 0.0, 0.0, 0.0," +
+					"0.0, 1.0, 0.0, 0.0," +
+					"0.0, 0.0, 1.0, 0.0," +
+					"offset.x, offset.y, offset.z, 1.0); }");
+			transform.append(" * _iris_internal_translate(iris_transforms.ModelOffset)");
+		}
+		transform.append(")");
+		root.replaceReferenceExpressions(t, "gl_ModelViewMatrix", transform.toString());
 
 		root.rename("gl_ProjectionMatrix", "iris_ProjMat");
 	}


### PR DESCRIPTION
Currently, because Iris always pass true to `hasChunkOffset` in [ShaderCreator.java#L80](https://github.com/IrisShaders/Iris/blob/26.1/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderCreator.java#L80) and [#L308](https://github.com/IrisShaders/Iris/blob/26.1/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderCreator.java#L308), the branches in [VanillaTransformer.java](https://github.com/IrisShaders/Iris/blob/26.1/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java#L343) for `gl_ModelViewMatrix` always run the first branch, ignoring the rest which includes the view scale patch for lines. This resulting wrong line rendering comparing to vanilla, made the lines partially hide inside blocks.

This pr make the detection of `hasChunkOffset` and `isNewLines()` run separately, so we can get the view scale patch for lines without removing chunk offset patch for lines. I don't know if lines really need chunk offset, but as Iris always pass true for `hasChunkOffset` when creating shaders, I would just left it here.