### PR TITLE
Fix core profile shaders and `renderStage` for lines in 26.2

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
@@ -8,14 +8,10 @@ import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
 import com.mojang.blaze3d.framegraph.FramePass;
 import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
-import com.mojang.blaze3d.resource.ResourceHandle;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTexture;
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Axis;
-import net.caffeinemc.mods.sodium.client.util.FogParameters;
 import net.caffeinemc.mods.sodium.client.util.GameRendererStorage;
 import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.MojLambdas;
@@ -29,36 +25,25 @@ import net.irisshaders.iris.pathways.HandRenderer;
 import net.irisshaders.iris.pipeline.IrisRenderingPipeline;
 import net.irisshaders.iris.pipeline.WorldRenderingPhase;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
-import net.irisshaders.iris.shadows.frustum.fallback.NonCullingFrustum;
 import net.irisshaders.iris.uniforms.CapturedRenderingState;
 import net.irisshaders.iris.uniforms.IrisTimeUniforms;
-import net.irisshaders.iris.uniforms.SystemTimeUniforms;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Camera;
-import net.minecraft.client.CloudStatus;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.CloudRenderer;
-import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LevelTargetBundle;
 import net.minecraft.client.renderer.RenderBuffers;
-import net.minecraft.client.renderer.rendertype.RenderType;
-import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.profiling.Profiler;
-import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.TickRateManager;
-import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector4f;
-import org.jspecify.annotations.Nullable;
 import org.lwjgl.opengl.GL43C;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -67,10 +52,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer {
@@ -268,9 +250,7 @@ public abstract class MixinLevelRenderer {
 		pipeline.setPhase(WorldRenderingPhase.NONE);
 	}
 
-	// TODO 26.2
-	//@ModifyArg(method = "submitBlockOutline",
-	//	at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;getBuffer(Lnet/minecraft/client/renderer/rendertype/RenderType;)Lcom/mojang/blaze3d/vertex/VertexConsumer;"))
+	@ModifyArg(method = "submitBlockOutline", index = 2,at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;submitHitOutline(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/state/level/BlockOutlineRenderState;IFZ)V"))
 	private RenderType iris$beginBlockOutline(RenderType type) {
 		return new OuterWrappedRenderType("iris:is_outline", type, IsOutlineRenderStateShard.INSTANCE);
 	}

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
@@ -24,7 +24,6 @@ public class SodiumCoreTransformer {
 		Root root,
 		SodiumParameters parameters) {
 		root.rename("alphaTestRef", "iris_currentAlphaTest");
-//		root.replaceExpressionMatches(t, modelViewMatrix, "");
 		root.processMatches(t, modelViewMatrix, ASTNode::detachAndDelete);
 		root.rename("modelViewMatrix", "u_ModelViewMatrix");
 		root.rename("modelViewMatrixInverse", "iris_ModelViewMatrixInverse");

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
@@ -1,23 +1,37 @@
 package net.irisshaders.iris.pipeline.transform.transformer;
 
 import io.github.douira.glsl_transformer.ast.node.TranslationUnit;
+import io.github.douira.glsl_transformer.ast.node.abstract_node.ASTNode;
+import io.github.douira.glsl_transformer.ast.node.expression.Expression;
+import io.github.douira.glsl_transformer.ast.node.external_declaration.ExternalDeclaration;
 import io.github.douira.glsl_transformer.ast.query.Root;
+import io.github.douira.glsl_transformer.ast.query.match.AutoHintedMatcher;
+import io.github.douira.glsl_transformer.ast.query.match.Matcher;
+import io.github.douira.glsl_transformer.ast.transform.ASTInjectionPoint;
 import io.github.douira.glsl_transformer.ast.transform.ASTParser;
+import io.github.douira.glsl_transformer.parser.ParseShape;
 import net.irisshaders.iris.pipeline.transform.PatchShaderType;
 import net.irisshaders.iris.pipeline.transform.parameter.SodiumParameters;
 
 public class SodiumCoreTransformer {
+	public static final AutoHintedMatcher<ExternalDeclaration> modelViewMatrix = new AutoHintedMatcher<>(
+		"uniform mat4 modelViewMatrix;", ParseShape.EXTERNAL_DECLARATION);
+	public static final AutoHintedMatcher<ExternalDeclaration> projectionMatrix = new AutoHintedMatcher<>(
+		"uniform mat4 projectionMatrix;", ParseShape.EXTERNAL_DECLARATION);
 	public static void transform(
 		ASTParser t,
 		TranslationUnit tree,
 		Root root,
 		SodiumParameters parameters) {
 		root.rename("alphaTestRef", "iris_currentAlphaTest");
-		root.rename("modelViewMatrix", "iris_ModelViewMatrix");
+//		root.replaceExpressionMatches(t, modelViewMatrix, "");
+		root.processMatches(t, modelViewMatrix, ASTNode::detachAndDelete);
+		root.rename("modelViewMatrix", "u_ModelViewMatrix");
 		root.rename("modelViewMatrixInverse", "iris_ModelViewMatrixInverse");
-		root.rename("projectionMatrix", "iris_ProjectionMatrix");
+		root.processMatches(t, projectionMatrix, ASTNode::detachAndDelete);
+		root.rename("projectionMatrix", "u_ProjectionMatrix");
 		root.rename("projectionMatrixInverse", "iris_ProjectionMatrixInverse");
-		root.rename("normalMatrix", "iris_NormalMatrix");
+		root.rename("normalMatrix", "iris_NormalMat");
 		root.rename("chunkOffset", "u_RegionOffset");
 		if (parameters.type == PatchShaderType.VERTEX) {
 			boolean needsNormal = root.identifierIndex.has("vaNormal") || root.identifierIndex.has("at_tangent");
@@ -38,5 +52,21 @@ public class SodiumCoreTransformer {
 
 			SodiumTransformer.injectVertInit(t, tree, root, parameters, needsNormal);
 		}
+
+        tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS, """
+            layout(std140) uniform u_Globals {
+                mat4 u_ProjectionMatrix;
+                mat4 u_ModelViewMatrix;
+
+                vec4 u_FogColor;
+                vec2 u_EnvironmentFog;
+                vec2 u_RenderFog;
+
+                vec2 u_TexelSize;
+                vec2 u_TexCoordShrink;
+
+                float u_FadePeriodInv;
+                bool u_UseRGSS;
+            };""");
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
@@ -89,6 +89,7 @@ public class SodiumTransformer {
 			tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
 
 				// _draw_translation replaced with Chunks[_draw_id].offset.xyz
+				"uniform vec3 u_RegionOffset;",
 				"vec4 getVertexPosition() { return vec4(_vert_position + u_RegionOffset + _get_draw_translation(_draw_id), 1.0); }");
 			root.replaceReferenceExpressions(t, "gl_Vertex", "getVertexPosition()");
 
@@ -103,14 +104,14 @@ public class SodiumTransformer {
                         layout(std140) uniform u_Globals {
                               mat4 u_ProjectionMatrix;
                               mat4 u_ModelViewMatrix;
-                        
+
                               vec4 u_FogColor;
                               vec2 u_EnvironmentFog;
                               vec2 u_RenderFog;
-                        
+
                               vec2 u_TexelSize;
                               vec2 u_TexCoordShrink;
-                        
+
                               float u_FadePeriodInv;
                               bool u_UseRGSS;
                           };""");
@@ -134,7 +135,6 @@ public class SodiumTransformer {
 				"mc_chunkFade = (chunkFade < 0) ? 1.0 : fade;";
 
 		tree.parseAndInjectNodes(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
-                "uniform vec3 u_RegionOffset;",
                 "uniform int u_CurrentTime;",
                 "uniform uint u_RegionID;",
 			// translated from sodium's chunk_vertex.glsl


### PR DESCRIPTION
Current `iris-fabric-1.11.1+mc26.2` cannot load core profile terrain shaders, because it will replace `chunkOffset` with `u_RegionOffset`, while still add another `uniform vec3 u_RegionOffset;` in `injectVertInit()`, but forgetting to add `layout(std140) uniform u_Globals` which contains `u_FadePeriodInv` that will be used in later code.

By moving additional `uniform vec3 u_RegionOffset;` to conpatibility profile code, there should be no re-declaration of `u_RegionOffset`; and by adding `layout(std140) uniform u_Globals`, `u_FadePeriodInv` no longer considered as undefined variable in patched core profile terrain shader.

Model view matrix and projection matrix are also changed to correct values in `layout(std140) uniform u_Globals` by removing current declaration of `modelViewMatrix` and `projectionMatrix`, and replace rest reference with `u_ModelViewMatrix` and `u_ProjectionMatrix`.

Normal matrix is corrected to the same name in compatibility profile patcher.

Done the missing outline rendering marker to fix `renderStage` when rendering lines.