### PR TITLE
Fix #3096 (docs) broken links to `supportedshaders.md`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ See the [Driver Support](usage/drivers.md) document for more information.
 
 ## Why is (insert shader) not working?
 
-That shader likely isn't supported currently, but should be in the future. See the list of supported shaders [here](./supportedshaders.md)
+That shader likely isn't supported currently, but should be in the future. See the list of unsupported shaders [here](./unsupportedshaders.md)
 
 ## How do I disable my shaders?
 
@@ -43,10 +43,6 @@ There are a few possible reasons:
 ## Why are entities becoming invisible randomly?
 
 You probably have an outdated version of GraalVM installed. Install a normal version of Java or update to GraalVM 22.3 to fix the [issue](https://github.com/oracle/graal/issues/4849).
-
-## What shaders have been tested and are working with Iris?
-
-See [this](./supportedshaders.md) document for the list
 
 ## Will (insert feature) part of OptiFine be added to iris?
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -141,9 +141,7 @@ You can rebind these keyboard shortcuts to any other key you want in the Control
 
 ## Shader compatibility
 
-For a list of compatible shaders, check out the [supported shaders list](supportedshaders.md).
-
-Other shaders are considered **unsupported** at the moment. When using shaders which are not in this list, except them to have major visual problems, or even not run at all. More shaders will be added as supported as new features are being added to Iris.
+Iris supports almost all shaderpacks, but a list of unsupported shaderpacks is available [here](docs/unsupportedshaders.md).
 
 For a list of known bugs with certain shaders, check out the [shader pack bug list](ShaderpackBugs.md).
 


### PR DESCRIPTION
I added some suggestions for the passages broken links. The line in the guide is copied from the README.