### PR TITLE
Fix Armourer's Workshop rendering compatibility

### DIFF
--- a/common/src/main/java/net/irisshaders/batchedentityrendering/impl/FullyBufferedMultiBufferSource.java
+++ b/common/src/main/java/net/irisshaders/batchedentityrendering/impl/FullyBufferedMultiBufferSource.java
@@ -144,17 +144,22 @@ public class FullyBufferedMultiBufferSource extends MultiBufferSource.BufferSour
 
 
 			type.setupRenderState();
+			boolean previousMergeRendering = ImmediateState.mergeRendering;
+			RenderType previousMergedRenderType = ImmediateState.mergedRenderType;
 			ImmediateState.mergeRendering = true;
+			ImmediateState.mergedRenderType = type;
 
-
-			for (BufferSegment segment : segments) {
-				segment.type().draw(segment.meshData());
-				drawCalls += 1;
+			try {
+				for (BufferSegment segment : segments) {
+					segment.type().draw(segment.meshData());
+					drawCalls += 1;
+				}
+			} finally {
+				ImmediateState.mergeRendering = previousMergeRendering;
+				ImmediateState.mergedRenderType = previousMergedRenderType;
+				type.clearRenderState();
 			}
-
-			type.clearRenderState();
 		}
-		ImmediateState.mergeRendering = false;
 
 		int targetClearTime = getTargetClearTime();
 
@@ -192,19 +197,24 @@ public class FullyBufferedMultiBufferSource extends MultiBufferSource.BufferSour
 
 
 			type.setupRenderState();
+			boolean previousMergeRendering = ImmediateState.mergeRendering;
+			RenderType previousMergedRenderType = ImmediateState.mergedRenderType;
 			ImmediateState.mergeRendering = true;
+			ImmediateState.mergedRenderType = type;
 
-
-			for (BufferSegment segment : segments) {
-				segment.type().draw(segment.meshData());
-				drawCalls += 1;
+			try {
+				for (BufferSegment segment : segments) {
+					segment.type().draw(segment.meshData());
+					drawCalls += 1;
+				}
+			} finally {
+				ImmediateState.mergeRendering = previousMergeRendering;
+				ImmediateState.mergedRenderType = previousMergedRenderType;
+				type.clearRenderState();
 			}
 
 			typeToSegment.remove(type);
-
-			type.clearRenderState();
 		}
-		ImmediateState.mergeRendering = false;
 
 		profiler.popPush("reset type " + transparencyType);
 

--- a/common/src/main/java/net/irisshaders/iris/layer/InnerWrappedRenderType.java
+++ b/common/src/main/java/net/irisshaders/iris/layer/InnerWrappedRenderType.java
@@ -1,6 +1,5 @@
 package net.irisshaders.iris.layer;
 
-import com.mojang.blaze3d.vertex.MeshData;
 import net.irisshaders.batchedentityrendering.impl.BlendingStateHolder;
 import net.irisshaders.batchedentityrendering.impl.TransparencyType;
 import net.irisshaders.batchedentityrendering.impl.WrappableRenderType;
@@ -90,11 +89,6 @@ public class InnerWrappedRenderType extends RenderType implements WrappableRende
 	@Override
 	public String toString() {
 		return "iris_wrapped:" + this.wrapped.toString();
-	}
-
-	@Override
-	public void draw(MeshData meshData) {
-		wrapped.draw(meshData);
 	}
 
 	@Override

--- a/common/src/main/java/net/irisshaders/iris/layer/OuterWrappedRenderType.java
+++ b/common/src/main/java/net/irisshaders/iris/layer/OuterWrappedRenderType.java
@@ -1,6 +1,5 @@
 package net.irisshaders.iris.layer;
 
-import com.mojang.blaze3d.vertex.MeshData;
 import net.irisshaders.batchedentityrendering.impl.BlendingStateHolder;
 import net.irisshaders.batchedentityrendering.impl.TransparencyType;
 import net.irisshaders.batchedentityrendering.impl.WrappableRenderType;
@@ -85,11 +84,6 @@ public class OuterWrappedRenderType extends RenderType implements WrappableRende
 		// Add one so that we don't have the exact same hash as the wrapped object.
 		// This means that we won't have a guaranteed collision if we're inserted to a map alongside the unwrapped object.
 		return this.wrapped.hashCode() + 1;
-	}
-
-	@Override
-	public void draw(MeshData meshData) {
-		wrapped.draw(meshData);
 	}
 
 	@Override

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinRenderType.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinRenderType.java
@@ -4,21 +4,24 @@ import net.irisshaders.iris.vertices.ImmediateState;
 import net.minecraft.client.renderer.RenderType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(RenderType.class)
 public class MixinRenderType {
 	@Redirect(method = "draw", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderType;setupRenderState()V"))
 	private void redirectSetupRenderState(RenderType renderType) {
-		if (!ImmediateState.mergeRendering) {
+		if (!shouldSkipRenderState(renderType)) {
 			renderType.setupRenderState();
 		}
 	}
 	@Redirect(method = "draw", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderType;clearRenderState()V"))
 	private void redirectClearRenderState(RenderType renderType) {
-		if (!ImmediateState.mergeRendering) {
+		if (!shouldSkipRenderState(renderType)) {
 			renderType.clearRenderState();
 		}
+	}
+
+	private static boolean shouldSkipRenderState(RenderType renderType) {
+		return ImmediateState.mergeRendering && ImmediateState.mergedRenderType == renderType;
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/vertices/ImmediateState.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/ImmediateState.java
@@ -1,5 +1,7 @@
 package net.irisshaders.iris.vertices;
 
+import net.minecraft.client.renderer.RenderType;
+
 /**
  * Some annoying global state needed for rendering.
  */
@@ -10,4 +12,5 @@ public class ImmediateState {
 	public static boolean renderWithExtendedVertexFormat = true;
 	public static boolean bypass;
 	public static boolean mergeRendering;
+	public static RenderType mergedRenderType;
 }


### PR DESCRIPTION
Fixes a rendering compatibility issue between Iris and Armourer's Workshop on NeoForge 1.21.1.
The previous `mergeRendering` flag was a global boolean. While Iris was rendering merged batches, every `RenderType.draw()` call could skip `setupRenderState()` / `clearRenderState()`, including render paths that were not part of the current Iris batch. This could leak render state into Armourer's Workshop GUI/item rendering, causing black quads, broken transparency, and in some modpacks a null shader crash.

Before：
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/68d2fd25-b3a8-43d2-9164-b6b767fb1c03" />
