### PR TITLE
Avoid concrete Sodium screen cast for graphics API prompt

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/compat/sodium/config/IrisConfig.java
+++ b/common/src/main/java/net/irisshaders/iris/compat/sodium/config/IrisConfig.java
@@ -24,6 +24,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.PreferredGraphicsApi;
 import net.minecraft.client.TextureFilteringMethod;
 import net.minecraft.client.gui.screens.ConfirmScreen;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
@@ -104,7 +105,7 @@ public class IrisConfig implements ConfigEntryPoint {
                                             PreferredGraphicsApi.class)
                                     .setBinding((value) -> {
                                         if (((GpuDeviceAccessor) RenderSystem.getDevice()).getBackend() instanceof GlDevice && value == PreferredGraphicsApi.VULKAN) {
-                                            VideoSettingsScreen s = (VideoSettingsScreen) Minecraft.getInstance().gui.screen();
+                                            Screen s = Minecraft.getInstance().gui.screen();
 
                                             Minecraft.getInstance().gui.setScreen(new ConfirmScreen(i -> {
                                                 if (i) {


### PR DESCRIPTION
Fixes a compatibility issue with mods that replace Sodium's video settings screen, such as Reese's Sodium Options.

When applying the Graphics API option, Iris stores the current screen by casting it to Sodium's concrete `VideoSettingsScreen`. If another mod replaces that screen, the cast throws a `ClassCastException` and the option never finishes applying/saving.

The saved screen only needs to be restored or closed, so it can be typed as Minecraft's base `Screen` instead.

Closes https://github.com/FlashyReese/reeses-sodium-options/issues/165
