### PR TITLE
Don't trigger F3 behavior when reloading shaders

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/Iris.java
+++ b/common/src/main/java/net/irisshaders/iris/Iris.java
@@ -755,7 +755,7 @@ public class Iris {
 		return getVersion().split("\\+")[0];
 	}
 
-    public static void handleDebugKeys(KeyEvent event) {
+    public static boolean handleDebugKeys(KeyEvent event) {
         if (reloadKeybind.matches(event)) {
             try {
                 reload();
@@ -771,7 +771,9 @@ public class Iris {
                     Minecraft.getInstance().player.sendSystemMessage(Component.translatable("iris.shaders.reloaded.failure", Throwables.getRootCause(e).getMessage()).withStyle(ChatFormatting.RED));
                 }
             }
+			return true;
         }
+		return false;
     }
 
     /**

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinKeyboardHandler.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinKeyboardHandler.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(KeyboardHandler.class)
 public class MixinKeyboardHandler {
-    @Inject(method = "handleDebugKeys", at = @At("RETURN"))
+    @Inject(method = "handleDebugKeys", at = @At("RETURN"), cancellable = true)
     private void iris$handleDebugKeys(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
-        Iris.handleDebugKeys(event);
+		cir.setReturnValue(Iris.handleDebugKeys(event));
     }
 }

--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinKeyboardHandler.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinKeyboardHandler.java
@@ -13,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class MixinKeyboardHandler {
     @Inject(method = "handleDebugKeys", at = @At("RETURN"), cancellable = true)
     private void iris$handleDebugKeys(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
-		cir.setReturnValue(Iris.handleDebugKeys(event));
+		if (Iris.handleDebugKeys(event)) {
+			cir.setReturnValue(true);
+		}
     }
 }


### PR DESCRIPTION
Just like most vanilla debug key binding groups, never trigger original F3 overlay when reloading shaders