### PR TITLE
virtual fluid volume api 1.21.1

### DIFF
--- a/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
@@ -3,6 +3,8 @@ package net.irisshaders.iris.api.v0;
 import java.nio.ByteBuffer;
 import java.util.function.IntFunction;
 
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidProvider;
+
 /**
  * The entry point to the Iris API, major version 0. This is currently the latest
  * version of the API.
@@ -23,7 +25,7 @@ public interface IrisApi {
 	 * if they wish to check whether given API calls are available on
 	 * the currently installed Iris version.
 	 *
-	 * @return The current minor revision. Currently, revision 2.
+	 * @return The current minor revision. Currently, revision 3.
 	 */
 	int getMinorApiRevision();
 
@@ -113,4 +115,22 @@ public interface IrisApi {
 	 * @since API v0.2
 	 */
 	float getSunPathRotation();
+
+	/**
+	 * Registers a provider for client-side virtual fluid volumes.
+	 *
+	 * <p>This is experimental API v0.3. It is intended for mods that render
+	 * fluid volumes without creating real chunk {@code FluidState}s, such as
+	 * tanks, vessels, and industrial machines.</p>
+	 *
+	 * @since API v0.3
+	 */
+	void registerVirtualFluidProvider(VirtualFluidProvider provider);
+
+	/**
+	 * Unregisters a previously registered virtual fluid provider.
+	 *
+	 * @since API v0.3
+	 */
+	void unregisterVirtualFluidProvider(VirtualFluidProvider provider);
 }

--- a/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidProvider.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidProvider.java
@@ -1,0 +1,15 @@
+package net.irisshaders.iris.api.v0.virtualfluid;
+
+/**
+ * Implemented by mods that expose virtual fluids to Iris.
+ */
+public interface VirtualFluidProvider {
+	/**
+	 * Called once per world frame before Iris renders translucent terrain.
+	 *
+	 * <p>The {@code level} and {@code camera} parameters are Objects to keep
+	 * the public API independent from loader-specific source sets. Implementors
+	 * can cast them to the Minecraft classes for the active runtime.</p>
+	 */
+	void collectVirtualFluids(Object level, Object camera, float tickDelta, VirtualFluidRegistry registry);
+}

--- a/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidRegistry.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidRegistry.java
@@ -1,0 +1,8 @@
+package net.irisshaders.iris.api.v0.virtualfluid;
+
+/**
+ * Per-frame sink for virtual fluid volumes.
+ */
+public interface VirtualFluidRegistry {
+	void register(VirtualFluidVolume volume);
+}

--- a/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidSurfaceConsumer.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidSurfaceConsumer.java
@@ -1,0 +1,15 @@
+package net.irisshaders.iris.api.v0.virtualfluid;
+
+/**
+ * Receives world-space quads for a virtual fluid surface.
+ */
+@FunctionalInterface
+public interface VirtualFluidSurfaceConsumer {
+	void acceptQuad(
+		double x0, double y0, double z0,
+		double x1, double y1, double z1,
+		double x2, double y2, double z2,
+		double x3, double y3, double z3,
+		float red, float green, float blue, float alpha
+	);
+}

--- a/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidType.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidType.java
@@ -1,0 +1,14 @@
+package net.irisshaders.iris.api.v0.virtualfluid;
+
+/**
+ * Describes the broad shader semantics a virtual fluid volume wants.
+ *
+ * <p>This intentionally does not describe a Minecraft {@code FluidState}. A
+ * virtual fluid can be backed by a block entity, tank renderer, multiblock, or
+ * another client-side structure that has no real chunk fluid state.</p>
+ */
+public enum VirtualFluidType {
+	WATER_LIKE,
+	LAVA_LIKE,
+	CUSTOM
+}

--- a/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidVisualProperties.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidVisualProperties.java
@@ -1,0 +1,41 @@
+package net.irisshaders.iris.api.v0.virtualfluid;
+
+/**
+ * Optional visual metadata for a virtual fluid volume.
+ *
+ * <p>Values are intentionally primitive so the API can stay stable across
+ * loader and Minecraft mapping changes.</p>
+ */
+public record VirtualFluidVisualProperties(
+	String fluidId,
+	int materialId,
+	float fogRed,
+	float fogGreen,
+	float fogBlue,
+	float fogDensity,
+	float tintRed,
+	float tintGreen,
+	float tintBlue,
+	float alpha,
+	float emissionRed,
+	float emissionGreen,
+	float emissionBlue,
+	float emissionStrength,
+	boolean useWaterCaustics,
+	boolean useWaterRefraction
+) {
+	public static VirtualFluidVisualProperties waterLike(String fluidId, int materialId) {
+		return new VirtualFluidVisualProperties(
+			fluidId,
+			materialId,
+			0.18F, 0.42F, 0.55F,
+			1.0F,
+			1.0F, 1.0F, 1.0F,
+			1.0F,
+			0.0F, 0.0F, 0.0F,
+			0.0F,
+			true,
+			true
+		);
+	}
+}

--- a/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidVolume.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/virtualfluid/VirtualFluidVolume.java
@@ -1,0 +1,52 @@
+package net.irisshaders.iris.api.v0.virtualfluid;
+
+/**
+ * A client-side fluid volume that should be treated by Iris as fluid-like
+ * without requiring a real chunk {@code FluidState}.
+ */
+public interface VirtualFluidVolume {
+	/**
+	 * Stable identifier for debugging and shader/mod attribution.
+	 */
+	String id();
+
+	VirtualFluidType type();
+
+	VirtualFluidVisualProperties visualProperties();
+
+	double minX();
+
+	double minY();
+
+	double minZ();
+
+	double maxX();
+
+	double maxY();
+
+	double maxZ();
+
+	/**
+	 * Returns whether this world-space point is inside the virtual fluid.
+	 */
+	boolean contains(double worldX, double worldY, double worldZ);
+
+	/**
+	 * Returns the water/lava surface height at a world-space X/Z column.
+	 */
+	double surfaceHeightAt(double worldX, double worldZ);
+
+	/**
+	 * Returns the fluid depth at a world-space X/Z column in blocks.
+	 */
+	double depthAt(double worldX, double worldZ);
+
+	/**
+	 * Emits the visible surface quads for this virtual fluid volume.
+	 *
+	 * <p>The first prototype consumes only simple world-space quads. This keeps
+	 * the public API independent from Minecraft renderer classes while still
+	 * allowing Iris to draw the surface in its own terrain/translucent pipeline.</p>
+	 */
+	void forEachSurfaceQuad(VirtualFluidSurfaceConsumer consumer);
+}

--- a/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
+++ b/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
@@ -4,11 +4,13 @@ import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.api.v0.IrisApi;
 import net.irisshaders.iris.api.v0.IrisApiConfig;
 import net.irisshaders.iris.api.v0.IrisTextVertexSink;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidProvider;
 import net.irisshaders.iris.gui.screen.ShaderPackScreen;
 import net.irisshaders.iris.pipeline.VanillaRenderingPipeline;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.shadows.ShadowRenderingState;
 import net.irisshaders.iris.vertices.IrisTextVertexSinkImpl;
+import net.irisshaders.iris.virtualfluid.VirtualFluidProviderRegistry;
 import net.minecraft.client.gui.screens.Screen;
 
 import java.nio.ByteBuffer;
@@ -20,7 +22,7 @@ public class IrisApiV0Impl implements IrisApi {
 
 	@Override
 	public int getMinorApiRevision() {
-		return 2;
+		return 3;
 	}
 
 	@Override
@@ -68,5 +70,15 @@ public class IrisApiV0Impl implements IrisApi {
 		}
 
 		return pipeline.getSunPathRotation();
+	}
+
+	@Override
+	public void registerVirtualFluidProvider(VirtualFluidProvider provider) {
+		VirtualFluidProviderRegistry.registerProvider(provider);
+	}
+
+	@Override
+	public void unregisterVirtualFluidProvider(VirtualFluidProvider provider) {
+		VirtualFluidProviderRegistry.unregisterProvider(provider);
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
@@ -15,6 +15,7 @@ import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.shadows.frustum.fallback.NonCullingFrustum;
 import net.irisshaders.iris.uniforms.CapturedRenderingState;
 import net.irisshaders.iris.uniforms.IrisTimeUniforms;
+import net.irisshaders.iris.virtualfluid.VirtualFluidProviderRegistry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
@@ -92,6 +93,7 @@ public class MixinLevelRenderer {
 		float fakeTickDelta = deltaTracker.getGameTimeDeltaPartialTick(false);
 		CapturedRenderingState.INSTANCE.setTickDelta(fakeTickDelta);
 		CapturedRenderingState.INSTANCE.setCloudTime((ticks + fakeTickDelta) * 0.03F);
+		VirtualFluidProviderRegistry.collect(this.minecraft.level, camera, fakeTickDelta);
 
 		pipeline = Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
 
@@ -146,6 +148,7 @@ public class MixinLevelRenderer {
 		if (Iris.shouldActivateWireframe() && this.minecraft.isLocalServer()) {
 			IrisRenderSystem.setPolygonMode(GL43C.GL_FILL);
 		}
+		VirtualFluidProviderRegistry.clearFrame();
 	}
 
 	// Setup shadow terrain & render shadows before the main terrain setup. We need to do things in this order to

--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisRenderingPipeline.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisRenderingPipeline.java
@@ -88,6 +88,7 @@ import net.irisshaders.iris.uniforms.CapturedRenderingState;
 import net.irisshaders.iris.uniforms.CommonUniforms;
 import net.irisshaders.iris.uniforms.FrameUpdateNotifier;
 import net.irisshaders.iris.uniforms.custom.CustomUniforms;
+import net.irisshaders.iris.virtualfluid.VirtualFluidRenderer;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.DimensionSpecialEffects;
@@ -1063,6 +1064,10 @@ public class IrisRenderingPipeline implements WorldRenderingPipeline, ShaderRend
 		// We need to copy the current depth texture so that depthtex1 can contain the depth values for
 		// all non-translucent content, as required.
 		renderTargets.copyPreTranslucentDepth();
+
+		setPhase(WorldRenderingPhase.TERRAIN_TRANSLUCENT);
+		VirtualFluidRenderer.renderBeforeDeferred();
+		setPhase(WorldRenderingPhase.NONE);
 
 		deferredRenderer.renderAll();
 

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/DebugVirtualFluidVolume.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/DebugVirtualFluidVolume.java
@@ -95,10 +95,10 @@ final class DebugVirtualFluidVolume implements VirtualFluidVolume {
 		
 		// Top Face
 		consumer.acceptQuad(
-			minX, maxY, minZ,
-			maxX, maxY, minZ,
-			maxX, maxY, maxZ,
 			minX, maxY, maxZ,
+			maxX, maxY, maxZ,
+			maxX, maxY, minZ,
+			minX, maxY, minZ,
 			r, g, b, a
 		);
 

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/DebugVirtualFluidVolume.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/DebugVirtualFluidVolume.java
@@ -91,12 +91,51 @@ final class DebugVirtualFluidVolume implements VirtualFluidVolume {
 
 	@Override
 	public void forEachSurfaceQuad(VirtualFluidSurfaceConsumer consumer) {
+		float r = 0.20F, g = 0.55F, b = 0.95F, a = 0.55F;
+		
+		// Top Face
 		consumer.acceptQuad(
 			minX, maxY, minZ,
 			maxX, maxY, minZ,
 			maxX, maxY, maxZ,
 			minX, maxY, maxZ,
-			0.20F, 0.55F, 0.95F, 0.55F
+			r, g, b, a
+		);
+
+		// South Face (+Z)
+		consumer.acceptQuad(
+			minX, minY, maxZ,
+			maxX, minY, maxZ,
+			maxX, maxY, maxZ,
+			minX, maxY, maxZ,
+			r, g, b, a
+		);
+
+		// North Face (-Z)
+		consumer.acceptQuad(
+			maxX, minY, minZ,
+			minX, minY, minZ,
+			minX, maxY, minZ,
+			maxX, maxY, minZ,
+			r, g, b, a
+		);
+
+		// East Face (+X)
+		consumer.acceptQuad(
+			maxX, minY, maxZ,
+			maxX, minY, minZ,
+			maxX, maxY, minZ,
+			maxX, maxY, maxZ,
+			r, g, b, a
+		);
+
+		// West Face (-X)
+		consumer.acceptQuad(
+			minX, minY, minZ,
+			minX, minY, maxZ,
+			minX, maxY, maxZ,
+			minX, maxY, minZ,
+			r, g, b, a
 		);
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/DebugVirtualFluidVolume.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/DebugVirtualFluidVolume.java
@@ -1,0 +1,102 @@
+package net.irisshaders.iris.virtualfluid;
+
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidSurfaceConsumer;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidType;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidVisualProperties;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidVolume;
+
+final class DebugVirtualFluidVolume implements VirtualFluidVolume {
+	private final double minX;
+	private final double minY;
+	private final double minZ;
+	private final double maxX;
+	private final double maxY;
+	private final double maxZ;
+	private final VirtualFluidVisualProperties properties;
+
+	DebugVirtualFluidVolume(double centerX, double centerY, double centerZ, int materialId) {
+		this.minX = centerX - 2.0D;
+		this.minY = centerY - 1.0D;
+		this.minZ = centerZ - 2.0D;
+		this.maxX = centerX + 2.0D;
+		this.maxY = centerY;
+		this.maxZ = centerZ + 2.0D;
+		this.properties = VirtualFluidVisualProperties.waterLike("iris:debug_virtual_water", materialId);
+	}
+
+	@Override
+	public String id() {
+		return "iris:debug_virtual_water";
+	}
+
+	@Override
+	public VirtualFluidType type() {
+		return VirtualFluidType.WATER_LIKE;
+	}
+
+	@Override
+	public VirtualFluidVisualProperties visualProperties() {
+		return properties;
+	}
+
+	@Override
+	public double minX() {
+		return minX;
+	}
+
+	@Override
+	public double minY() {
+		return minY;
+	}
+
+	@Override
+	public double minZ() {
+		return minZ;
+	}
+
+	@Override
+	public double maxX() {
+		return maxX;
+	}
+
+	@Override
+	public double maxY() {
+		return maxY;
+	}
+
+	@Override
+	public double maxZ() {
+		return maxZ;
+	}
+
+	@Override
+	public boolean contains(double worldX, double worldY, double worldZ) {
+		return worldX >= minX && worldX <= maxX
+			&& worldY >= minY && worldY <= maxY
+			&& worldZ >= minZ && worldZ <= maxZ;
+	}
+
+	@Override
+	public double surfaceHeightAt(double worldX, double worldZ) {
+		return maxY;
+	}
+
+	@Override
+	public double depthAt(double worldX, double worldZ) {
+		if (worldX < minX || worldX > maxX || worldZ < minZ || worldZ > maxZ) {
+			return 0.0D;
+		}
+		return maxY - minY;
+	}
+
+	@Override
+	public void forEachSurfaceQuad(VirtualFluidSurfaceConsumer consumer) {
+		consumer.acceptQuad(
+			minX, maxY, minZ,
+			maxX, maxY, minZ,
+			maxX, maxY, maxZ,
+			minX, maxY, maxZ,
+			0.20F, 0.55F, 0.95F, 0.55F
+		);
+	}
+}

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidProviderRegistry.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidProviderRegistry.java
@@ -1,0 +1,70 @@
+package net.irisshaders.iris.virtualfluid;
+
+import net.irisshaders.iris.Iris;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidProvider;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidRegistry;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidVolume;
+import net.minecraft.client.Camera;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public final class VirtualFluidProviderRegistry {
+	private static final CopyOnWriteArrayList<VirtualFluidProvider> PROVIDERS = new CopyOnWriteArrayList<>();
+	private static final ArrayList<VirtualFluidVolume> FRAME_VOLUMES = new ArrayList<>();
+	private static final VirtualFluidRegistry FRAME_REGISTRY = volume -> {
+		if (volume != null) {
+			FRAME_VOLUMES.add(volume);
+		}
+	};
+	private static final boolean DEBUG_VOLUME_ENABLED = Boolean.getBoolean("iris.debugVirtualFluid");
+	private static final int DEBUG_VOLUME_MATERIAL_ID = Integer.getInteger("iris.debugVirtualFluid.materialId", 8);
+
+	private VirtualFluidProviderRegistry() {
+	}
+
+	public static void registerProvider(VirtualFluidProvider provider) {
+		PROVIDERS.addIfAbsent(Objects.requireNonNull(provider, "provider"));
+	}
+
+	public static void unregisterProvider(VirtualFluidProvider provider) {
+		PROVIDERS.remove(provider);
+	}
+
+	public static void collect(Object level, Object camera, float tickDelta) {
+		FRAME_VOLUMES.clear();
+		collectDebugVolume(camera);
+		for (VirtualFluidProvider provider : PROVIDERS) {
+			try {
+				provider.collectVirtualFluids(level, camera, tickDelta, FRAME_REGISTRY);
+			} catch (RuntimeException e) {
+				Iris.logger.warn("Virtual fluid provider failed during collection: " + provider.getClass().getName(), e);
+			}
+		}
+	}
+
+	private static void collectDebugVolume(Object camera) {
+		if (!DEBUG_VOLUME_ENABLED || !(camera instanceof Camera minecraftCamera)) {
+			return;
+		}
+
+		Vec3 pos = minecraftCamera.getPosition();
+		FRAME_VOLUMES.add(new DebugVirtualFluidVolume(
+			pos.x + minecraftCamera.getLookVector().x * 5.0D,
+			pos.y - 1.0D,
+			pos.z + minecraftCamera.getLookVector().z * 5.0D,
+			DEBUG_VOLUME_MATERIAL_ID
+		));
+	}
+
+	public static List<VirtualFluidVolume> currentFrameVolumes() {
+		return List.copyOf(FRAME_VOLUMES);
+	}
+
+	public static void clearFrame() {
+		FRAME_VOLUMES.clear();
+	}
+}

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidRenderer.java
@@ -2,6 +2,8 @@ package net.irisshaders.iris.virtualfluid;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
 import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidType;
 import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidVolume;
 import net.irisshaders.iris.vertices.BlockSensitiveBufferBuilder;
@@ -32,7 +34,7 @@ public final class VirtualFluidRenderer {
 		}
 
 		MultiBufferSource.BufferSource buffer = minecraft.renderBuffers().bufferSource();
-		RenderType renderType = RenderType.translucent();
+		RenderType renderType = CustomRenderType.VIRTUAL_FLUID;
 		VertexConsumer consumer = buffer.getBuffer(renderType);
 		Vec3 camera = minecraft.gameRenderer.getMainCamera().getPosition();
 		PoseStack poseStack = new PoseStack();
@@ -44,7 +46,7 @@ public final class VirtualFluidRenderer {
 			if (volume.type() != VirtualFluidType.WATER_LIKE && volume.type() != VirtualFluidType.LAVA_LIKE) {
 				continue;
 			}
-			int materialId = volume.visualProperties().materialId();
+			int materialId = volume.type() == VirtualFluidType.WATER_LIKE ? 8 : volume.visualProperties().materialId();
 			volume.forEachSurfaceQuad((x0, y0, z0, x1, y1, z1, x2, y2, z2, x3, y3, z3, red, green, blue, alpha) -> {
 				tryBeginFluidBlock(consumer, materialId, x0, y0, z0);
 				Vector3f normal = computeNormal(x0, y0, z0, x1, y1, z1, x2, y2, z2);
@@ -95,5 +97,27 @@ public final class VirtualFluidRenderer {
 			return new Vector3f(0.0F, 1.0F, 0.0F);
 		}
 		return normal.normalize();
+	}
+
+	private static class CustomRenderType extends RenderType {
+		private CustomRenderType(String string, VertexFormat vertexFormat, VertexFormat.Mode mode, int i, boolean bl, boolean bl2, Runnable runnable, Runnable runnable2) {
+			super(string, vertexFormat, mode, i, bl, bl2, runnable, runnable2);
+		}
+
+		public static final RenderType VIRTUAL_FLUID = create(
+			"iris_virtual_fluid",
+			DefaultVertexFormat.BLOCK,
+			VertexFormat.Mode.QUADS,
+			1536,
+			true,
+			true,
+			RenderType.CompositeState.builder()
+				.setLightmapState(LIGHTMAP)
+				.setShaderState(RENDERTYPE_TRANSLUCENT_SHADER)
+				.setTextureState(BLOCK_SHEET)
+				.setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+				.setWriteMaskState(COLOR_DEPTH_WRITE)
+				.createCompositeState(true)
+		);
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidRenderer.java
@@ -1,0 +1,99 @@
+package net.irisshaders.iris.virtualfluid;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidType;
+import net.irisshaders.iris.api.v0.virtualfluid.VirtualFluidVolume;
+import net.irisshaders.iris.vertices.BlockSensitiveBufferBuilder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Vector3f;
+
+public final class VirtualFluidRenderer {
+	private static final byte FLUID_RENDER_TYPE = 1;
+	private static final byte NO_EMISSION = 0;
+	private static final int FULL_BRIGHT = 0xF000F0;
+
+	private VirtualFluidRenderer() {
+	}
+
+	public static void renderBeforeDeferred() {
+		if (VirtualFluidProviderRegistry.currentFrameVolumes().isEmpty()) {
+			return;
+		}
+
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft.level == null) {
+			return;
+		}
+
+		MultiBufferSource.BufferSource buffer = minecraft.renderBuffers().bufferSource();
+		RenderType renderType = RenderType.translucent();
+		VertexConsumer consumer = buffer.getBuffer(renderType);
+		Vec3 camera = minecraft.gameRenderer.getMainCamera().getPosition();
+		PoseStack poseStack = new PoseStack();
+		poseStack.translate(-camera.x, -camera.y, -camera.z);
+		PoseStack.Pose pose = poseStack.last();
+
+		boolean rendered = false;
+		for (VirtualFluidVolume volume : VirtualFluidProviderRegistry.currentFrameVolumes()) {
+			if (volume.type() != VirtualFluidType.WATER_LIKE && volume.type() != VirtualFluidType.LAVA_LIKE) {
+				continue;
+			}
+			int materialId = volume.visualProperties().materialId();
+			volume.forEachSurfaceQuad((x0, y0, z0, x1, y1, z1, x2, y2, z2, x3, y3, z3, red, green, blue, alpha) -> {
+				tryBeginFluidBlock(consumer, materialId, x0, y0, z0);
+				Vector3f normal = computeNormal(x0, y0, z0, x1, y1, z1, x2, y2, z2);
+				addVertex(consumer, pose, x0, y0, z0, red, green, blue, alpha, 0.0F, 0.0F, normal);
+				addVertex(consumer, pose, x1, y1, z1, red, green, blue, alpha, 1.0F, 0.0F, normal);
+				addVertex(consumer, pose, x2, y2, z2, red, green, blue, alpha, 1.0F, 1.0F, normal);
+				addVertex(consumer, pose, x3, y3, z3, red, green, blue, alpha, 0.0F, 1.0F, normal);
+				tryEndFluidBlock(consumer);
+			});
+			rendered = true;
+		}
+
+		if (rendered) {
+			buffer.endBatch(renderType);
+		}
+	}
+
+	private static void tryBeginFluidBlock(VertexConsumer consumer, int materialId, double x, double y, double z) {
+		if (consumer instanceof BlockSensitiveBufferBuilder blockSensitive) {
+			BlockPos pos = BlockPos.containing(x, y, z);
+			blockSensitive.beginBlock(materialId, FLUID_RENDER_TYPE, NO_EMISSION, pos.getX(), pos.getY(), pos.getZ());
+		}
+	}
+
+	private static void tryEndFluidBlock(VertexConsumer consumer) {
+		if (consumer instanceof BlockSensitiveBufferBuilder blockSensitive) {
+			blockSensitive.endBlock();
+		}
+	}
+
+	private static void addVertex(VertexConsumer consumer, PoseStack.Pose pose, double x, double y, double z,
+								  float red, float green, float blue, float alpha, float u, float v, Vector3f normal) {
+		consumer.addVertex(pose, (float) x, (float) y, (float) z)
+			.setColor(red, green, blue, alpha)
+			.setUv(u, v)
+			.setOverlay(OverlayTexture.NO_OVERLAY)
+			.setLight(FULL_BRIGHT)
+			.setNormal(pose, normal.x(), normal.y(), normal.z());
+	}
+
+	private static Vector3f computeNormal(double x0, double y0, double z0,
+										 double x1, double y1, double z1,
+										 double x2, double y2, double z2) {
+		Vector3f a = new Vector3f((float) (x1 - x0), (float) (y1 - y0), (float) (z1 - z0));
+		Vector3f b = new Vector3f((float) (x2 - x0), (float) (y2 - y0), (float) (z2 - z0));
+		Vector3f normal = a.cross(b, new Vector3f());
+		if (normal.lengthSquared() <= 1.0E-6F) {
+			return new Vector3f(0.0F, 1.0F, 0.0F);
+		}
+		return normal.normalize();
+	}
+}

--- a/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/virtualfluid/VirtualFluidRenderer.java
@@ -46,7 +46,7 @@ public final class VirtualFluidRenderer {
 			if (volume.type() != VirtualFluidType.WATER_LIKE && volume.type() != VirtualFluidType.LAVA_LIKE) {
 				continue;
 			}
-			int materialId = volume.type() == VirtualFluidType.WATER_LIKE ? 8 : volume.visualProperties().materialId();
+			int materialId = volume.visualProperties().materialId();
 			volume.forEachSurfaceQuad((x0, y0, z0, x1, y1, z1, x2, y2, z2, x3, y3, z3, red, green, blue, alpha) -> {
 				tryBeginFluidBlock(consumer, materialId, x0, y0, z0);
 				Vector3f normal = computeNormal(x0, y0, z0, x1, y1, z1, x2, y2, z2);


### PR DESCRIPTION
### Description
Currently, when mods (like the Create mod) render custom multiblock fluid tanks, they often bypass the standard block fluid rendering pipeline. This causes issues with modern shader packs that rely on accurate fluid boundaries to render volumetric underwater fog and calculate depth correctly. Often, this leads to the "white world" bug or completely invisible water surfaces.

This PR introduces the **Virtual Fluid Volume API** to solve this. It provides a way for mod developers to explicitly register custom, non-block-aligned fluid boundaries directly into Iris's rendering pipeline.

### Changes Made
* Added `VirtualFluidRegistry` and `VirtualFluidProvider` to allow mods to register callbacks for dynamic virtual fluid generation.
* Created the `VirtualFluidVolume` interface, allowing mods to define the geometry (quads), color, texture, and light properties of their fluid boundaries.
* Updated `VirtualFluidRenderer` to process and dispatch these registered virtual fluids during the translucent rendering phase.
* Ensured correct depth writes and shader uniform bindings (e.g., volumetric fog support) for virtual fluids.
* Added `DebugVirtualFluidVolume` built-in implementation. You can test it by launching the game with `-Diris.debugVirtualFluid=true`.

### Usage Example (Attached)
I am attaching a sample mod [CreateWatertanktest.zip](https://github.com/user-attachments/files/29272157/CreateWatertanktest.zip) that serves as a proof of concept. It uses a Mixin to cancel the default Create Mod fluid tank rendering and instead passes the tank's water coordinates directly to the new `VirtualFluidRegistry`.
When using a shader like Bliss Shaders, the water inside the tank is rendered flawlessly, including underwater volumetric fog and correct face culling, completely bypassing the visual glitches previously caused by forced buffer batches.

### Testing
* Verified that the debug virtual fluid renders correctly on all faces with proper culling.
* Verified that modded fluid rendering via the API correctly triggers volume
tric fog in shader packs without breaking the rendering state of the world.