### PR TITLE
Fix shadows flickering and incorrect matrices

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/compat/sodium/mixin/MixinRenderSectionManagerShadow.java
+++ b/common/src/main/java/net/irisshaders/iris/compat/sodium/mixin/MixinRenderSectionManagerShadow.java
@@ -177,6 +177,27 @@ public abstract class MixinRenderSectionManagerShadow implements ShadowRenderLis
 		this.shadowTaskLists = null;
 	}
 
+	@WrapMethod(method = "finalizeRenderLists", remap = false)
+	private void finalizeShadowRenderLists(Camera camera, Viewport viewport, FogParameters fogParameters, boolean updateChunksImmediately, Operation<Void> original) {
+		if (!ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
+			original.call(camera, viewport, fogParameters, updateChunksImmediately);
+			return;
+		}
+
+		this.iris$swapToShadowRenderLists();
+
+		if (this.shadowNeedsRenderListUpdate) {
+			this.renderOutOfGraph(viewport, fogParameters);
+			this.shadowRenderLists = this.renderLists;
+			this.shadowTaskLists = this.taskLists;
+			this.shadowNeedsRenderListUpdate = false;
+		}
+
+		this.needsRenderListUpdate = false;
+		this.needsGraphUpdate = false;
+		this.cameraChanged = false;
+	}
+
 	@Inject(method = "markGraphDirty", at = @At("HEAD"), remap = false)
 	private void markShadowGraphDirty(CallbackInfo ci) {
 		this.shadowNeedsRenderListUpdate = true;

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
@@ -26,11 +26,11 @@ public class SodiumCoreTransformer {
 		root.rename("alphaTestRef", "iris_currentAlphaTest");
 		root.processMatches(t, modelViewMatrix, ASTNode::detachAndDelete);
 		root.rename("modelViewMatrix", "u_ModelViewMatrix");
-		root.rename("modelViewMatrixInverse", "iris_DefaultModelViewMatrixInverse");
+		root.replaceReferenceExpressions(t, "modelViewMatrixInverse", "inverse(u_ModelViewMatrix)");
 		root.processMatches(t, projectionMatrix, ASTNode::detachAndDelete);
 		root.rename("projectionMatrix", "u_ProjectionMatrix");
-		root.rename("projectionMatrixInverse", "iris_DefaultProjectionMatrixInverse");
-		root.rename("normalMatrix", "iris_DefaultNormalMat");
+		root.replaceReferenceExpressions(t, "projectionMatrixInverse", "inverse(u_ProjectionMatrix)");
+		root.replaceReferenceExpressions(t, "normalMatrix", "mat3(u_ModelViewMatrix)");
 		root.rename("chunkOffset", "u_RegionOffset");
 		if (parameters.type == PatchShaderType.VERTEX) {
 			boolean needsNormal = root.identifierIndex.has("vaNormal") || root.identifierIndex.has("at_tangent");

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumTransformer.java
@@ -61,22 +61,13 @@ public class SodiumTransformer {
 
 		// TODO: Should probably add the normal matrix as a proper uniform that's
 		// computed on the CPU-side of things
-		root.replaceReferenceExpressions(t, "gl_NormalMatrix",
-			"iris_DefaultNormalMat");
-		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
-			"uniform mat3 iris_DefaultNormalMat;");
-
-		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
-			"uniform mat4 iris_DefaultModelViewMatrixInverse;");
-
-		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
-			"uniform mat4 iris_DefaultProjectionMatrixInverse;");
+		root.replaceReferenceExpressions(t, "gl_NormalMatrix", "mat3(u_ModelViewMatrix)");
 
 		// TODO: All of the transformed variants of the input matrices, preferably
 		// computed on the CPU side...
 		root.rename("gl_ModelViewMatrix", "u_ModelViewMatrix");
-		root.rename("gl_ModelViewMatrixInverse", "iris_DefaultModelViewMatrixInverse");
-		root.rename("gl_ProjectionMatrixInverse", "iris_DefaultProjectionMatrixInverse");
+		root.replaceReferenceExpressions(t, "gl_ModelViewMatrixInverse", "inverse(u_ModelViewMatrix)");
+		root.replaceReferenceExpressions(t, "gl_ProjectionMatrixInverse", "inverse(u_ProjectionMatrix)");
 
 		if (parameters.type.glShaderType == ShaderType.VERTEX) {
 			// TODO: Vaporwave-Shaderpack expects that vertex positions will be aligned to


### PR DESCRIPTION
This fixes shadows flickering and WSR from Complementary being broken. https://github.com/IrisShaders/Iris/pull/3231 would need to be merged as well for WSR to be fully fixed.
I am putting this into a separate PR from the other one, as I am not so sure if this is the right way to handle this.
Feel free to merge, or feel free to do it better than me <3

This, for some reason, only seems to affect 26.1.2 with the new sodium 0.9.1 update. Iris 1.10.9 with sodium 0.8.12 also had no issues, and 26.2 1.11.2 with sodium 0.9.1 is also doing fine...