### PR TITLE
1.21.1 fix wrong VertexFormatElement of at_midBlock for the vanilla terrain format

### DIFF
--- a/common/src/main/java/net/irisshaders/iris/vertices/IrisVertexFormats.java
+++ b/common/src/main/java/net/irisshaders/iris/vertices/IrisVertexFormats.java
@@ -30,7 +30,7 @@ public class IrisVertexFormats {
 		ENTITY_ID_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), LAST_UV + 1, VertexFormatElement.Type.USHORT, VertexFormatElement.Usage.UV, 3);
 		MID_TEXTURE_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 2);
 		TANGENT_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.BYTE, VertexFormatElement.Usage.GENERIC, 4);
-		MID_BLOCK_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.BYTE, VertexFormatElement.Usage.GENERIC, 3);
+		MID_BLOCK_ELEMENT = VertexFormatElement.register(getNextVertexFormatElementId(), 0, VertexFormatElement.Type.BYTE, VertexFormatElement.Usage.GENERIC, 4);
 
 		TERRAIN = VertexFormat.builder()
 			.add("Position", VertexFormatElement.POSITION)
@@ -43,7 +43,6 @@ public class IrisVertexFormats {
 			.add("mc_midTexCoord", MID_TEXTURE_ELEMENT)
 			.add("at_tangent", TANGENT_ELEMENT)
 			.add("at_midBlock", MID_BLOCK_ELEMENT)
-			.padding(1)
 			.build();
 
 		ENTITY = VertexFormat.builder()


### PR DESCRIPTION
this fixes mods that render with the vanilla terrain vertex format getting garbage data for at_midblock.w light emission

the data is still not actually set correctly here <https://github.com/IrisShaders/Iris/blob/eb7afb99f747cc8ed5ee4072119539035d33cefd/common/src/main/java/net/irisshaders/iris/mixin/vertices/MixinBufferBuilder.java#L131-L132>, but it at least isn't using undefined data