### PR TITLE
Fix light coord in fallback

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/fallback/ShaderSynthesizer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/fallback/ShaderSynthesizer.java
@@ -140,7 +140,7 @@ public class ShaderSynthesizer {
 			shader.append("in ivec2 UV2;\n");
 			shader.append("out vec2 lightCoord;\n");
 
-			main.append("    lightCoord = clamp(UV2 / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0));\n");
+			main.append("    lightCoord = clamp(vec2(UV2 + 8) / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0));\n");
 		}
 
 


### PR DESCRIPTION
You forget to change the fallback shader code when updating terrain light coord