### PR TITLE
Fix mc_Entity being zero on the vanilla and core shader paths

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/gl/state/ShaderAttributeInputs.java
+++ b/common/src/main/java/net/irisshaders/iris/gl/state/ShaderAttributeInputs.java
@@ -2,6 +2,9 @@ package net.irisshaders.iris.gl.state;
 
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormatElement;
+
+import java.util.List;
 
 public class ShaderAttributeInputs {
 	private boolean ie;
@@ -13,6 +16,7 @@ public class ShaderAttributeInputs {
 	private boolean newLines;
 	private boolean glint;
 	private boolean text;
+	private int entityComponents;
 	// WARNING: adding new fields requires updating hashCode and equals methods!
 
 	public ShaderAttributeInputs(VertexFormat format, boolean isFullbright, boolean isLines, boolean glint, boolean text, boolean ie) {
@@ -47,6 +51,23 @@ public class ShaderAttributeInputs {
 				normal = true;
 			}
 		});
+
+		// Packs declare mc_Entity as a float, so it reads back zero and the transformer has to
+		// redeclare it. Zero here means there is nothing to fix.
+		List<String> names = format.getElementAttributeNames();
+		List<VertexFormatElement> elements = format.getElements();
+		for (int index = 0; index < names.size(); index++) {
+			VertexFormatElement element = elements.get(index);
+			String name = names.get(index);
+
+			if (element.normalized() || element.type() == VertexFormatElement.Type.FLOAT) {
+				continue;
+			}
+
+			if ("mc_Entity".equals(name)) {
+				entityComponents = element.count();
+			}
+		}
 	}
 
 	public ShaderAttributeInputs(boolean color, boolean tex, boolean overlay, boolean light, boolean normal) {
@@ -85,6 +106,10 @@ public class ShaderAttributeInputs {
 		return glint;
 	}
 
+	public int getEntityComponents() {
+		return entityComponents;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -97,6 +122,7 @@ public class ShaderAttributeInputs {
 		result = prime * result + (newLines ? 1231 : 1237);
 		result = prime * result + (glint ? 1231 : 1237);
 		result = prime * result + (text ? 1231 : 1237);
+		result = prime * result + entityComponents;
 		return result;
 	}
 
@@ -123,7 +149,9 @@ public class ShaderAttributeInputs {
 			return false;
 		if (glint != other.glint)
 			return false;
-		return text == other.text;
+		if (text != other.text)
+			return false;
+		return entityComponents == other.entityComponents;
 	}
 
 	public boolean isText() {

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/CommonTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/CommonTransformer.java
@@ -27,6 +27,7 @@ import io.github.douira.glsl_transformer.parser.ParseShape;
 import io.github.douira.glsl_transformer.util.Type;
 import net.irisshaders.iris.gl.blending.AlphaTest;
 import net.irisshaders.iris.gl.shader.ShaderType;
+import net.irisshaders.iris.gl.state.ShaderAttributeInputs;
 import net.irisshaders.iris.pipeline.transform.parameter.Parameters;
 import net.irisshaders.iris.pipeline.transform.parameter.VanillaParameters;
 
@@ -131,6 +132,86 @@ public class CommonTransformer {
 			tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
 				"attribute vec4 mc_midTexCoord;");
 		}
+	}
+
+	// Packs declare mc_Entity as a float, but TERRAIN binds it as an integer attribute, so it reads
+	// back as zero. Swap the pack's declaration for the integer type and hand it a converted alias.
+	// SodiumTransformer.replaceMCEntity does the same on its path; the core and vanilla ones did not.
+	public static void patchIntegerAttribute(
+		ASTParser t,
+		TranslationUnit tree,
+		Root root,
+		String name,
+		String alias,
+		int components) {
+		if (components == 0) {
+			return;
+		}
+
+		Type dimension = Type.BOOL;
+		for (Identifier id : root.identifierIndex.get(name)) {
+			TypeAndInitDeclaration initDeclaration = (TypeAndInitDeclaration) id.getAncestor(
+				2, 0, TypeAndInitDeclaration.class::isInstance);
+			if (initDeclaration == null) {
+				continue;
+			}
+			DeclarationExternalDeclaration declaration = (DeclarationExternalDeclaration) initDeclaration.getAncestor(
+				1, 0, DeclarationExternalDeclaration.class::isInstance);
+			if (declaration == null) {
+				continue;
+			}
+			if (initDeclaration.getType().getTypeSpecifier() instanceof BuiltinNumericTypeSpecifier numeric) {
+				dimension = numeric.type;
+
+				declaration.detachAndDelete();
+				initDeclaration.detachAndDelete();
+				id.detachAndDelete();
+				break;
+			}
+		}
+
+		// The pack never declared it, so there is nothing to redeclare.
+		if (dimension == Type.BOOL) {
+			return;
+		}
+
+		root.replaceReferenceExpressions(t, name, alias);
+
+		String declaration = switch (dimension) {
+			case FLOAT32 -> "float " + alias + " = float(" + name + ".x);";
+			case INT32 -> "int " + alias + " = " + name + ".x;";
+			case F32VEC2 -> "vec2 " + alias + " = vec2(" + swizzle(name, components, 2, true) + ");";
+			case F32VEC3 -> "vec3 " + alias + " = vec3(" + swizzle(name, components, 3, true) + ");";
+			case F32VEC4 -> "vec4 " + alias + " = vec4(" + swizzle(name, components, 4, true) + ");";
+			case I32VEC2 -> "ivec2 " + alias + " = ivec2(" + swizzle(name, components, 2, false) + ");";
+			case I32VEC3 -> "ivec3 " + alias + " = ivec3(" + swizzle(name, components, 3, false) + ");";
+			case I32VEC4 -> "ivec4 " + alias + " = ivec4(" + swizzle(name, components, 4, false) + ");";
+			default -> throw new IllegalStateException(
+				"Got an invalid format for " + name + " (" + dimension.getCompactName() + ").");
+		};
+
+		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS, declaration);
+		tree.parseAndInjectNode(t, ASTInjectionPoint.BEFORE_DECLARATIONS,
+			"in ivec" + components + " " + name + ";");
+	}
+
+	// Pads the attribute out to the width the pack declared, matching how SodiumTransformer
+	// pads mc_Entity: zero, with one in the fourth slot.
+	private static String swizzle(String name, int available, int declared, boolean floating) {
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < declared; i++) {
+			if (i > 0) {
+				builder.append(", ");
+			}
+			if (i < available) {
+				builder.append(name).append('.').append("xyzw".charAt(i));
+			} else if (i == 3) {
+				builder.append(floating ? "1.0" : "1");
+			} else {
+				builder.append(floating ? "0.0" : "0");
+			}
+		}
+		return builder.toString();
 	}
 
 	public static void upgradeStorageQualifiers(

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaCoreTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaCoreTransformer.java
@@ -96,6 +96,8 @@ public class VanillaCoreTransformer {
 		CommonTransformer.upgradeStorageQualifiers(t, tree, root, parameters);
 
 		if (parameters.type == PatchShaderType.VERTEX) {
+			CommonTransformer.patchIntegerAttribute(t, tree, root, "mc_Entity", "iris_Entity", parameters.inputs.getEntityComponents());
+
 			root.replaceReferenceExpressions(t, "gl_Vertex", "vec4(iris_Position, 1.0)");
 			root.rename("vaPosition", "iris_Position");
 			if (parameters.inputs.hasColor()) {

--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/VanillaTransformer.java
@@ -72,6 +72,8 @@ public class VanillaTransformer {
 				} iris_globalInfo;
 				""");
 		if (parameters.type.glShaderType == ShaderType.VERTEX) {
+			CommonTransformer.patchIntegerAttribute(t, tree, root, "mc_Entity", "iris_Entity", parameters.inputs.getEntityComponents());
+
 			// Alias of gl_MultiTexCoord1 on 1.15+ for OptiFine
 			// See https://github.com/IrisShaders/Iris/issues/1149
 			root.rename("gl_MultiTexCoord2", "gl_MultiTexCoord1");


### PR DESCRIPTION
Programs using `IrisVertexFormats.TERRAIN` read `mc_Entity` as 0.

`SodiumTransformer.replaceMCEntity` already redeclares it on the Sodium path, the vanilla and core paths just never got the same fix. But basically the format declares it as two unnormalized shorts, so Blaze3D binds it as an integer attribute, but packs declare it as attribute vec4 `mc_Entity`. Mods rendering custom blocks through `assignPipeline` can supply a block ID and packs can apply the block ID material instead of getting nothing.

Im pretty sure that `at_midBlock` has the same issue but I haven't touched it.