### PR TITLE
Fix u_regionoffset being a required uniform

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/SodiumShader.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/SodiumShader.java
@@ -76,7 +76,7 @@ public class SodiumShader implements ChunkShaderInterface {
 						boolean containsTessellation) {
 		this.anisotropySupported = pipeline.hasFeature(FeatureFlags.TEXTURE_FILTERING);
 
-		this.regionUniform = context.bindUniform("u_RegionOffset", GlUniformFloat3v::new);
+		this.regionUniform = context.bindUniformOptional("u_RegionOffset", GlUniformFloat3v::new);
 		this.timeUniform = context.bindUniformOptional("u_CurrentTime", GlUniformInt::new);
 		this.idUniform = context.bindUniformOptional("u_RegionID", GlUniformUnsignedInt::new);
 

--- a/common/src/main/java/net/irisshaders/iris/pipeline/programs/SodiumShader.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/programs/SodiumShader.java
@@ -201,7 +201,7 @@ public class SodiumShader implements ChunkShaderInterface {
 		float y = getCameraTranslation(region.getOriginY(), camera.intY, camera.fracY);
 		float z = getCameraTranslation(region.getOriginZ(), camera.intZ, camera.fracZ);
 
-		this.regionUniform.set(x, y, z);
+		if (this.regionUniform != null) this.regionUniform.set(x, y, z);
 		if (this.timeUniform != null) this.timeUniform.set(Math.toIntExact(System.currentTimeMillis() - region.getCreationTime()));
 		if (this.idUniform != null) this.idUniform.set(region.getId());
 	}


### PR DESCRIPTION
This often produces compile errors on shaderpacks which do not make use of the vertex position in a terrain shader.