### PR TITLE
fix wrong VertexFormatElement of at_midBlock for the vanilla terrain format

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/vertices/IrisVertexFormats.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/IrisVertexFormats.java
@@ -30,7 +30,7 @@ public class IrisVertexFormats {
 		ENTITY_ID_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 3, VertexFormatElement.Type.USHORT, false, 4);
 		MID_TEXTURE_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.FLOAT, false, 2);
 		TANGENT_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.BYTE, true, 4);
-		MID_BLOCK_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.BYTE, false, 3);
+		MID_BLOCK_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.BYTE, false, 4);
 
 		TERRAIN = VertexFormat.builder()
 			.add("Position", VertexFormatElement.POSITION)
@@ -43,7 +43,6 @@ public class IrisVertexFormats {
 			.add("mc_midTexCoord", MID_TEXTURE_ELEMENT)
 			.add("at_tangent", TANGENT_ELEMENT)
 			.add("at_midBlock", MID_BLOCK_ELEMENT)
-			.padding(1)
 			.build();
 
 		ENTITY = VertexFormat.builder()


### PR DESCRIPTION
this fixes mods that render with the vanilla terrain vertex format getting garbage data for at_midblock.w light emission

the data is still not actually set correctly here <https://github.com/IrisShaders/Iris/blob/24c119f61a4232119d29c2c5448b307758eee6d9/common/src/main/java/net/irisshaders/iris/mixin/vertices/MixinBufferBuilder.java#L132-L133>, but it at least isn't using undefined data