### PR TITLE
Fix override lookup for copied render pipelines

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/IrisPipelines.java
@@ -10,6 +10,7 @@ import net.irisshaders.iris.pipeline.programs.ShaderKey;
 import net.irisshaders.iris.shaderpack.loading.ProgramId;
 import net.irisshaders.iris.shadows.ShadowRenderingState;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -19,6 +20,8 @@ import static net.irisshaders.iris.pipeline.programs.ShaderOverrides.isBlockEnti
 public class IrisPipelines {
 	private static final Map<RenderPipeline, Function<IrisRenderingPipeline, ShaderKey>> coreShaderMap = new Object2ObjectArrayMap<>();
 	private static final Map<RenderPipeline, Function<IrisRenderingPipeline, ShaderKey>> coreShaderMapShadow = new Object2ObjectArrayMap<>();
+	private static final Map<Identifier, Function<IrisRenderingPipeline, ShaderKey>> coreShaderMapByLocation = new Object2ObjectArrayMap<>();
+	private static final Map<Identifier, Function<IrisRenderingPipeline, ShaderKey>> coreShaderMapShadowByLocation = new Object2ObjectArrayMap<>();
 	private static final Function<IrisRenderingPipeline, ShaderKey> FAKE_FUNCTION = p -> null;
 
 	static {
@@ -173,6 +176,7 @@ public class IrisPipelines {
 		}
 
 		coreShaderMap.put(pipeline, o);
+		coreShaderMapByLocation.put(pipeline.getLocation(), o);
 	}
 
 	private static void assignToShadow(RenderPipeline pipeline, Function<IrisRenderingPipeline, ShaderKey> o) {
@@ -181,6 +185,7 @@ public class IrisPipelines {
 		}
 
 		coreShaderMapShadow.put(pipeline, o);
+		coreShaderMapShadowByLocation.put(pipeline.getLocation(), o);
 	}
 
 	private static ShaderKey getCutout(Object p) {
@@ -231,27 +236,42 @@ public class IrisPipelines {
             }
         }
 		if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
-			return coreShaderMapShadow.getOrDefault(shader, FAKE_FUNCTION).apply(pipeline);
+			return getMappedShader(coreShaderMapShadow, coreShaderMapShadowByLocation, shader).apply(pipeline);
 		} else {
-			return coreShaderMap.getOrDefault(shader, FAKE_FUNCTION).apply(pipeline);
+			return getMappedShader(coreShaderMap, coreShaderMapByLocation, shader).apply(pipeline);
 		}
+	}
+
+	private static Function<IrisRenderingPipeline, ShaderKey> getMappedShader(
+		Map<RenderPipeline, Function<IrisRenderingPipeline, ShaderKey>> pipelineMap,
+		Map<Identifier, Function<IrisRenderingPipeline, ShaderKey>> locationMap,
+		RenderPipeline shader
+	) {
+		Function<IrisRenderingPipeline, ShaderKey> mappedShader = pipelineMap.get(shader);
+		return mappedShader != null ? mappedShader : locationMap.getOrDefault(shader.getLocation(), FAKE_FUNCTION);
 	}
 
 	public static void assignPipeline(RenderPipeline pipeline, ShaderKey programId) {
 		if (coreShaderMap.containsKey(pipeline)) {
 			throw new IllegalStateException("Shader already assigned: " + pipeline.getLocation() + ": " + programId);
 		} else {
-			coreShaderMap.put(pipeline, p -> programId);
+			Function<IrisRenderingPipeline, ShaderKey> mapping = p -> programId;
+			coreShaderMap.put(pipeline, mapping);
+			coreShaderMapByLocation.put(pipeline.getLocation(), mapping);
 		}
 	}
 
 	public static void copyPipeline(RenderPipeline pipelineToCopy, RenderPipeline returnValue) {
 		if (coreShaderMap.containsKey(pipelineToCopy)) {
-			coreShaderMap.put(returnValue, coreShaderMap.get(pipelineToCopy));
+			Function<IrisRenderingPipeline, ShaderKey> mapping = coreShaderMap.get(pipelineToCopy);
+			coreShaderMap.put(returnValue, mapping);
+			coreShaderMapByLocation.put(returnValue.getLocation(), mapping);
 		}
 
 		if (coreShaderMapShadow.containsKey(pipelineToCopy)) {
-			coreShaderMapShadow.put(returnValue, coreShaderMapShadow.get(pipelineToCopy));
+			Function<IrisRenderingPipeline, ShaderKey> mapping = coreShaderMapShadow.get(pipelineToCopy);
+			coreShaderMapShadow.put(returnValue, mapping);
+			coreShaderMapShadowByLocation.put(returnValue.getLocation(), mapping);
 		}
 	}
 }


### PR DESCRIPTION
## What changed

Pipeline override lookup now falls back to a render pipeline's identifier when the exact `RenderPipeline` instance is not registered. The existing instance lookup remains the fast path.

Location mappings are kept in sync for Iris's built-in registrations, API-assigned pipelines, and copied pipelines.

## Why

Minecraft 26.2 can render with a copied or recreated pipeline that has the canonical identifier but is not the same Java object as the statically registered pipeline. During the shadow pass this caused `minecraft:pipeline/entity_translucent` to miss its existing `SHADOW_ENTITIES_CUTOUT` mapping, producing a fatal log message and severe flickering/reload behavior.

## Validation

- `./gradlew :fabric:build` passes.
- Reproduced on Minecraft 26.2, Fabric Loader 0.19.3, Iris 1.11.2, Sodium 0.9.1, and an AMD Radeon RX550 with Complementary Unbound r5.8.1.
- Before the change, entering the test world logged `Missing program minecraft:pipeline/entity_translucent in override list` and flickered.
- With this change, the same world and shader pack load without the error or flickering.
