### PR TITLE
Fix normalMatrix in core profile

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
+++ b/common/src/main/java/net/irisshaders/iris/pipeline/transform/transformer/SodiumCoreTransformer.java
@@ -17,7 +17,7 @@ public class SodiumCoreTransformer {
 	public static final AutoHintedMatcher<ExternalDeclaration> modelViewMatrix = new AutoHintedMatcher<>(
 		"uniform mat4 modelViewMatrix;", ParseShape.EXTERNAL_DECLARATION);
 	public static final AutoHintedMatcher<ExternalDeclaration> normalMatrix = new AutoHintedMatcher<>(
-		"uniform mat4 normalMatrix;", ParseShape.EXTERNAL_DECLARATION);
+		"uniform mat3 normalMatrix;", ParseShape.EXTERNAL_DECLARATION);
 	public static final AutoHintedMatcher<ExternalDeclaration> projectionMatrix = new AutoHintedMatcher<>(
 		"uniform mat4 projectionMatrix;", ParseShape.EXTERNAL_DECLARATION);
 	public static void transform(
@@ -35,7 +35,7 @@ public class SodiumCoreTransformer {
 		root.processMatches(t, normalMatrix, ASTNode::detachAndDelete);
 		root.rename("projectionMatrix", "u_ProjectionMatrix");
 		root.rename("projectionMatrixInverse", "iris_" + objectType + "ProjectionMatrixInverse");
-		root.rename("normalMatrix", "mat3(u_ModelViewMatrix)");
+		root.replaceReferenceExpressions(t, "normalMatrix", "mat3(u_ModelViewMatrix)");
 		root.rename("chunkOffset", "u_RegionOffset");
 		if (parameters.type == PatchShaderType.VERTEX) {
 			boolean needsNormal = root.identifierIndex.has("vaNormal") || root.identifierIndex.has("at_tangent");


### PR DESCRIPTION
`gl_NormalMatrix`'s type is mat3, and `normalMatrix` also according to [Optifine's document](https://github.com/sp614x/optifine/blob/master/OptiFineDoc/doc/shaders.txt#L243). Using `uniform mat4 normalMatrix;` won't catch the normalMatrix declare in correctly written core profile shaders.

Also, `rename()` of glsl-transformer only accept an identifier, while `mat3(u_ModelViewMatrix)` is an expression, so this code will lead to a glsl-transformer error if shader is using core profile. By using `replaceReferenceExpressions()`, core shaders are working again, and I'v confirmed the patch is applied correctly on `normalMatrix`.