### PR TITLE
Fixes mc_midTexCoord being broken on iris 1.11.2 for 26.1.2

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/vertices/sodium/terrain/IrisChunkMeshAttributes.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/sodium/terrain/IrisChunkMeshAttributes.java
@@ -4,7 +4,7 @@ import net.caffeinemc.mods.sodium.client.gl.attribute.GlVertexAttributeFormat;
 import net.caffeinemc.mods.sodium.client.render.vertex.VertexFormatAttribute;
 
 public class IrisChunkMeshAttributes {
-	public static final VertexFormatAttribute MID_TEX_COORD = new VertexFormatAttribute("midTexCoord", GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, false);
+	public static final VertexFormatAttribute MID_TEX_COORD = new VertexFormatAttribute("midTexCoord", GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, true);
 	public static final VertexFormatAttribute TANGENT = new VertexFormatAttribute("TANGENT", GlVertexAttributeFormat.BYTE, 4, true, false);
 	public static final VertexFormatAttribute NORMAL = new VertexFormatAttribute("NORMAL", GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true);
 	public static final VertexFormatAttribute BLOCK_ID = new VertexFormatAttribute("BLOCK_ID", GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true);


### PR DESCRIPTION
Currently:
- The nether portal in Complementary and Photon Shaders (so we know it's not a comp issue) are **invisible**, both use `mc_midTexCoord` for the parallax effect
- In complementary world space reflections are broken which also rely on it
- Anisotropic filtering is also broken in complementary, which again, relies on that.

This PR fixes that