### PR TITLE
draw translucent features before deferred, if separateEntityDraws is false

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
@@ -27,6 +27,7 @@ import net.irisshaders.iris.layer.OuterWrappedRenderType;
 import net.irisshaders.iris.pathways.HandRenderer;
 import net.irisshaders.iris.pipeline.WorldRenderingPhase;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
+import net.irisshaders.iris.shaderpack.materialmap.WorldRenderingSettings;
 import net.irisshaders.iris.shadows.frustum.fallback.NonCullingFrustum;
 import net.irisshaders.iris.uniforms.CapturedRenderingState;
 import net.irisshaders.iris.uniforms.IrisTimeUniforms;
@@ -42,6 +43,7 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LevelTargetBundle;
 import net.minecraft.client.renderer.RenderBuffers;
+import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
@@ -274,11 +276,18 @@ public abstract class MixinLevelRenderer {
 	}
 
 	// TODO this needs to be more consistent.
-	@Inject(method = { MojLambdas.RENDER_MAIN_PASS, NeoLambdas.NEO_RENDER_MAIN_PASS }, require = 1, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher;renderTranslucentFeatures()V"))
-	private void iris$beginTranslucents(CallbackInfo ci,  @Local(ordinal = 0, argsOnly = true) Matrix4fc modelMatrix) {
+	@WrapOperation(method = { MojLambdas.RENDER_MAIN_PASS, NeoLambdas.NEO_RENDER_MAIN_PASS }, require = 1, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher;renderTranslucentFeatures()V"))
+	private void iris$beginTranslucents(FeatureRenderDispatcher instance, Operation<Void> original, @Local(ordinal = 0, argsOnly = true) Matrix4fc modelMatrix) {
+		if (!WorldRenderingSettings.INSTANCE.shouldSeparateEntityDraws()) {
+			original.call(instance);
+			this.renderBuffers.bufferSource().endBatch();
+		}
 		pipeline.beginHand();
 		HandRenderer.INSTANCE.renderSolid(modelMatrix, Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(true), Minecraft.getInstance().gameRenderer.getMainCamera(), levelRenderState.cameraRenderState, Minecraft.getInstance().gameRenderer, pipeline);
 		Profiler.get().popPush("iris_pre_translucent");
 		pipeline.beginTranslucents();
+		if (WorldRenderingSettings.INSTANCE.shouldSeparateEntityDraws()) {
+			original.call(instance);
+		}
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisRenderingPipeline.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisRenderingPipeline.java
@@ -269,9 +269,11 @@ public class IrisRenderingPipeline implements WorldRenderingPipeline, ShaderRend
 			.map(ImageClearPass::create)
 			.collect(ImmutableList.toImmutableList());
 
+		boolean separateEntityDraws = programSet.getPackDirectives().shouldUseSeparateEntityDraws().orElse(programSet.get(ProgramId.EntitiesTrans).isPresent() || programSet.get(ProgramId.BlockTrans).isPresent());
+
 		if (programSet.getPackDirectives().getParticleRenderingSettings() != ParticleRenderingSettings.UNSET) {
 			this.particleRenderingSettings = programSet.getPackDirectives().getParticleRenderingSettings();
-		} else if (programSet.getComposite(ProgramArrayId.Deferred).length > 0 && !programSet.getPackDirectives().shouldUseSeparateEntityDraws()) {
+		} else if (programSet.getComposite(ProgramArrayId.Deferred).length > 0 && !separateEntityDraws) {
 			this.particleRenderingSettings = ParticleRenderingSettings.AFTER;
 		} else {
 			this.particleRenderingSettings = ParticleRenderingSettings.MIXED;
@@ -446,7 +448,7 @@ public class IrisRenderingPipeline implements WorldRenderingPipeline, ShaderRend
 		WorldRenderingSettings.INSTANCE.setUseSeparateAo(programSet.getPackDirectives().shouldUseSeparateAo());
 		WorldRenderingSettings.INSTANCE.setBreaksAnisotropy(programSet.getPackDirectives().breaksAnisotropy());
 		WorldRenderingSettings.INSTANCE.setVoxelizeLightBlocks(programSet.getPackDirectives().shouldVoxelizeLightBlocks());
-		WorldRenderingSettings.INSTANCE.setSeparateEntityDraws(programSet.getPackDirectives().shouldUseSeparateEntityDraws());
+		WorldRenderingSettings.INSTANCE.setSeparateEntityDraws(separateEntityDraws);
 
 		if (shadowRenderTargets != null) {
 			GlProgram shader = shaderMap.getShader(ShaderKey.SHADOW_TERRAIN_CUTOUT);

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/properties/PackDirectives.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/properties/PackDirectives.java
@@ -8,6 +8,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.gl.texture.TextureScaleOverride;
 import net.irisshaders.iris.gl.texture.TextureType;
+import net.irisshaders.iris.helpers.OptionalBoolean;
 import net.irisshaders.iris.helpers.Tri;
 import net.irisshaders.iris.shaderpack.parsing.DirectiveHolder;
 import net.irisshaders.iris.shaderpack.texture.TextureStage;
@@ -41,7 +42,7 @@ public class PackDirectives {
 	private boolean separateAo;
 	private boolean breaksAnisotropy;
 	private boolean voxelizeLightBlocks;
-	private boolean separateEntityDraws;
+	private OptionalBoolean separateEntityDraws;
 	private boolean skipAllRendering;
 	private boolean frustumCulling;
 	private boolean supportsEndFlash;
@@ -84,7 +85,7 @@ public class PackDirectives {
 		separateAo = properties.getSeparateAo().orElse(false);
 		breaksAnisotropy = properties.breaksAnisotropy().orElse(false);
 		voxelizeLightBlocks = properties.getVoxelizeLightBlocks().orElse(false);
-		separateEntityDraws = properties.getSeparateEntityDraws().orElse(false);
+		separateEntityDraws = properties.getSeparateEntityDraws();
 		skipAllRendering = properties.skipAllRendering().orElse(false);
 		frustumCulling = properties.getFrustumCulling().orElse(true);
 		supportsEndFlash = properties.supportsEndFlash().orElse(false);
@@ -212,7 +213,7 @@ public class PackDirectives {
 		return voxelizeLightBlocks;
 	}
 
-	public boolean shouldUseSeparateEntityDraws() {
+	public OptionalBoolean shouldUseSeparateEntityDraws() {
 		return separateEntityDraws;
 	}
 


### PR DESCRIPTION
This restores the old behavior, of rendering translucent entities before deferred, if separateEntityDraws is set to false.

this also automatically switches to separateEntityDraws = true, if block_translucent or entities_translucent are present, and separateEntityDraws is unset

not sure if exposing the OptionalBoolean in the PackDirectives is okay, I'm open for suggestions to handle that better.