### PR TITLE
Fixed selected shader not in menu center

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gui/element/ShaderPackSelectionList.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/element/ShaderPackSelectionList.java
@@ -197,28 +197,30 @@ public class ShaderPackSelectionList extends IrisObjectSelectionList<ShaderPackS
 		topButtonRow.allowEnableShadersButton = !names.isEmpty();
 
 		int index = 0;
+		String selectedName = Iris.getIrisConfig().getShaderPackName().orElse(null);
+		ShaderPackEntry selectedPack = null;
 
 		for (String name : names) {
 			index++;
-			addPackEntry(index, name);
+			ShaderPackEntry entry = addPackEntry(index, name);
+			if (name.equals(selectedName)) {
+				selectedPack = entry;
+			}
+		}
+		if (selectedPack != null) {
+			setSelected(selectedPack);
+			setFocused(selectedPack);
+			centerScrollOn(selectedPack);
+			setApplied(selectedPack);
 		}
 
 		this.addLabelEntries(PACK_LIST_LABEL);
 	}
 
-	public void addPackEntry(int index, String name) {
+	public ShaderPackEntry addPackEntry(int index, String name) {
 		ShaderPackEntry entry = new ShaderPackEntry(index, this, name);
-
-		Iris.getIrisConfig().getShaderPackName().ifPresent(currentPackName -> {
-			if (name.equals(currentPackName)) {
-				setSelected(entry);
-				setFocused(entry);
-				centerScrollOn(entry);
-				setApplied(entry);
-			}
-		});
-
 		this.addEntry(entry);
+		return entry;
 	}
 
 	public void addLabelEntries(Component... lines) {


### PR DESCRIPTION
When creating shader selection menu, Iris will directly do the below thing when detecting the currently added one is selected pack:
```java
setSelected(entry);
setFocused(entry);
centerScrollOn(entry);
setApplied(entry);
```
However, this is done even before the current entry is added. So when selected pack detected, Iris will just roll current screen to the end, and then add the entry of selected pack. This will result in selected pack is perfectly outside the bottom of shaderpack selection menu when open it, which is very annoying.

By temporary store the matched entry, and do the above thing after all entry is added, now selected shader will be in the middle of menu when open it.