### PR TITLE
Fix inversed matrices for terrain

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
@@ -26,10 +26,10 @@ public class SodiumCoreTransformer {
 		root.rename("alphaTestRef", "iris_currentAlphaTest");
 		root.processMatches(t, modelViewMatrix, ASTNode::detachAndDelete);
 		root.rename("modelViewMatrix", "u_ModelViewMatrix");
-		root.rename("modelViewMatrixInverse", "iris_ModelViewMatrixInverse");
+		root.rename("modelViewMatrixInverse", "iris_ModelViewMatInverse");
 		root.processMatches(t, projectionMatrix, ASTNode::detachAndDelete);
 		root.rename("projectionMatrix", "u_ProjectionMatrix");
-		root.rename("projectionMatrixInverse", "iris_ProjectionMatrixInverse");
+		root.rename("projectionMatrixInverse", "iris_ProjMatInverse");
 		root.rename("normalMatrix", "iris_NormalMat");
 		root.rename("chunkOffset", "u_RegionOffset");
 		if (parameters.type == PatchShaderType.VERTEX) {

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
@@ -68,16 +68,16 @@ public class SodiumTransformer {
 			"uniform mat3 iris_NormalMat;");
 
 		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
-			"uniform mat4 iris_ModelViewMatrixInverse;");
+			"uniform mat4 iris_ModelViewMatInverse;");
 
 		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
-			"uniform mat4 iris_ProjectionMatrixInverse;");
+			"uniform mat4 iris_ProjMatInverse;");
 
 		// TODO: All of the transformed variants of the input matrices, preferably
 		// computed on the CPU side...
 		root.rename("gl_ModelViewMatrix", "u_ModelViewMatrix");
-		root.rename("gl_ModelViewMatrixInverse", "iris_ModelViewMatrixInverse");
-		root.rename("gl_ProjectionMatrixInverse", "iris_ProjectionMatrixInverse");
+		root.rename("gl_ModelViewMatrixInverse", "iris_ModelViewMatInverse");
+		root.rename("gl_ProjectionMatrixInverse", "iris_ProjMatInverse");
 
 		if (parameters.type.glShaderType == ShaderType.VERTEX) {
 			// TODO: Vaporwave-Shaderpack expects that vertex positions will be aligned to


### PR DESCRIPTION
Corrected name of inversed model view and projection matrix for sodium shader transformer, so terrain will receive correct values.

Notice: There is another issue on inversed projection matrix for hand. I'm not sure how to fix it so it's not included in this pr. Iris uses `CapturedRenderingState.INSTANCE.getGbufferProjection()` for inversed projection matrix, but projection matrix of this INSTANCE only sets one time per frame and it's value is global projection, so `gl_ProjectionMatrixInverse` for hand does not match inversed `gl_ProjectionMatrix`. Some related discussion can be found in https://discord.com/channels/774352792659820594/1522743919039877150