### PR TITLE
[1.21.11] Update Sodium compatibility to 0.8.14 and bump version to 1.10.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     id("java")
-    id("fabric-loom") version("1.14.4") apply(false)
+    id("fabric-loom") version("1.16.1") apply(false)
 }
 
 val MINECRAFT_VERSION by extra { "1.21.11" }
@@ -9,7 +9,7 @@ val NEOFORGE_VERSION by extra { "21.11.5-beta" }
 val FABRIC_LOADER_VERSION by extra { "0.18.1" }
 val FABRIC_API_VERSION by extra { "0.140.2+1.21.11" }
 
-val SODIUM_DEPENDENCY_FABRIC by extra { files(rootDir.resolve("custom_sodium/sodium-fabric-0.8.7+mc1.21.11.jar")) }
+val SODIUM_DEPENDENCY_FABRIC by extra { files(rootDir.resolve("custom_sodium/sodium-fabric-0.8.14+mc1.21.11.jar")) }
 val SODIUM_DEPENDENCY_NEO by extra { files(rootDir.resolve("custom_sodium/net.caffeinemc.sodium-neoforge-0.8.6+mc1.21.11-mod.jar")) }
 
 // This value can be set to null to disable Parchment.
@@ -17,7 +17,7 @@ val SODIUM_DEPENDENCY_NEO by extra { files(rootDir.resolve("custom_sodium/net.ca
 val PARCHMENT_VERSION by extra { null }
 
 // https://semver.org/
-val MOD_VERSION by extra { "1.10.6" }
+val MOD_VERSION by extra { "1.10.8" }
 
 allprojects {
     apply(plugin = "java")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("idea")
-    id("fabric-loom") version "1.14.4"
+    id("fabric-loom") version "1.16.1"
     id("com.github.gmazzo.buildconfig") version "5.3.5"
 }
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("idea")
-    id("fabric-loom") version ("1.14.4")
+    id("fabric-loom") version ("1.16.1")
 }
 
 val MINECRAFT_VERSION: String by rootProject.extra

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary
    Sodium 0.8.14 for Minecraft 1.21.11 introduced a breaking constraint against older Iris releases (`"breaks": { "iris": "<=1.10.7" }`), preventing Iris 1.10.7 from launching on modern setups.
  
    ### Changes
    - Updated Fabric Loom to `1.16.1` and Gradle wrapper to `9.4.0` to support modern build tooling.
    - Updated the Sodium dependency to `0.8.14` and verified clean compilation.
    - Bumped version string to `1.10.8`.
  
    ### Testing
    - Built cleanly with `./gradlew :fabric:build -Pbuild.release`.
    - Verified in-game that Fabric Loader launches without incompatibility errors and Iris shaders function as expected alongside Sodium 0.8.14 and Sodium Extra 0.9.3.
