### PR TITLE
Add custom uniform block (ChunkFix) passthrough API (#2974)

### DIFF
--- a/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
@@ -122,4 +122,39 @@ public interface IrisApi {
 	 * @since API v0.3
 	 */
 	void assignPipeline(RenderPipeline pipeline, IrisProgram program);
+
+	/**
+	 * Registers a custom std140 uniform block (UBO) that a mod binds to its own
+	 * {@code RenderPass} via {@code RenderPass.setUniform(blockName, buffer)}, so that
+	 * Iris forwards it to the program it substitutes for the given pipeline when a
+	 * shader pack is active.
+	 *
+	 * <p>Without this, when Iris substitutes its own program for a mod's terrain
+	 * pipeline (see {@link #assignPipeline}), the mod's custom uniform block is
+	 * silently dropped, because Iris's substituted program only declares Iris's own
+	 * uniform blocks. This is the mechanism requested by IrisShaders/Iris#2974 for
+	 * MaLiLib/Litematica's {@code ChunkFix} block.
+	 *
+	 * <p>The mod must:
+	 * <ol>
+	 *     <li>have already assigned the pipeline via {@link #assignPipeline};</li>
+	 *     <li>bind the block to its render pass each draw via
+	 *     {@code RenderPass.setUniform(blockName, gpuBuffer)}; and</li>
+	 *     <li>pass the exact std140 GLSL declaration of the block, so Iris can inject
+	 *     it into the substituted program's source (the mod cannot, since Iris
+	 *     generates that program from the active shader pack).</li>
+	 * </ol>
+	 *
+	 * <p>The binding is <em>optional at draw time</em>: Iris only binds the buffer for
+	 * draws that actually supply it on the pass, so unrelated draws that share the same
+	 * substituted program (e.g. vanilla terrain) are unaffected.
+	 *
+	 * @param pipeline        The mod render pipeline previously passed to {@link #assignPipeline}.
+	 * @param blockName       The std140 uniform block name (e.g. {@code "ChunkFix"}), matching the
+	 *                        name used in {@code RenderPass.setUniform} and in {@code glslDeclaration}.
+	 * @param glslDeclaration The full GLSL declaration of the block, e.g.
+	 *                        {@code "layout(std140) uniform ChunkFix { ivec2 TextureSize; float ChunkVisibility; int UseRgss; int hasShadersOn; };"}.
+	 * @since API v0.4
+	 */
+	void registerCustomUniformBlock(RenderPipeline pipeline, String blockName, String glslDeclaration);
 }

--- a/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
+++ b/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
@@ -25,7 +25,7 @@ public class IrisApiV0Impl implements IrisApi {
 
 	@Override
 	public int getMinorApiRevision() {
-		return 3;
+		return 4;
 	}
 
 	@Override
@@ -78,5 +78,10 @@ public class IrisApiV0Impl implements IrisApi {
 	@Override
 	public void assignPipeline(RenderPipeline pipeline, IrisProgram program) {
 		IrisPipelines.assignPipeline(pipeline, ShaderKey.findBestMatch(pipeline, ProgramId.fromAPI(program)));
+	}
+
+	@Override
+	public void registerCustomUniformBlock(RenderPipeline pipeline, String blockName, String glslDeclaration) {
+		IrisPipelines.registerCustomUniformBlock(pipeline, blockName, glslDeclaration);
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/gl/IrisRenderSystem.java
+++ b/common/src/main/java/net/irisshaders/iris/gl/IrisRenderSystem.java
@@ -257,6 +257,11 @@ public class IrisRenderSystem {
 		GL43C.glBindBufferBase(target, index, buffer);
 	}
 
+	public static void bindBufferRange(int target, int index, int buffer, long offset, long size) {
+		RenderSystem.assertOnRenderThread();
+		org.lwjgl.opengl.GL30C.glBindBufferRange(target, index, buffer, offset, size);
+	}
+
 	public static void vertexAttrib4f(int index, float v0, float v1, float v2, float v3) {
 		RenderSystem.assertOnRenderThread();
 		GL32C.glVertexAttrib4f(index, v0, v1, v2, v3);

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinGlCommandEncoder.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinGlCommandEncoder.java
@@ -196,6 +196,9 @@ public class MixinGlCommandEncoder {
 				irp.onSetAlbedoTex(sam.view());
 			}
 			is.iris$setupState(glRenderPass.samplers, sam == null ? null : sam.view());
+			// IrisShaders/Iris#2974: forward any mod-registered custom uniform blocks (e.g. ChunkFix)
+			// that this render pass supplies to the substituted program.
+			is.iris$bindCustomUniformBlocks(glRenderPass.uniforms);
 			programsToClear.add(is);
 		}
 	}

--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
@@ -12,7 +12,11 @@ import net.irisshaders.iris.shadows.ShadowRenderingState;
 import net.minecraft.client.renderer.RenderPipelines;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static net.irisshaders.iris.pipeline.programs.ShaderOverrides.isBlockEntities;
 
@@ -20,6 +24,19 @@ public class IrisPipelines {
 	private static final Map<RenderPipeline, Function<IrisRenderingPipeline, ShaderKey>> coreShaderMap = new Object2ObjectArrayMap<>();
 	private static final Map<RenderPipeline, Function<IrisRenderingPipeline, ShaderKey>> coreShaderMapShadow = new Object2ObjectArrayMap<>();
 	private static final Function<IrisRenderingPipeline, ShaderKey> FAKE_FUNCTION = p -> null;
+
+	/**
+	 * Custom mod-provided std140 uniform blocks (see IrisShaders/Iris#2974), keyed by the Iris
+	 * {@link ShaderKey} that the mod's pipeline resolves to, so that {@code ShaderCreator} can
+	 * inject their GLSL declarations into the substituted program's source.
+	 */
+	private static final Map<ShaderKey, List<CustomUniformBlock>> customUniformBlocks = new Object2ObjectArrayMap<>();
+	/** Flat set of all registered custom block names, for the per-draw binding fast path. */
+	private static final Set<String> customUniformBlockNames = new HashSet<>();
+
+	/** A mod-registered custom uniform block: its GLSL name and full std140 declaration. */
+	public record CustomUniformBlock(String name, String glslDeclaration) {
+	}
 
 	static {
 		assignToMain(RenderPipelines.SOLID_BLOCK, p -> ShaderKey.TERRAIN_SOLID);
@@ -243,6 +260,41 @@ public class IrisPipelines {
 		} else {
 			coreShaderMap.put(pipeline, p -> programId);
 		}
+	}
+
+	/**
+	 * Registers a mod-provided custom uniform block for the substituted program of the given
+	 * pipeline. See {@link net.irisshaders.iris.api.v0.IrisApi#registerCustomUniformBlock}.
+	 */
+	public static void registerCustomUniformBlock(RenderPipeline pipeline, String blockName, String glslDeclaration) {
+		Function<IrisRenderingPipeline, ShaderKey> fn = coreShaderMap.get(pipeline);
+		if (fn == null) {
+			Iris.logger.warn("registerCustomUniformBlock: pipeline " + pipeline.getLocation()
+				+ " was not assigned via assignPipeline; ignoring custom block '" + blockName + "'.");
+			return;
+		}
+		ShaderKey key = fn.apply(null);
+		if (key == null) {
+			// The pipeline resolves to no substituted program (e.g. IrisProgram.TERRAIN), so Iris
+			// keeps the mod's own program, which binds the block itself. Nothing to forward.
+			Iris.logger.info("registerCustomUniformBlock: pipeline " + pipeline.getLocation()
+				+ " is not substituted by Iris; custom block '" + blockName + "' is left to the mod's own program.");
+			return;
+		}
+		customUniformBlocks.computeIfAbsent(key, k -> new ArrayList<>()).add(new CustomUniformBlock(blockName, glslDeclaration));
+		customUniformBlockNames.add(blockName);
+		Iris.logger.info("Registered custom uniform block '" + blockName + "' for ShaderKey " + key
+			+ " (pipeline " + pipeline.getLocation() + ").");
+	}
+
+	/** The custom uniform blocks whose GLSL declarations must be injected into this key's program. */
+	public static List<CustomUniformBlock> getCustomUniformBlocks(ShaderKey key) {
+		return customUniformBlocks.getOrDefault(key, List.of());
+	}
+
+	/** All registered custom block names, for the per-draw optional-binding fast path. */
+	public static Set<String> getCustomUniformBlockNames() {
+		return customUniformBlockNames;
 	}
 
 	public static void copyPipeline(RenderPipeline pipelineToCopy, RenderPipeline returnValue) {

--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/ExtendedShader.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/ExtendedShader.java
@@ -1,5 +1,7 @@
 package net.irisshaders.iris.pipeline.programs;
 
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.opengl.GlBuffer;
 import com.mojang.blaze3d.opengl.GlProgram;
 import com.mojang.blaze3d.opengl.GlRenderPass;
 import com.mojang.blaze3d.opengl.GlStateManager;
@@ -29,6 +31,7 @@ import net.irisshaders.iris.gl.sampler.SamplerHolder;
 import net.irisshaders.iris.gl.texture.TextureType;
 import net.irisshaders.iris.gl.uniform.DynamicLocationalUniformHolder;
 import net.irisshaders.iris.mixinterface.ShaderInstanceInterface;
+import net.irisshaders.iris.pipeline.IrisPipelines;
 import net.irisshaders.iris.pipeline.IrisRenderingPipeline;
 import net.irisshaders.iris.pipeline.transform.Patch;
 import net.irisshaders.iris.samplers.IrisSamplers;
@@ -276,5 +279,39 @@ public class ExtendedShader extends GlProgram implements IrisProgram {
 	@Override
 	public boolean iris$isSetUp() {
 		return isSetup;
+	}
+
+	// Binding points 0..~7 are used by Iris's own uniform blocks (dynamic transforms, projection,
+	// fog, globals, ...); start mod-provided custom blocks well clear of those.
+	private static final int CUSTOM_UBO_BINDING_BASE = 12;
+
+	@Override
+	public void iris$bindCustomUniformBlocks(Map<String, GpuBufferSlice> passUniforms) {
+		java.util.Set<String> names = IrisPipelines.getCustomUniformBlockNames();
+		if (names.isEmpty() || passUniforms.isEmpty()) {
+			return;
+		}
+
+		int bindingPoint = CUSTOM_UBO_BINDING_BASE;
+		for (String name : names) {
+			GpuBufferSlice slice = passUniforms.get(name);
+			// Optional by design: only bind blocks this draw actually supplies. Vanilla terrain draws
+			// share this program but never setUniform("ChunkFix", ...), so they are left untouched.
+			if (slice == null || !(slice.buffer() instanceof GlBuffer glBuffer)) {
+				continue;
+			}
+
+			// The block only exists if it was injected into this program's source (i.e. it was
+			// registered for this ShaderKey). If not present, glGetUniformBlockIndex returns
+			// GL_INVALID_INDEX and we safely skip.
+			int blockIndex = GL46C.glGetUniformBlockIndex(getProgramId(), name);
+			if (blockIndex == GL46C.GL_INVALID_INDEX) {
+				continue;
+			}
+
+			IrisRenderSystem.uniformBlockBinding(getProgramId(), blockIndex, bindingPoint);
+			IrisRenderSystem.bindBufferRange(GL46C.GL_UNIFORM_BUFFER, bindingPoint, glBuffer.handle(), slice.offset(), slice.length());
+			bindingPoint++;
+		}
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/IrisProgram.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/IrisProgram.java
@@ -1,9 +1,11 @@
 package net.irisshaders.iris.pipeline.programs;
 
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.opengl.GlRenderPass;
 import com.mojang.blaze3d.textures.GpuTextureView;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public interface IrisProgram {
 	void iris$setupState(HashMap<String, GlRenderPass.TextureViewAndSampler> samplers, GpuTextureView albedoTex);
@@ -13,4 +15,13 @@ public interface IrisProgram {
 	int iris$getBlockIndex(int program, CharSequence uniformBlockName);
 
 	boolean iris$isSetUp();
+
+	/**
+	 * Binds any mod-registered custom uniform blocks (IrisShaders/Iris#2974) that this draw's render
+	 * pass supplies, into this substituted program. Optional by design: only blocks actually present
+	 * in {@code passUniforms} are bound, so draws that share this program but don't use the block
+	 * (e.g. vanilla terrain) are left untouched. Default no-op.
+	 */
+	default void iris$bindCustomUniformBlocks(Map<String, GpuBufferSlice> passUniforms) {
+	}
 }

--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderCreator.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/ShaderCreator.java
@@ -18,6 +18,7 @@ import net.irisshaders.iris.gl.blending.BufferBlendOverride;
 import net.irisshaders.iris.gl.framebuffer.GlFramebuffer;
 import net.irisshaders.iris.gl.state.FogMode;
 import net.irisshaders.iris.gl.state.ShaderAttributeInputs;
+import net.irisshaders.iris.pipeline.IrisPipelines;
 import net.irisshaders.iris.pipeline.IrisRenderingPipeline;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.pipeline.fallback.ShaderSynthesizer;
@@ -96,6 +97,20 @@ public class ShaderCreator {
 		String tessControl = transformed.get(PatchShaderType.TESS_CONTROL);
 		String tessEval = transformed.get(PatchShaderType.TESS_EVAL);
 		String fragment = transformed.get(PatchShaderType.FRAGMENT);
+
+		// IrisShaders/Iris#2974: inject any mod-registered custom uniform block declarations
+		// (e.g. MaLiLib's "ChunkFix") into the substituted program's source, so the block exists
+		// and the mod-provided buffer can be forwarded to it at draw time. The block is only bound
+		// for draws that actually supply it, so unrelated draws sharing this program are unaffected.
+		List<IrisPipelines.CustomUniformBlock> customBlocks = IrisPipelines.getCustomUniformBlocks(shaderKey);
+		if (!customBlocks.isEmpty()) {
+			StringBuilder decls = new StringBuilder();
+			for (IrisPipelines.CustomUniformBlock b : customBlocks) {
+				decls.append('\n').append(b.glslDeclaration()).append('\n');
+			}
+			vertex = injectAfterVersion(vertex, decls.toString());
+			fragment = injectAfterVersion(fragment, decls.toString());
+		}
 
 		String shaderJsonString = String.format("""
 			    {
@@ -205,6 +220,26 @@ public class ShaderCreator {
 
 			return new PartialShader(i, vertexS, fragS, geometryS, tessContS, tessEvalS);
 		}
+	}
+
+	/**
+	 * Inserts {@code injection} immediately after the {@code #version} line of a GLSL source (or at
+	 * the top if there is none), so declarations land at global scope after the version/extension
+	 * preamble. No-op on null sources.
+	 */
+	private static String injectAfterVersion(String src, String injection) {
+		if (src == null) {
+			return null;
+		}
+		int v = src.indexOf("#version");
+		if (v < 0) {
+			return injection + src;
+		}
+		int nl = src.indexOf('\n', v);
+		if (nl < 0) {
+			return src + injection;
+		}
+		return src.substring(0, nl + 1) + injection + src.substring(nl + 1);
 	}
 
 	private static void attachIfValid(int i, int s) {

--- a/common/src/main/resources/iris.accesswidener
+++ b/common/src/main/resources/iris.accesswidener
@@ -9,6 +9,7 @@ accessible  class   net/minecraft/world/level/biome/Biome$ClimateSettings
 accessible  class   net/minecraft/client/Options$FieldAccess
 accessible field com/mojang/blaze3d/opengl/GlRenderPass pipeline Lcom/mojang/blaze3d/opengl/GlRenderPipeline;
 accessible field com/mojang/blaze3d/opengl/GlRenderPass samplers Ljava/util/HashMap;
+accessible field com/mojang/blaze3d/opengl/GlRenderPass uniforms Ljava/util/HashMap;
 accessible class net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture
 accessible class net/minecraft/client/renderer/texture/SpriteContents$FrameInfo
 accessible  class   net/minecraft/client/OptionInstance$ValueSet


### PR DESCRIPTION
## Summary

Implements the custom-UBO (`ChunkFix`) passthrough requested in #2974, so a mod can have its own `std140` uniform block forwarded to the program Iris substitutes for its terrain pipeline when a shader pack is active.

**Status: draft — compiles cleanly (`:fabric:build`) but is _not_ yet verified in-game.** Opening for design review and to give the assignee something concrete to build on. Details and open questions below.

## The problem (per #2974)

When a shader pack is active and a mod assigns a terrain pipeline via `IrisApi.assignPipeline(...)`, Iris substitutes its own `ExtendedShader` for that pipeline. That substituted program declares only Iris's own uniform blocks (`ExtendedShader` bind-group layouts), so a custom block the mod bound to the render pass via `RenderPass.setUniform("ChunkFix", buffer)` is silently discarded — nothing in Iris reads unknown UBO names off the pass. This is what breaks MaLiLib/Litematica's `ChunkFix` (texture-atlas size) block under shaders.

## Approach

New API (minor revision bumped `3 → 4`):

```java
void registerCustomUniformBlock(RenderPipeline pipeline, String blockName, String glslDeclaration);
```

The mod passes the block name and its exact `std140` GLSL declaration (Iris can't derive the layout, and the mod can't edit Iris's generated program, so both pieces cross the API). Then:

1. **Registry** (`IrisPipelines`) — resolves the pipeline to its `ShaderKey` at registration and stores the block(s) under that key.
2. **Declaration injection** (`ShaderCreator`) — injects the block's GLSL after the `#version` line of the substituted program's source, so the block exists in the linked program.
3. **Optional per-draw bind** (`ExtendedShader` + `MixinGlCommandEncoder`) — after Iris sets up the substituted program, for each registered block **present on this draw's pass**, binds the mod's `GpuBufferSlice` (`GlBuffer.handle()` + `glBindBufferRange`) to a binding point clear of Iris's own blocks.

## Why this is safe for shared programs

A mod's terrain pipeline resolves to the same `ShaderKey` (e.g. `TERRAIN_SOLID`) that vanilla chunk terrain uses, so the substituted program is **shared**. The bind is therefore made **optional**: it only fires for draws whose `GlRenderPass.uniforms` actually contains the block. Vanilla terrain draws never `setUniform("ChunkFix", …)`, so they are provably untouched — the block is declared-but-unbound-and-unused for them.

## Files

- `api/v0/IrisApi` + `apiimpl/IrisApiV0Impl` — new method, revision → 4
- `pipeline/IrisPipelines` — registry keyed by resolved `ShaderKey`
- `pipeline/programs/ShaderCreator` — inject declaration after `#version`
- `pipeline/programs/ExtendedShader` + `pipeline/programs/IrisProgram` + `mixin/MixinGlCommandEncoder` — optional per-draw bind
- `gl/IrisRenderSystem` — `bindBufferRange` helper
- `iris.accesswidener` — widen `GlRenderPass.uniforms` (mirrors existing `.samplers`)

## Open questions for review

- **Binding-point selection** is a fixed base (`12`) beyond Iris's own blocks rather than dynamically queried — is there a canonical free range to use?
- **Declaration injection** is a string insert after `#version`; a transformer-level injection may be preferable. An unused injected block could in principle be optimized out (then the bind is a safe no-op).
- **Consumption semantics:** this makes the data _available_ to the substituted (shader-pack) terrain program, but that program won't call MaLiLib's `sampleNearest(TextureSize)` — so this is the plumbing half; the visual result still depends on the mod side. Paired with a MaLiLib change that registers the block; happy to iterate.

Refs #2974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
