### PR TITLE
fix(patcher): force core profile on the lines program

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/TransformPatcher.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/TransformPatcher.java
@@ -149,6 +149,12 @@ public class TransformPatcher {
 								versionStatement.version = Version.GLSL33;
 							}
 
+							// lines shaders are forced through VanillaCoreTransformer regardless of
+							// their declared profile, so ensure the output profile is core
+							if (isLine && profile != Profile.CORE) {
+								versionStatement.profile = Profile.CORE;
+							}
+
 							switch (parameters.patch) {
 								case COMPOSITE:
 									CompositeCoreTransformer.transform(transformer, tree, root, parameters);


### PR DESCRIPTION
## Summary

On macOS (OpenGL 4.1 Metal — core-profile only), enabling any shader pack that provides a `gbuffers_line` shader fails after 1.10.8:

```
net.irisshaders.iris.gl.shader.ShaderCompileException: lines: lines: ERROR: 0:1: '' : syntax error: #version
```

The patched `lines` program is emitted as `#version 330 compatibility`, which Apple's core-only driver rejects, so the entire pipeline is disabled. Regression between 1.10.8 (emitted `#version 330`) and 1.10.9.

Reproduced on: macOS 27.0, Apple M5, MC 26.1.1, Sodium 0.8.9, with both IterationV and stock Complementary Reimagined r5.8.1.

## Root cause

`TransformPatcher` routes line shaders through `VanillaCoreTransformer` via the `isLine` branch regardless of their declared profile. The `else` branch (standard non-core shaders) explicitly sets `versionStatement.profile = Profile.CORE` at line 175, but the `if` branch (`profile == CORE || version >= 150 && profile == null || isLine`) does not.

When `isLine` is the sole reason for entering the branch and the incoming shader has `#version 330 compatibility`, the profile is never updated — so `compatibility` survives to the driver output.

## Fix

One targeted guard, inserted after the version-number bump and before the transformer switch:

```java
// lines shaders are forced through VanillaCoreTransformer regardless of
// their declared profile, so ensure the output profile is core
if (isLine && profile != Profile.CORE) {
    versionStatement.profile = Profile.CORE;
}
```

This ensures line shaders always emit a core profile, matching the intent of the `VanillaCoreTransformer` path.

## Testing

- macOS 27.0, Apple M5, MC 26.1.1, Fabric API 0.151.0, Sodium 0.8.9
- **Before:** pipeline fails with `lines: ERROR: 0:1: '' : syntax error: #version`; shaders disabled on load
- **After:** patched `lines.vsh` emits `#version 330 core`; pipeline builds; shaders load in overworld and End
- Tested with IterationV and Complementary Reimagined r5.8.1
