### PR TITLE
Refactor blend mode parsing and improve error handling

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/shaderpack/parsing/ComputeDirectiveParser.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/parsing/ComputeDirectiveParser.java
@@ -9,12 +9,14 @@ public class ComputeDirectiveParser {
 	public static void setComputeWorkGroups(ComputeSource source, ConstDirectiveParser.ConstDirective directive) {
 		if (!directive.getValue().startsWith("ivec3")) {
 			Iris.logger.error("Failed to process " + directive + ": value was not a valid ivec3 constructor");
+			return;
 		}
 
 		String ivec3Args = directive.getValue().substring("ivec3".length()).trim();
 
 		if (!ivec3Args.startsWith("(") || !ivec3Args.endsWith(")")) {
 			Iris.logger.error("Failed to process " + directive + ": value was not a valid ivec3 constructor");
+			return;
 		}
 
 		ivec3Args = ivec3Args.substring(1, ivec3Args.length() - 1);
@@ -28,6 +30,7 @@ public class ComputeDirectiveParser {
 		if (parts.length != 3) {
 			Iris.logger.error("Failed to process " + directive +
 				": expected 3 arguments to a ivec3 constructor, got " + parts.length);
+			return;
 		}
 
 		try {
@@ -43,12 +46,14 @@ public class ComputeDirectiveParser {
 	public static void setComputeWorkGroupsRelative(ComputeSource source, ConstDirectiveParser.ConstDirective directive) {
 		if (!directive.getValue().startsWith("vec2")) {
 			Iris.logger.error("Failed to process " + directive + ": value was not a valid vec2 constructor");
+			return;
 		}
 
 		String vec2Args = directive.getValue().substring("vec2".length()).trim();
 
 		if (!vec2Args.startsWith("(") || !vec2Args.endsWith(")")) {
 			Iris.logger.error("Failed to process " + directive + ": value was not a valid vec2 constructor");
+			return;
 		}
 
 		vec2Args = vec2Args.substring(1, vec2Args.length() - 1);
@@ -62,6 +67,7 @@ public class ComputeDirectiveParser {
 		if (parts.length != 2) {
 			Iris.logger.error("Failed to process " + directive +
 				": expected 2 arguments to a vec2 constructor, got " + parts.length);
+			return;
 		}
 
 		try {

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/parsing/DispatchingDirectiveHolder.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/parsing/DispatchingDirectiveHolder.java
@@ -119,12 +119,14 @@ public class DispatchingDirectiveHolder implements DirectiveHolder {
 			if (consumer != null) {
 				if (!value.startsWith("vec2")) {
 					Iris.logger.error("Failed to process " + directive + ": value was not a valid vec2 constructor");
+					return;
 				}
 
 				String vec2Args = value.substring("vec2".length()).trim();
 
 				if (!vec2Args.startsWith("(") || !vec2Args.endsWith(")")) {
 					Iris.logger.error("Failed to process " + directive + ": value was not a valid vec2 constructor");
+					return;
 				}
 
 				vec2Args = vec2Args.substring(1, vec2Args.length() - 1);
@@ -138,6 +140,7 @@ public class DispatchingDirectiveHolder implements DirectiveHolder {
 				if (parts.length != 2) {
 					Iris.logger.error("Failed to process " + directive +
 						": expected 2 arguments to a vec2 constructor, got " + parts.length);
+					return;
 				}
 
 				try {
@@ -162,12 +165,14 @@ public class DispatchingDirectiveHolder implements DirectiveHolder {
 			if (consumer != null) {
 				if (!value.startsWith("ivec3")) {
 					Iris.logger.error("Failed to process " + directive + ": value was not a valid ivec3 constructor");
+					return;
 				}
 
 				String ivec3Args = value.substring("ivec3".length()).trim();
 
 				if (!ivec3Args.startsWith("(") || !ivec3Args.endsWith(")")) {
 					Iris.logger.error("Failed to process " + directive + ": value was not a valid ivec3 constructor");
+					return;
 				}
 
 				ivec3Args = ivec3Args.substring(1, ivec3Args.length() - 1);
@@ -181,6 +186,7 @@ public class DispatchingDirectiveHolder implements DirectiveHolder {
 				if (parts.length != 3) {
 					Iris.logger.error("Failed to process " + directive +
 						": expected 3 arguments to a ivec3 constructor, got " + parts.length);
+					return;
 				}
 
 				try {
@@ -206,12 +212,14 @@ public class DispatchingDirectiveHolder implements DirectiveHolder {
 			if (consumer != null) {
 				if (!value.startsWith("vec4")) {
 					Iris.logger.error("Failed to process " + directive + ": value was not a valid vec4 constructor");
+					return;
 				}
 
 				String vec4Args = value.substring("vec4".length()).trim();
 
 				if (!vec4Args.startsWith("(") || !vec4Args.endsWith(")")) {
 					Iris.logger.error("Failed to process " + directive + ": value was not a valid vec4 constructor");
+					return;
 				}
 
 				vec4Args = vec4Args.substring(1, vec4Args.length() - 1);
@@ -225,6 +233,7 @@ public class DispatchingDirectiveHolder implements DirectiveHolder {
 				if (parts.length != 4) {
 					Iris.logger.error("Failed to process " + directive +
 						": expected 4 arguments to a vec4 constructor, got " + parts.length);
+					return;
 				}
 
 				try {

--- a/common/src/main/java/net/irisshaders/iris/shaderpack/properties/ShaderProperties.java
+++ b/common/src/main/java/net/irisshaders/iris/shaderpack/properties/ShaderProperties.java
@@ -340,7 +340,7 @@ public class ShaderProperties {
 						return;
 					}
 
-					String[] modeArray = value.split(" ");
+					String[] modeArray = value.trim().split("\\s+");
 					int[] modes = new int[modeArray.length];
 
 					int i = 0;
@@ -349,7 +349,12 @@ public class ShaderProperties {
 						i++;
 					}
 
-					bufferBlendOverrides.computeIfAbsent(parts[0], list -> new ArrayList<>()).add(new BufferBlendInformation(index, new BlendMode(modes[0], modes[1], modes[2], modes[3])));
+					int srcRgb = modes[0];
+					int dstRgb = modes.length > 1 ? modes[1] : modes[0];
+					int srcAlpha = modes.length > 2 ? modes[2] : srcRgb;
+					int dstAlpha = modes.length > 3 ? modes[3] : dstRgb;
+
+					bufferBlendOverrides.computeIfAbsent(parts[0], list -> new ArrayList<>()).add(new BufferBlendInformation(index, new BlendMode(srcRgb, dstRgb, srcAlpha, dstAlpha)));
 
 					return;
 				}
@@ -359,7 +364,7 @@ public class ShaderProperties {
 					return;
 				}
 
-				String[] modeArray = value.split(" ");
+				String[] modeArray = value.trim().split("\\s+");
 				int[] modes = new int[modeArray.length];
 
 				int i = 0;
@@ -368,7 +373,12 @@ public class ShaderProperties {
 					i++;
 				}
 
-				blendModeOverrides.put(pass, new BlendModeOverride(new BlendMode(modes[0], modes[1], modes[2], modes[3])));
+				int srcRgb = modes[0];
+				int dstRgb = modes.length > 1 ? modes[1] : modes[0];
+				int srcAlpha = modes.length > 2 ? modes[2] : srcRgb;
+				int dstAlpha = modes.length > 3 ? modes[3] : dstRgb;
+
+				blendModeOverrides.put(pass, new BlendModeOverride(new BlendMode(srcRgb, dstRgb, srcAlpha, dstAlpha)));
 			});
 
 			handlePassDirective("indirect.", key, value, pass -> {


### PR DESCRIPTION
Refactor blend mode parsing to support variable-length mode arrays. Enhance error handling for `vec2`, `ivec3`, and `vec4` constructors to ensure valid input and provide clearer error messages.