### PR TITLE
Fix vertex format of text_see_through

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/mixin/MixinRenderPipeline.java
+++ b/common/src/main/java/net/irisshaders/iris/mixin/MixinRenderPipeline.java
@@ -33,6 +33,8 @@ public class MixinRenderPipeline {
 				cir.setReturnValue(IrisVertexFormats.TERRAIN);
 			} else if (Objects.equals(vf, DefaultVertexFormat.POSITION_TEX_LIGHTMAP_COLOR)) {
 				cir.setReturnValue(IrisVertexFormats.GLYPH);
+			} else if (Objects.equals(vf, DefaultVertexFormat.POSITION_TEX_COLOR)) {
+				cir.setReturnValue(IrisVertexFormats.GLYPH);
 			} else if (Objects.equals(vf, DefaultVertexFormat.ENTITY)) {
 				cir.setReturnValue(IrisVertexFormats.ENTITY);
 			} else if (Objects.equals(vf, ChunkMeshFormats.COMPACT.getVertexFormat())) {
@@ -48,6 +50,8 @@ public class MixinRenderPipeline {
 			if (Objects.equals(vf, DefaultVertexFormat.BLOCK)) {
 				cir.setReturnValue(new VertexFormat[] { IrisVertexFormats.TERRAIN });
 			} else if (Objects.equals(vf, DefaultVertexFormat.POSITION_TEX_LIGHTMAP_COLOR)) {
+				cir.setReturnValue(new VertexFormat[] { IrisVertexFormats.GLYPH });
+			} else if (Objects.equals(vf, DefaultVertexFormat.POSITION_TEX_COLOR)) {
 				cir.setReturnValue(new VertexFormat[] { IrisVertexFormats.GLYPH });
 			} else if (Objects.equals(vf, DefaultVertexFormat.ENTITY)) {
 				cir.setReturnValue(new VertexFormat[] { IrisVertexFormats.ENTITY });


### PR DESCRIPTION
Render pipeline text_see_through (like black background and dark text of name tags that can be seen through blocks) is using POSITION_TEX_COLOR vertex format which Iris does not consider when changing vanilla vertex format. This result in their vertex buffer used in very wrong way. By correcting their vertex format, name tags can be rendered correctly now.