### PR TITLE
Add assignPipelineShadow and expand IrisShadowProgram enums

### DIFF
--- a/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
@@ -129,4 +129,11 @@ public interface IrisApi {
 	 * @since API v0.4
 	 */
 	void assignPipelineShadow(RenderPipeline pipeline, IrisShadowProgram program);
+
+	/**
+	 * Registers a callback invoked during the shadow pass, after opaque terrain.
+	 *
+	 * @since API v0.4
+	 */
+	void registerShadowRenderCallback(IrisShadowRenderCallback callback);
 }

--- a/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/IrisApi.java
@@ -122,4 +122,11 @@ public interface IrisApi {
 	 * @since API v0.3
 	 */
 	void assignPipeline(RenderPipeline pipeline, IrisProgram program);
+
+	/**
+	 * Assigns a render pipeline to an Iris shader key for the shadow pass.
+	 *
+	 * @since API v0.4
+	 */
+	void assignPipelineShadow(RenderPipeline pipeline, IrisShadowProgram program);
 }

--- a/common/src/api/java/net/irisshaders/iris/api/v0/IrisShadowProgram.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/IrisShadowProgram.java
@@ -2,7 +2,9 @@ package net.irisshaders.iris.api.v0;
 
 public enum IrisShadowProgram {
 	SHADOW,
+	SHADOW_TERRAIN_CUTOUT,
 	SHADOW_TRANSLUCENT,
 	SHADOW_ENTITIES,
+	SHADOW_LIGHTNING,
 	SHADOW_BLOCK,
 }

--- a/common/src/api/java/net/irisshaders/iris/api/v0/IrisShadowRenderCallback.java
+++ b/common/src/api/java/net/irisshaders/iris/api/v0/IrisShadowRenderCallback.java
@@ -1,0 +1,32 @@
+package net.irisshaders.iris.api.v0;
+
+import org.joml.Matrix4f;
+
+/**
+ * A callback invoked during the shadow pass, after opaque terrain has been
+ * drawn.
+ *
+ * <p>Implementations should draw using a {@code RenderPipeline} that has been
+ * assigned with {@link IrisApi#assignPipelineShadow}, otherwise no shader will
+ * be applied to the geometry.
+ *
+ * <p>The shadow pass runs with backface culling disabled and the terrain-cutout
+ * phase active. Geometry is drawn into the shadow framebuffer regardless of the
+ * render target the implementation binds, so any target may be passed when
+ * creating a render pass.
+ *
+ * @since API v0.4
+ */
+
+@FunctionalInterface
+public interface IrisShadowRenderCallback {
+	/**
+	 * @param modelView  the shadow pass model-view matrix
+	 * @param projection the shadow pass projection matrix
+	 * @param cameraX    the player camera X position the shadow pass is centered on
+	 * @param cameraY    the player camera Y position the shadow pass is centered on
+	 * @param cameraZ    the player camera Z position the shadow pass is centered on
+	 * @param tickDelta  the partial tick the frame is being rendered at
+	 */
+	void renderShadow(Matrix4f modelView, Matrix4f projection, double cameraX, double cameraY, double cameraZ, float tickDelta);
+}

--- a/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
+++ b/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
@@ -6,6 +6,7 @@ import net.irisshaders.iris.api.v0.IrisApi;
 import net.irisshaders.iris.api.v0.IrisApiConfig;
 import net.irisshaders.iris.api.v0.IrisProgram;
 import net.irisshaders.iris.api.v0.IrisShadowProgram;
+import net.irisshaders.iris.api.v0.IrisShadowRenderCallback;
 import net.irisshaders.iris.api.v0.IrisTextVertexSink;
 import net.irisshaders.iris.gui.screen.ShaderPackScreen;
 import net.irisshaders.iris.pipeline.IrisPipelines;
@@ -13,6 +14,7 @@ import net.irisshaders.iris.pipeline.VanillaRenderingPipeline;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.pipeline.programs.ShaderKey;
 import net.irisshaders.iris.shaderpack.loading.ProgramId;
+import net.irisshaders.iris.shadows.ShadowRenderCallbacks;
 import net.irisshaders.iris.shadows.ShadowRenderingState;
 import net.irisshaders.iris.vertices.IrisTextVertexSinkImpl;
 import net.minecraft.client.gui.screens.Screen;
@@ -84,5 +86,10 @@ public class IrisApiV0Impl implements IrisApi {
 	@Override
 	public void assignPipelineShadow(RenderPipeline pipeline, IrisShadowProgram program) {
 		IrisPipelines.assignPipelineShadow(pipeline, ShaderKey.findBestMatch(pipeline, ProgramId.fromAPI(program)));
+	}
+
+	@Override
+	public void registerShadowRenderCallback(IrisShadowRenderCallback callback) {
+		ShadowRenderCallbacks.register(callback);
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
+++ b/common/src/main/java/net/irisshaders/iris/apiimpl/IrisApiV0Impl.java
@@ -5,6 +5,7 @@ import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.api.v0.IrisApi;
 import net.irisshaders.iris.api.v0.IrisApiConfig;
 import net.irisshaders.iris.api.v0.IrisProgram;
+import net.irisshaders.iris.api.v0.IrisShadowProgram;
 import net.irisshaders.iris.api.v0.IrisTextVertexSink;
 import net.irisshaders.iris.gui.screen.ShaderPackScreen;
 import net.irisshaders.iris.pipeline.IrisPipelines;
@@ -25,7 +26,7 @@ public class IrisApiV0Impl implements IrisApi {
 
 	@Override
 	public int getMinorApiRevision() {
-		return 3;
+		return 4;
 	}
 
 	@Override
@@ -78,5 +79,10 @@ public class IrisApiV0Impl implements IrisApi {
 	@Override
 	public void assignPipeline(RenderPipeline pipeline, IrisProgram program) {
 		IrisPipelines.assignPipeline(pipeline, ShaderKey.findBestMatch(pipeline, ProgramId.fromAPI(program)));
+	}
+
+	@Override
+	public void assignPipelineShadow(RenderPipeline pipeline, IrisShadowProgram program) {
+		IrisPipelines.assignPipelineShadow(pipeline, ShaderKey.findBestMatch(pipeline, ProgramId.fromAPI(program)));
 	}
 }

--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
@@ -238,6 +238,14 @@ public class IrisPipelines {
 		}
 	}
 
+	public static void assignPipelineShadow(RenderPipeline pipeline, ShaderKey programId) {
+		if (coreShaderMapShadow.containsKey(pipeline)) {
+			throw new IllegalStateException("Shadow shader already assigned: " + pipeline.getLocation() + ": " + programId);
+		} else {
+			coreShaderMapShadow.put(pipeline, p -> programId);
+		}
+	}
+
 	public static void copyPipeline(RenderPipeline pipelineToCopy, RenderPipeline returnValue) {
 		if (coreShaderMap.containsKey(pipelineToCopy)) {
 			coreShaderMap.put(returnValue, coreShaderMap.get(pipelineToCopy));

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/loading/ProgramId.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/loading/ProgramId.java
@@ -1,6 +1,7 @@
 package net.irisshaders.iris.shaderpack.loading;
 
 import net.irisshaders.iris.api.v0.IrisProgram;
+import net.irisshaders.iris.api.v0.IrisShadowProgram;
 import net.irisshaders.iris.gl.blending.BlendMode;
 import net.irisshaders.iris.gl.blending.BlendModeFunction;
 import net.irisshaders.iris.gl.blending.BlendModeOverride;
@@ -114,6 +115,17 @@ public enum ProgramId {
 			case EMISSIVE_ENTITIES -> SpiderEyes;
 			case BEACON_BEAM -> BeaconBeam;
 			case LINES -> Line;
+		};
+	}
+
+	public static ProgramId fromAPI(IrisShadowProgram program) {
+		return switch (program) {
+			case SHADOW -> Shadow;
+			case SHADOW_TERRAIN_CUTOUT -> ShadowCutout;
+			case SHADOW_TRANSLUCENT -> ShadowWater;
+			case SHADOW_ENTITIES -> ShadowEntities;
+			case SHADOW_LIGHTNING -> ShadowLightning;
+			case SHADOW_BLOCK -> ShadowBlock;
 		};
 	}
 

--- a/common/src/main/java/net/irisshaders/iris/shadows/ShadowRenderCallbacks.java
+++ b/common/src/main/java/net/irisshaders/iris/shadows/ShadowRenderCallbacks.java
@@ -1,0 +1,32 @@
+package net.irisshaders.iris.shadows;
+
+import net.irisshaders.iris.Iris;
+import net.irisshaders.iris.api.v0.IrisShadowRenderCallback;
+import org.joml.Matrix4f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ShadowRenderCallbacks {
+	private static final List<IrisShadowRenderCallback> CALLBACKS = new ArrayList<>();
+
+	private ShadowRenderCallbacks() {}
+
+	public static void register(IrisShadowRenderCallback callback) {
+		CALLBACKS.add(callback);
+	}
+
+	public static boolean isEmpty() {
+		return CALLBACKS.isEmpty();
+	}
+
+	public static void invoke(Matrix4f modelView, Matrix4f projection, double cameraX, double cameraY, double cameraZ, float tickDelta) {
+		for (IrisShadowRenderCallback callback : CALLBACKS) {
+			try {
+				callback.renderShadow(modelView, projection, cameraX, cameraY, cameraZ, tickDelta);
+			} catch (Throwable t) {
+				Iris.logger.error("Error while running shadow render callback", t);
+			}
+		}
+	}
+}

--- a/common/src/main/java/net/irisshaders/iris/shadows/ShadowRenderer.java
+++ b/common/src/main/java/net/irisshaders/iris/shadows/ShadowRenderer.java
@@ -86,6 +86,7 @@ public class ShadowRenderer {
 	public static int renderDistance;
 	public static Matrix4f MODELVIEW;
 	public static Matrix4f PROJECTION;
+
 	public static Frustum FRUSTUM;
 	private final float halfPlaneLength;
 	private final float nearPlane, farPlane;
@@ -509,6 +510,14 @@ public class ShadowRenderer {
 			sections.renderGroup(ChunkSectionLayerGroup.OPAQUE, theSampler);
 			pipeline.setPhase(WorldRenderingPhase.NONE);
 		}
+
+		if (!ShadowRenderCallbacks.isEmpty()) {
+			profiler.popPush("iris_shadow_callbacks");
+			pipeline.setPhase(WorldRenderingPhase.TERRAIN_CUTOUT);
+			ShadowRenderCallbacks.invoke(MODELVIEW, PROJECTION, cameraX, cameraY, cameraZ, CapturedRenderingState.INSTANCE.getTickDelta());
+			pipeline.setPhase(WorldRenderingPhase.NONE);
+		}
+
 		pipeline.setPhase(WorldRenderingPhase.ENTITIES);
 
 		// Reset our viewport in case Sodium overrode it


### PR DESCRIPTION
This adds `assignPipelineShadow`, mirroring `assignPipeline`.

Added 2 enums to IrisShadowProgram
- `SHADOW_TERRAIN_CUTOUT` -> `ProgramId.ShadowCutout`
- `SHADOW_LIGHTNING` -> `ProgramId.ShadowLightning`

`SHADOW_TERRAIN_CUTOUT` is needed because `findBestMatch` compares program ids by
identity and doesn't walk `ProgramId.fallback`, so `SHADOW` -> `ProgramId.Shadow`
can't reach `ShaderKey.SHADOW_TERRAIN_CUTOUT`, the only shadow key on
`IrisVertexFormats.TERRAIN`.