### PR TITLE
Wire up pipeline exclusion and add resource pack exclusion support

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/Iris.java
+++ b/common/src/main/java/net/irisshaders/iris/Iris.java
@@ -236,6 +236,11 @@ public class Iris {
 			}
 		}
 
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft != null && minecraft.getResourceManager() != null) {
+			irisConfig.loadPackExclusions(minecraft.getResourceManager());
+		}
+
 		if (!irisConfig.areShadersEnabled()) {
 			logger.info("Shaders are disabled because enableShaders is set to false in iris.properties");
 

--- a/common/src/main/java/net/irisshaders/iris/config/IrisConfig.java
+++ b/common/src/main/java/net/irisshaders/iris/config/IrisConfig.java
@@ -9,10 +9,13 @@ import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.gui.option.IrisVideoSettings;
 import net.irisshaders.iris.pathways.colorspace.ColorSpace;
 import net.minecraft.resources.Identifier;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -48,6 +51,10 @@ public class IrisConfig {
 	 * What shaders should be nuked.
 	 */
 	private List<Identifier> shadersToSkip = new ArrayList<>();
+	/**
+	 * What shaders resource packs have asked to skip, via assets/iris/excluded.json.
+	 */
+	private List<Identifier> packShadersToSkip = new ArrayList<>();
 	/**
 	 * If the update notification should be disabled or not.
 	 */
@@ -216,7 +223,33 @@ public class IrisConfig {
 	}
 
 	public boolean shouldSkip(Identifier value) {
-		return shadersToSkip.contains(value); // TODO
+		return shadersToSkip.contains(value) || packShadersToSkip.contains(value);
+	}
+
+	public void loadPackExclusions(ResourceManager resourceManager) {
+		List<Identifier> excluded = new ArrayList<>();
+
+		for (Resource resource : resourceManager.getResourceStack(Identifier.fromNamespaceAndPath("iris", "excluded.json"))) {
+			try (InputStream is = resource.open()) {
+				JsonArray json = JsonParser.parseString(new String(is.readAllBytes(), StandardCharsets.UTF_8)).getAsJsonObject().getAsJsonArray("excluded");
+				for (int i = 0; i < json.size(); i++) {
+					Identifier resource1 = Identifier.tryParse(json.get(i).getAsString());
+					if (resource1 == null) {
+						Iris.logger.warn("Unknown shader " + json.get(i).getAsString() + " in " + resource.sourcePackId());
+					} else {
+						excluded.add(resource1);
+					}
+				}
+			} catch (Exception e) {
+				Iris.logger.warn("Failed to read excluded.json from a resource pack", e);
+			}
+		}
+
+		packShadersToSkip = excluded;
+
+		if (!excluded.isEmpty()) {
+			Iris.logger.info("Resource packs excluded " + excluded.size() + " pipeline(s) from Iris override: " + excluded);
+		}
 	}
 
 	public void setUnknown(boolean b) throws IOException {

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinGlCommandEncoder.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinGlCommandEncoder.java
@@ -168,6 +168,16 @@ public class MixinGlCommandEncoder {
 			}
 			is.iris$setupState(glRenderPass.samplers, sam == null ? null : sam.view());
 			programsToClear.add(is);
+		} else if (ImmediateState.isRenderingLevel
+			&& !(glRenderPass.pipeline.program() instanceof IrisProgram)
+			&& Iris.getPipelineManager().getPipelineNullable() instanceof IrisRenderingPipeline irp
+			&& irp.shouldOverrideShaders()) {
+			// Skipped vanilla shader; bind the gbuffer so it writes to colortex0 instead of the main framebuffer.
+			if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
+				irp.bindDefaultShadow();
+			} else {
+				irp.bindDefault();
+			}
 		}
 	}
 

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinShaderManager_Overrides.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinShaderManager_Overrides.java
@@ -48,7 +48,7 @@ import static net.irisshaders.iris.pipeline.programs.ShaderOverrides.isBlockEnti
 @Mixin(GlDevice.class)
 public abstract class MixinShaderManager_Overrides {
 	@Unique
-	private Set<RenderPipeline> missingShaders = new HashSet<>();
+	private static final Set<RenderPipeline> missingShaders = new HashSet<>();
 
 	@Inject(method = "getOrCompilePipeline", at = @At(value = "HEAD"), cancellable = true)
 	private void redirectIrisProgram(RenderPipeline renderPipeline, CallbackInfoReturnable<GlRenderPipeline> cir) {
@@ -64,7 +64,7 @@ public abstract class MixinShaderManager_Overrides {
 
 			if (program != null) {
 				cir.setReturnValue(new GlRenderPipeline(renderPipeline, program));
-			} else if (missingShaders.add(renderPipeline)) {
+			} else if (!Iris.getIrisConfig().shouldSkip(renderPipeline.getLocation()) && missingShaders.add(renderPipeline)) {
 				if (renderPipeline.getLocation().getNamespace().equals("minecraft")) {
 					Iris.logger.fatal("Missing program " + renderPipeline.getLocation() + " in override list. This is likely an Iris bug!!!", new Throwable());
 				} else {
@@ -98,6 +98,10 @@ public abstract class MixinShaderManager_Overrides {
 	private static GlProgram override(IrisRenderingPipeline pipeline, RenderPipeline shaderProgram) {
 		ShaderKey shaderKey = IrisPipelines.getPipeline(pipeline, shaderProgram);
 
-		return shaderKey == null ? null : pipeline.getShaderMap().getShader(shaderKey);
+		if (shaderKey == null || Iris.getIrisConfig().shouldSkip(shaderProgram.getLocation())) {
+			return null;
+		}
+
+		return pipeline.getShaderMap().getShader(shaderKey);
 	}
 }


### PR DESCRIPTION
While vanilla resource pack shaders are not currently a priority for Iris, we can still provide resource pack creators with the ability to disable specific rendering pipelines. This would allow certain core shaders to function correctly. I tested armor and entity shaders, and they already work quite well.