### PR TITLE
Fix uv related thing of end portal and gateway

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinTheEndPortalRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinTheEndPortalRenderer.java
@@ -74,11 +74,27 @@ public class MixinTheEndPortalRenderer {
 			float ny = direction.getStepY();
 			float nz = direction.getStepZ();
 
-			for (Vector3fc faceVertex : FACES.get(direction)) {
-				buffer.addVertex(pose, faceVertex.x(), faceVertex.y(), faceVertex.z()).setColor(RED, GREEN, BLUE, 1.0f)
-					.setUv(0.0F + progress, 0.0F + progress).setOverlay(overlay).setLight(light)
-					.setNormal(pose, nx, ny, nz);
-			}
+			List<Vector3fc> vertices = FACES.get(direction);
+
+			Vector3fc vertex0 = vertices.get(0);
+			buffer.addVertex(pose, vertex0.x(), vertex0.y(), vertex0.z()).setColor(RED, GREEN, BLUE, 1.0f)
+				.setUv(0.0F + progress, 0.0F + progress).setOverlay(overlay).setLight(light)
+				.setNormal(pose, nx, ny, nz);
+
+			Vector3fc vertex1 = vertices.get(1);
+			buffer.addVertex(pose, vertex1.x(), vertex1.y(), vertex1.z()).setColor(RED, GREEN, BLUE, 1.0f)
+				.setUv(0.0F + progress, 0.2F + progress).setOverlay(overlay).setLight(light)
+				.setNormal(pose, nx, ny, nz);
+
+			Vector3fc vertex2 = vertices.get(2);
+			buffer.addVertex(pose, vertex2.x(), vertex2.y(), vertex2.z()).setColor(RED, GREEN, BLUE, 1.0f)
+				.setUv(0.2F + progress, 0.2F + progress).setOverlay(overlay).setLight(light)
+				.setNormal(pose, nx, ny, nz);
+
+			Vector3fc vertex3 = vertices.get(3);
+			buffer.addVertex(pose, vertex3.x(), vertex3.y(), vertex3.z()).setColor(RED, GREEN, BLUE, 1.0f)
+				.setUv(0.2F + progress, 0.0F + progress).setOverlay(overlay).setLight(light)
+				.setNormal(pose, nx, ny, nz);
 		}
 	}
 


### PR DESCRIPTION
In [common/src/main/java/net/irisshaders/iris/mixin/MixinTheEndPortalRenderer.java#L77-L81](https://github.com/IrisShaders/Iris/blob/26.1/common/src/main/java/net/irisshaders/iris/mixin/MixinTheEndPortalRenderer.java#L77-L81), Iris set 4 vertices to exactly same UV, which breaks all uv related thing, including `at_tangent` and `mc_midTexCoord`.

This pr restores the behavior before (with order changed as vanilla is using different vertex order comparing to previous Iris versions), letting each face of end portal/gateway get 0.2x size of its texture. This also fixes `at_tangent` and `mc_midTexCoord` of ender portal and gateway.