### PR TITLE
Fix at_midBlock on high coordinate

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/vertices/ExtendedDataHelper.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/ExtendedDataHelper.java
@@ -14,9 +14,9 @@ public final class ExtendedDataHelper {
 
 	public static int computeMidBlock(float x, float y, float z, int localPosX, int localPosY, int localPosZ) {
 		return packMidBlock(
-			localPosX + 0.5f - x,
-			localPosY + 0.5f - y,
-			localPosZ + 0.5f - z
+			(localPosX & 0xFFFF) + 0.5f - x,
+			(localPosY & 0xFFFF) + 0.5f - y,
+			(localPosZ & 0xFFFF) + 0.5f - z
 		);
 	}
 }


### PR DESCRIPTION
The raw vertex position input of `computeMidBlock()` will be in range [-8, 24], while localPosXYZ seems to be the global position, which means when local position of certain block is too far away, it will reduce the effective precision of `at_midBlock`; if local position is greater than 8,388,608, `at_midBlock` will break with even common full blocks.

Considering the raw vertex position is just in such a short range, we can also reduce the abstract value of local position, to avoid the precision loss on high coordinate.