### PR TITLE
Merging previous fixes

### DIFF
--- a/common/src/api/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/item/IrisItemLightProvider.java
@@ -1,8 +1,11 @@
 package net.irisshaders.iris.api.v0.item;
 
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.BlockItemStateProperties;
+import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3f;
 
 public interface IrisItemLightProvider {
@@ -11,8 +14,12 @@ public interface IrisItemLightProvider {
 
 	default int getLightEmission(Player player, ItemStack stack) {
 		if (stack.getItem() instanceof BlockItem item) {
-
-			return item.getBlock().defaultBlockState().getLightEmission();
+			BlockState blockState = item.getBlock().defaultBlockState();
+			BlockItemStateProperties itemBlockState = stack.getComponents().get(DataComponents.BLOCK_STATE);
+			if (itemBlockState != null) {
+				blockState = itemBlockState.apply(blockState);
+			}
+			return blockState.getLightEmission();
 		}
 
 		return 0;

--- a/common/src/main/java/net/irisshaders/iris/gl/texture/TextureType.java
+++ b/common/src/main/java/net/irisshaders/iris/gl/texture/TextureType.java
@@ -1,16 +1,16 @@
 package net.irisshaders.iris.gl.texture;
 
 import net.irisshaders.iris.gl.IrisRenderSystem;
-import org.lwjgl.opengl.GL30C;
+import org.lwjgl.opengl.GL32C;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
 public enum TextureType {
-	TEXTURE_1D(GL30C.GL_TEXTURE_1D),
-	TEXTURE_2D(GL30C.GL_TEXTURE_2D),
-	TEXTURE_3D(GL30C.GL_TEXTURE_3D),
-	TEXTURE_RECTANGLE(GL30C.GL_TEXTURE_3D);
+	TEXTURE_1D(GL32C.GL_TEXTURE_1D),
+	TEXTURE_2D(GL32C.GL_TEXTURE_2D),
+	TEXTURE_3D(GL32C.GL_TEXTURE_3D),
+	TEXTURE_RECTANGLE(GL32C.GL_TEXTURE_RECTANGLE);
 
 	private final int glType;
 

--- a/common/src/main/java/net/irisshaders/iris/gui/element/ShaderPackSelectionList.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/element/ShaderPackSelectionList.java
@@ -189,28 +189,30 @@ public class ShaderPackSelectionList extends IrisObjectSelectionList<ShaderPackS
 		topButtonRow.allowEnableShadersButton = !names.isEmpty();
 
 		int index = 0;
+		String selectedName = Iris.getIrisConfig().getShaderPackName().orElse(null);
+		ShaderPackEntry selectedPack = null;
 
 		for (String name : names) {
 			index++;
-			addPackEntry(index, name);
+			ShaderPackEntry entry = addPackEntry(index, name);
+			if (name.equals(selectedName)) {
+				selectedPack = entry;
+			}
+		}
+		if (selectedPack != null) {
+			setSelected(selectedPack);
+			setFocused(selectedPack);
+			centerScrollOn(selectedPack);
+			setApplied(selectedPack);
 		}
 
 		this.addLabelEntries(PACK_LIST_LABEL);
 	}
 
-	public void addPackEntry(int index, String name) {
+	public ShaderPackEntry addPackEntry(int index, String name) {
 		ShaderPackEntry entry = new ShaderPackEntry(index, this, name);
-
-		Iris.getIrisConfig().getShaderPackName().ifPresent(currentPackName -> {
-			if (name.equals(currentPackName)) {
-				setSelected(entry);
-				setFocused(entry);
-				centerScrollOn(entry);
-				setApplied(entry);
-			}
-		});
-
 		this.addEntry(entry);
+		return entry;
 	}
 
 	public void addLabelEntries(Component... lines) {

--- a/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
+++ b/common/src/main/java/net/irisshaders/iris/gui/screen/ShaderPackScreen.java
@@ -157,12 +157,6 @@ public class ShaderPackScreen extends Screen implements HudHideable {
 
 		if (!this.guiHidden) {
 			super.render(guiGraphics, mouseX, mouseY, delta);
-
-			if (optionMenuOpen && this.shaderOptionList != null) {
-				this.shaderOptionList.render(guiGraphics, mouseX, mouseY, delta);
-			} else {
-				this.shaderPackList.render(guiGraphics, mouseX, mouseY, delta);
-			}
 		} else {
 			this.renderBlurredBackground(delta);
 			this.showHideButton.render(guiGraphics, mouseX, mouseY, delta);

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinItemInHandRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinItemInHandRenderer.java
@@ -2,6 +2,7 @@ package net.irisshaders.iris.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.irisshaders.iris.Iris;
+import net.irisshaders.iris.mixinterface.ItemInHandInterface;
 import net.irisshaders.iris.pathways.HandRenderer;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.ItemInHandRenderer;
@@ -9,20 +10,34 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemInHandRenderer.class)
-public class MixinItemInHandRenderer {
+public class MixinItemInHandRenderer implements ItemInHandInterface {
 	@Inject(method = "renderArmWithItem", at = @At("HEAD"), cancellable = true)
 	private void iris$skipTranslucentHands(AbstractClientPlayer abstractClientPlayer, float f, float g, InteractionHand interactionHand, float h, ItemStack itemStack, float i, PoseStack poseStack, MultiBufferSource multiBufferSource, int j, CallbackInfo ci) {
 		if (Iris.isPackInUseQuick()) {
-			if (HandRenderer.INSTANCE.isRenderingSolid() && HandRenderer.INSTANCE.isHandTranslucent(interactionHand)) {
-				ci.cancel();
-			} else if (!HandRenderer.INSTANCE.isRenderingSolid() && !HandRenderer.INSTANCE.isHandTranslucent(interactionHand)) {
+			if (HandRenderer.INSTANCE.isRenderingSolid() == HandRenderer.INSTANCE.isHandTranslucent(itemStack)) {
 				ci.cancel();
 			}
 		}
+	}
+
+	@Shadow
+	private ItemStack mainHandItem;
+	@Shadow
+	private ItemStack offHandItem;
+
+	@Override
+	public boolean iris$isAnyHandTranslucent () {
+		return HandRenderer.INSTANCE.isHandTranslucent(mainHandItem) || HandRenderer.INSTANCE.isHandTranslucent(offHandItem);
+	}
+
+	@Override
+	public boolean iris$isAnyHandSolid () {
+		return !(HandRenderer.INSTANCE.isHandTranslucent(mainHandItem) && HandRenderer.INSTANCE.isHandTranslucent(offHandItem));
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/mixinterface/ItemInHandInterface.java
+++ b/common/src/main/java/net/irisshaders/iris/mixinterface/ItemInHandInterface.java
@@ -1,0 +1,7 @@
+package net.irisshaders.iris.mixinterface;
+
+public interface ItemInHandInterface {
+	boolean iris$isAnyHandTranslucent();
+
+	boolean iris$isAnyHandSolid();
+}

--- a/common/src/main/java/net/irisshaders/iris/pathways/HandRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/pathways/HandRenderer.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.irisshaders.batchedentityrendering.impl.FullyBufferedMultiBufferSource;
 import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.mixin.GameRendererAccessor;
+import net.irisshaders.iris.mixinterface.ItemInHandInterface;
 import net.irisshaders.iris.pipeline.WorldRenderingPhase;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.uniforms.CapturedRenderingState;
@@ -19,6 +20,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -59,9 +61,8 @@ public class HandRenderer {
 			|| Minecraft.getInstance().gameMode.getPlayerMode() == GameType.SPECTATOR);
 	}
 
-	public boolean isHandTranslucent(InteractionHand hand) {
-		Item item = Minecraft.getInstance().player.getItemBySlot(hand == InteractionHand.OFF_HAND ? EquipmentSlot.OFFHAND : EquipmentSlot.MAINHAND).getItem();
-
+	public boolean isHandTranslucent(ItemStack itemStack) {
+		Item item = itemStack.getItem();
 		if (item instanceof BlockItem) {
 			return ItemBlockRenderTypes.getChunkRenderType(((BlockItem) item).getBlock().defaultBlockState()) == RenderType.translucent();
 		}
@@ -69,12 +70,8 @@ public class HandRenderer {
 		return false;
 	}
 
-	public boolean isAnyHandTranslucent() {
-		return isHandTranslucent(InteractionHand.MAIN_HAND) || isHandTranslucent(InteractionHand.OFF_HAND);
-	}
-
 	public void renderSolid(Matrix4fc modelMatrix, float tickDelta, Camera camera, GameRenderer gameRenderer, WorldRenderingPipeline pipeline) {
-		if (!canRender(camera, gameRenderer) || !Iris.isPackInUseQuick()) {
+		if (!canRender(camera, gameRenderer) || !((ItemInHandInterface)gameRenderer.itemInHandRenderer).iris$isAnyHandSolid() || !Iris.isPackInUseQuick()) {
 			return;
 		}
 
@@ -115,7 +112,7 @@ public class HandRenderer {
 	}
 
 	public void renderTranslucent(Matrix4fc modelMatrix, float tickDelta, Camera camera, GameRenderer gameRenderer, WorldRenderingPipeline pipeline) {
-		if (!canRender(camera, gameRenderer) || !isAnyHandTranslucent() || !Iris.isPackInUseQuick()) {
+		if (!canRender(camera, gameRenderer) || !((ItemInHandInterface)gameRenderer.itemInHandRenderer).iris$isAnyHandTranslucent() || !Iris.isPackInUseQuick()) {
 			return;
 		}
 

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java
@@ -188,19 +188,9 @@ public class VanillaTransformer {
 		root.replaceReferenceExpressions(t, "gl_ModelViewProjectionMatrix",
 			"(gl_ProjectionMatrix * gl_ModelViewMatrix)");
 
-		if (parameters.hasChunkOffset) {
-			boolean doInjection = root.replaceReferenceExpressionsReport(t, "gl_ModelViewMatrix",
-				"(iris_ModelViewMat * _iris_internal_translate(iris_ChunkOffset))");
-			if (doInjection) {
-				tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_FUNCTIONS,
-					"uniform vec3 iris_ChunkOffset;",
-					"mat4 _iris_internal_translate(vec3 offset) {" +
-						"return mat4(1.0, 0.0, 0.0, 0.0," +
-						"0.0, 1.0, 0.0, 0.0," +
-						"0.0, 0.0, 1.0, 0.0," +
-						"offset.x, offset.y, offset.z, 1.0); }");
-			}
-		} else if (parameters.inputs.isNewLines()) {
+		StringBuilder transform = new StringBuilder("(");
+		// `hasChunkOffset` is always true currently. We need move this branch out to get correct line scale.
+		if (parameters.inputs.isNewLines()) {
 			tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
 				"const float iris_VIEW_SHRINK = 1.0 - (1.0 / 256.0);",
 				"const mat4 iris_VIEW_SCALE = mat4(" +
@@ -208,11 +198,21 @@ public class VanillaTransformer {
 					"0.0, iris_VIEW_SHRINK, 0.0, 0.0," +
 					"0.0, 0.0, iris_VIEW_SHRINK, 0.0," +
 					"0.0, 0.0, 0.0, 1.0);");
-			root.replaceReferenceExpressions(t, "gl_ModelViewMatrix",
-				"(iris_VIEW_SCALE * iris_ModelViewMat)");
-		} else {
-			root.rename("gl_ModelViewMatrix", "iris_ModelViewMat");
+			transform.append("iris_VIEW_SCALE * ");
 		}
+		transform.append("iris_ModelViewMat");
+		if (parameters.hasChunkOffset) {
+			tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_FUNCTIONS,
+				"uniform vec3 iris_ChunkOffset;",
+				"mat4 _iris_internal_translate(vec3 offset) {" +
+					"return mat4(1.0, 0.0, 0.0, 0.0," +
+					"0.0, 1.0, 0.0, 0.0," +
+					"0.0, 0.0, 1.0, 0.0," +
+					"offset.x, offset.y, offset.z, 1.0); }");
+			transform.append(" * _iris_internal_translate(iris_ChunkOffset)");
+		}
+		transform.append(")");
+		root.replaceReferenceExpressions(t, "gl_ModelViewMatrix", transform.toString());
 
 		root.rename("gl_ProjectionMatrix", "iris_ProjMat");
 		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,


### PR DESCRIPTION
Merged:
3047 (TEXTURE_RECTANGLE)
3055 (Solid/transparent detection does not match vanilla animation)
3059 (Consider blockstate component for `heldBlockLightValue`)
3064 (Shader selection/option screen drawn twice)
3106 (Selected shader not in screen center when open menu)