### PR TITLE
Fixed conduit is using gbuffers_entities instead of gbuffers_block

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinModelStorageTrigger.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/entity_render_context/MixinModelStorageTrigger.java
@@ -9,6 +9,7 @@ import net.irisshaders.iris.layer.OuterWrappedRenderType;
 import net.irisshaders.iris.mixinterface.ModelStorage;
 import net.irisshaders.iris.vertices.ImmediateState;
 import net.minecraft.client.model.Model;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.SubmitNodeCollection;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -48,6 +49,15 @@ public class MixinModelStorageTrigger {
 		}
 
 		original.call(poseStack, renderType, customGeometryRenderer);
+	}
+
+	@WrapMethod(method = "submitModelPart")
+	private void iris$changeRenderType3(ModelPart modelPart, PoseStack poseStack, RenderType renderType, int lightCoords, int overlayCoords, @Nullable TextureAtlasSprite sprite, boolean sheeted, boolean hasFoil, int tintedColor, ModelFeatureRenderer.@Nullable CrumblingOverlay crumblingOverlay, int outlineColor, Operation<Void> original) {
+		if (ImmediateState.isRenderingBEs) {
+			renderType = OuterWrappedRenderType.wrapExactlyOnce("iris:block_entity", renderType, BlockEntityRenderStateShard.INSTANCE);
+		}
+
+		original.call(modelPart, poseStack, renderType, lightCoords, overlayCoords, sprite, sheeted, hasFoil, tintedColor, crumblingOverlay, outlineColor);
 	}
 
 	@WrapOperation(method = "submitModelPart", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/feature/ModelPartFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelPartSubmit;)V"))


### PR DESCRIPTION
Conduit is using `submitModelPart()` when submitting geometry, and Iris does not apply block entity check for this function.

By adding block entity check for `submitModelPart()`, now conduits can correctly use gbuffers_block.