### PR TITLE
Fix NeoForge 1.21.1 shader screen blur/menu when certain other mods are present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,16 @@
 
 name: Java CI with Gradle
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      release_build:
+        description: "Build as release (-Dbuild.release=true)"
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -23,7 +32,12 @@ jobs:
           gradle-version: current
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release_build }}" = "true" ]; then
+            ./gradlew :neoforge:build -Dbuild.release=true
+          else
+            ./gradlew build
+          fi
 
       - name: Upload built JAR
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-neoforge-manual.yml
+++ b/.github/workflows/release-neoforge-manual.yml
@@ -1,0 +1,72 @@
+name: Manual NeoForge Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Git tag to create/use (example: v1.8.12-ia3+1.21.1-neoforge)"
+        required: true
+        type: string
+      release_name:
+        description: "GitHub release title"
+        required: true
+        type: string
+      publish_mod_sites:
+        description: "Also publish to Modrinth/CurseForge via mc-publish secrets"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+
+      - name: Build release artifacts
+        run: ./gradlew :neoforge:build -Dbuild.release=true
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: neoforge-release-jars
+          path: build/libs/iris-neoforge-*.jar
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          name: ${{ inputs.release_name }}
+          generate_release_notes: true
+          files: build/libs/iris-neoforge-*.jar
+
+      - name: Publish to Modrinth/CurseForge
+        if: ${{ inputs.publish_mod_sites }}
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: YL57xq9U
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-featured: true
+          curseforge-id: 455508
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          files: build/libs/iris-neoforge-*.jar
+          version-type: release
+          loaders: neoforge
+          dependencies: sodium

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ val SODIUM_DEPENDENCY_NEO by extra { "maven.modrinth:sodium:I9RMZOOH"}
 val PARCHMENT_VERSION by extra { null }
 
 // https://semver.org/
-val MOD_VERSION by extra { "1.8.8" }
+val MOD_VERSION by extra { "1.8.12-ia3" }
 
 allprojects {
     apply(plugin = "java")

--- a/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
@@ -157,12 +157,6 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 
 		if (!this.guiHidden) {
 			super.render(guiGraphics, mouseX, mouseY, delta);
-
-			if (optionMenuOpen && this.shaderOptionList != null) {
-				this.shaderOptionList.render(guiGraphics, mouseX, mouseY, delta);
-			} else {
-				this.shaderPackList.render(guiGraphics, mouseX, mouseY, delta);
-			}
 		} else {
 			this.renderBlurredBackground(delta);
 			this.showHideButton.render(guiGraphics, mouseX, mouseY, delta);
@@ -377,6 +371,14 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 
 	@Override
 	protected void renderBlurredBackground(float pScreen0) {
+		// NeoForge 1.21.1 modpacks can trigger a GUI composition bug where
+		// post-processing blur wipes this screen while in-world.
+		// Keep the menu readable by skipping Iris's custom blur pass only here.
+		if (this.minecraft.level != null) {
+			this.minecraft.getMainRenderTarget().bindWrite(false);
+			return;
+		}
+
 		processFixedBlur(pScreen0);
 		this.minecraft.getMainRenderTarget().bindWrite(false);
 	}

--- a/common/src/main/java/net/irisshaders/iris/pipeline/CompositeRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/CompositeRenderer.java
@@ -253,6 +253,7 @@ public class CompositeRenderer {
 	public void renderAll() {
 		GLDebug.pushGroup(20 + compositePass.ordinal(), compositePass.name().toLowerCase(Locale.ROOT));
 		RenderSystem.disableBlend();
+		GlStateManager._colorMask(true, true, true, true);
 
 		FullScreenQuadRenderer.INSTANCE.begin();
 		com.mojang.blaze3d.pipeline.RenderTarget main = Minecraft.getInstance().getMainRenderTarget();


### PR DESCRIPTION
fixes

https://github.com/IrisShaders/Iris/issues/2704 
https://github.com/IrisShaders/Iris/issues/2765 

failsafes the settings menu by using a safer rendering path when another mod affects blur effects
not sure if this is the best way to do it so draft atm